### PR TITLE
Remove top level name from `parent_name`

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -98,11 +98,7 @@ pub async fn run_test_command(
                     }
                 };
                 for suite in junitxml.suites {
-                    let parent_name = if junitxml.name.is_empty() {
-                        suite.name
-                    } else {
-                        format!("{}/{}", junitxml.name, suite.name)
-                    };
+                    let parent_name = suite.name;
                     for case in suite.cases {
                         let failure = case.status.is_failure();
                         if failure {


### PR DESCRIPTION
We removed this from the ETL but did not update it here. 