### PR TITLE
find remote reference when HEAD detached

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -174,7 +174,8 @@ impl BundleRepo {
                                 && git_head.id().is_some()
                                 && id.unwrap().to_string() == git_head.id().unwrap().to_string()
                             {
-                                git_head_branch = r.name().to_path().to_str().map(|s| s.to_string());
+                                git_head_branch =
+                                    r.name().to_path().to_str().map(|s| s.to_string());
                                 break;
                             };
                         }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -174,13 +174,12 @@ impl BundleRepo {
                                 && git_head.id().is_some()
                                 && id.unwrap().to_string() == git_head.id().unwrap().to_string()
                             {
-                                git_head_branch =
-                                    Some(r.name().to_path().to_str().unwrap().to_string());
+                                git_head_branch = r.name().to_path().to_str().map(|s| s.to_string());
                                 break;
                             };
                         }
                         Err(e) => {
-                            log::warn!("unable to match reference {:?}", e);
+                            log::info!("Unexpected error when trying to find reference {:?}", e);
                         }
                     }
                 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -177,7 +177,7 @@ impl BundleRepo {
                         };
                     }
                     Err(e) => {
-                        log::info!("reference {:?}", e);
+                        log::warn!("unable to match reference {:?}", e);
                     }
                 });
             }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
-use std::format;
 use serde::Serialize;
+use std::format;
 
 use crate::constants::{ALLOW_LIST, ENVS_TO_GET};
 use crate::types::{BundledFile, FileSetType, Repo};
@@ -163,23 +163,24 @@ impl BundleRepo {
                 .map(|s| s.to_string());
             let mut git_head = git_repo.head()?;
 
-            let reference = git_repo.references().unwrap();
-            let git_head_id = git_head.id().unwrap();
             let mut git_head_branch = git_head.referent_name().map(|s| s.as_bstr().to_string());
-            reference.remote_branches()?.for_each(|r| {
-                match r {
+            if git_head_branch.is_none() {
+                let git_head_id = git_head.id().unwrap();
+                let reference = git_repo.references().unwrap();
+                reference.remote_branches()?.for_each(|r| match r {
                     Ok(r) => {
                         let target = r.target();
                         let id = target.try_id();
                         if id.is_some() && id.unwrap().to_string() == git_head_id.to_string() {
-                            git_head_branch = Some(r.name().to_path().to_str().unwrap().to_string());
+                            git_head_branch =
+                                Some(r.name().to_path().to_str().unwrap().to_string());
                         };
                     }
                     Err(e) => {
                         log::info!("reference {:?}", e);
                     }
-                }
-            });
+                });
+            }
             let git_head_sha = git_head.id().map(|id| id.to_string());
             let git_head_commit_time = git_head.peel_to_commit_in_place()?.time()?;
             git_head_commit_message = git_head.peel_to_commit_in_place().map_or(None, |commit| {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -180,7 +180,7 @@ impl BundleRepo {
                             };
                         }
                         Err(e) => {
-                            log::info!("Unexpected error when trying to find reference {:?}", e);
+                            log::debug!("Unexpected error when trying to find reference {:?}", e);
                         }
                     }
                 }


### PR DESCRIPTION
Scan the references to find the matching reference name. This is equivalent to `git for-each-ref --contains e0c6eaa19870c1ae30601bed5bee604c7436c9a2`

After:
```
2024-04-08T05:37:42 [INFO] - Found git_sha: Some("e0c6eaa19870c1ae30601bed5bee604c7436c9a2")
2024-04-08T05:37:42 [INFO] - Found git_branch: Some("refs/remotes/pull/47/merge")
```

Before
```
2024-04-08T05:39:17 [INFO] - Found git_sha: Some("e0c6eaa19870c1ae30601bed5bee604c7436c9a2")
2024-04-08T05:39:17 [INFO] - Found git_branch: None
```

Repro:
```
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +e0c6eaa19870c1ae30601bed5bee604c7436c9a2:refs/remotes/pull/47/merge
git checkout --progress --force refs/remotes/pull/47/merge
```