### PR TITLE
Move to more generic linux target

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,8 +23,7 @@ jobs:
       matrix:
         target: [x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu]
     name: Build CLI for ${{ matrix.target }}
-    # trunk-ignore(actionlint/runner-label)
-    runs-on: [self-hosted, ubuntu-x64]
+    runs-on: [self-hosted, linux]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +54,7 @@ jobs:
 
   build:
     name: Unit Tests
-    runs-on: [self-hosted, ubuntu-x64]
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
this was overfit - in public space we can target the OS directly + self-hosted