### PR TITLE
update download-artifact gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: build
 


### PR DESCRIPTION
I updated our `upload-artifact` action, but forgot to update our `download-artifact` action. Currently, the release job is broken because of this. 