### PR TITLE
Handle version directly in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
+      - name: Update version
+        run: |
+          export VERSION=${{ github.event.inputs.release_tag }}
+          sed -i "s/0.0.0/$VERSION/g" Cargo.toml
+
       - name: Build ${{ matrix.target }} target
         uses: ./.github/actions/build_target
         if: "!cancelled()"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "trunk-analytics-cli"
-version = "0.5.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trunk-analytics-cli"
 edition = "2021"
-version = "0.5.2"
+version = "0.0.0"
 
 [[bin]]
 name = "trunk-analytics-cli"


### PR DESCRIPTION
We've had a few instances where we forgot to update the release version. Let's just handle it entirely in the release and leave local as `0.0.0`.