### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "trunk-analytics-cli"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,10 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
 use trunk_analytics_cli::bundler::BundlerUtil;
 use trunk_analytics_cli::clients::get_quarantine_bulk_test_status;
-use trunk_analytics_cli::constants::{EXIT_SUCCESS, TRUNK_API_ADDRESS_ENV};
+use trunk_analytics_cli::constants::{EXIT_FAILURE, EXIT_SUCCESS, TRUNK_API_ADDRESS_ENV};
 use trunk_analytics_cli::runner::run_test_command;
 use trunk_analytics_cli::scanner::{BundleRepo, EnvScanner, FileSet, FileSetCounter};
-use trunk_analytics_cli::types::{BundleMeta, QuarantineBulkTestStatus, META_VERSION};
+use trunk_analytics_cli::types::{BundleMeta, QuarantineBulkTestStatus, RunResult, META_VERSION};
 use trunk_analytics_cli::utils::{from_non_empty_or_default, parse_custom_tags};
 
 #[derive(Debug, Parser)]
@@ -283,20 +283,31 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         command.iter().skip(1).collect(),
         junit_paths.iter().collect(),
     )
-    .await?;
-    let quarantine_results = Retry::spawn(default_delay(), || {
-        get_quarantine_bulk_test_status(
-            &api_address,
-            token,
-            org_url_slug,
-            &repo.repo,
-            &run_result.failures,
-        )
-    })
     .await
-    .unwrap_or(QuarantineBulkTestStatus {
-        group_is_quarantined: false,
+    .unwrap_or(RunResult {
+        exit_code: EXIT_FAILURE,
+        failures: Vec::new(),
     });
+
+    let quarantine_results = match run_result.failures.is_empty() {
+        true => QuarantineBulkTestStatus {
+            group_is_quarantined: false,
+        },
+        false => Retry::spawn(default_delay(), || {
+            get_quarantine_bulk_test_status(
+                &api_address,
+                token,
+                org_url_slug,
+                &repo.repo,
+                &run_result.failures,
+            )
+        })
+        .await
+        .unwrap_or(QuarantineBulkTestStatus {
+            group_is_quarantined: false,
+        }),
+    };
+
     log::info!("Quarantine results: {:?}", quarantine_results);
     // use the exit code from the command if the group is not quarantined
     // override exit code to be exit_success if the group is quarantined
@@ -310,13 +321,11 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         run_result.exit_code
     };
 
-    let upload_exit_code = run_upload(upload_args).await.unwrap_or(EXIT_SUCCESS);
-    // use the upload exit code if the command exit code is exit_success
-    if exit_code == EXIT_SUCCESS {
-        Ok(upload_exit_code)
-    } else {
-        Ok(exit_code)
+    let upload_exit_code = run_upload(upload_args).await.unwrap_or(EXIT_FAILURE);
+    if upload_exit_code != EXIT_SUCCESS {
+        log::error!("Error uploading test results: {}", upload_exit_code);
     }
+    Ok(exit_code)
 }
 
 async fn run(cli: Cli) -> anyhow::Result<i32> {


### PR DESCRIPTION
We should always either return exit_success or the underlying exit code. We should not obfuscate it when an unhandled exception occurs. 