### PR TITLE
Add createRepo public endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -272,7 +272,13 @@ async fn run_upload(
 
     let remote_urls = vec![repo.repo_url.clone()];
     Retry::spawn(default_delay(), || {
-        create_trunk_repo(&api_address, &token, &org_url_slug, &repo.repo, &remote_urls)
+        create_trunk_repo(
+            &api_address,
+            &token,
+            &org_url_slug,
+            &repo.repo,
+            &remote_urls,
+        )
     })
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ use clap::{Args, Parser, Subcommand};
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
 use trunk_analytics_cli::bundler::BundlerUtil;
-use trunk_analytics_cli::clients::get_quarantine_bulk_test_status;
+use trunk_analytics_cli::clients::{
+    create_trunk_repo, get_bundle_upload_location, get_quarantine_bulk_test_status,
+    put_bundle_to_s3,
+};
 use trunk_analytics_cli::constants::{EXIT_FAILURE, EXIT_SUCCESS, TRUNK_PUBLIC_API_ADDRESS_ENV};
 use trunk_analytics_cli::runner::run_test_command;
 use trunk_analytics_cli::scanner::{BundleRepo, EnvScanner, FileSet, FileSetCounter};
@@ -253,12 +256,7 @@ async fn run_upload(
     log::info!("Flushed temporary tarball to {:?}", bundle_time_file);
 
     let upload = Retry::spawn(default_delay(), || {
-        trunk_analytics_cli::clients::get_bundle_upload_location(
-            &api_address,
-            &token,
-            &org_url_slug,
-            &repo.repo,
-        )
+        get_bundle_upload_location(&api_address, &token, &org_url_slug, &repo.repo)
     })
     .await?;
 
@@ -268,7 +266,13 @@ async fn run_upload(
     }
 
     Retry::spawn(default_delay(), || {
-        trunk_analytics_cli::clients::put_bundle_to_s3(&upload.url, &bundle_time_file)
+        put_bundle_to_s3(&upload.url, &bundle_time_file)
+    })
+    .await?;
+
+    let remote_urls = vec![repo.repo_url.clone()];
+    Retry::spawn(default_delay(), || {
+        create_trunk_repo(&api_address, &token, &org_url_slug, &repo.repo, &remote_urls)
     })
     .await?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,7 +67,8 @@ pub struct QuarantineBulkTestStatus {
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
 pub struct TrunkRepo {
-    pub id: String,
+    #[serde(rename = "repoId")]
+    pub repo_id: String,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,15 @@ pub struct RunResult {
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
+pub struct CreateRepoRequest {
+    pub repo: Repo,
+    #[serde(rename = "orgUrlSlug")]
+    pub org_url_slug: String,
+    #[serde(rename = "remoteUrls")]
+    pub remote_urls: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize)]
 pub struct CreateBundleUploadRequest {
     pub repo: Repo,
     #[serde(rename = "orgUrlSlug")]
@@ -54,6 +63,11 @@ pub struct QuarantineBulkTestStatus {
     pub group_is_quarantined: bool,
     #[serde(rename = "quarantineResults")]
     pub quarantine_results: Vec<QuarantineResult>,
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize)]
+pub struct TrunkRepo {
+    pub id: String,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]


### PR DESCRIPTION
- this should create a trunk repo for orgs that don't already have them
- calls the createRepo public endpoint: https://github.com/trunk-io/trunk/pull/14243
- tested upload on a test repo and seems to work fine
- TODO: wait for endpoint to be on prod, then merge this and update cli version on uploader