### PR TITLE
Update release runner type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
   tag_and_release:
     name: Tag and Release [ ${{ github.event.inputs.release_tag }} ]
-    runs-on: [self-hosted, Linux]
+    runs-on: [ubuntu-latest]
     needs: [build]
 
     steps:


### PR DESCRIPTION
Our self hosted runners don't have `gh` installed. Not sure how the first release went through.