### PR TITLE
upload codeowners file with bundle

### DIFF
--- a/cli/src/bundler.rs
+++ b/cli/src/bundler.rs
@@ -1,6 +1,7 @@
 use std::io::{Seek, Write};
 use std::path::PathBuf;
 
+use crate::codeowners::CodeOwners;
 use crate::types::BundleMeta;
 
 /// Utility type for packing files into tarball.
@@ -47,6 +48,12 @@ impl BundlerUtil {
             })?;
             Ok::<(), anyhow::Error>(())
         })?;
+
+        if let Some(CodeOwners { ref path, .. }) = self.meta.codeowners {
+            let mut file = std::fs::File::open(path)?;
+            tar.append_file("CODEOWNERS", &mut file)?;
+            total_bytes_in += std::fs::metadata(path)?.len();
+        }
 
         // Flush to disk.
         tar.into_inner()?.finish()?;

--- a/cli/src/codeowners.rs
+++ b/cli/src/codeowners.rs
@@ -1,0 +1,65 @@
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use codeowners::Owners;
+
+use crate::constants::CODEOWNERS_LOCATIONS;
+
+#[derive(Default, Debug)]
+pub struct CodeOwners {
+    pub path: PathBuf,
+    pub file: Option<File>,
+    pub owners: Option<Owners>,
+}
+
+impl CodeOwners {
+    pub fn find_file<T: AsRef<Path>, U: AsRef<Path>>(
+        repo_root: T,
+        codeowners_path_cli_option: &Option<U>,
+    ) -> Option<Self> {
+        let cli_option_location = codeowners_path_cli_option
+            .as_slice()
+            .iter()
+            .map(|path_str| -> &Path { path_str.as_ref() });
+        let default_locations = CODEOWNERS_LOCATIONS
+            .iter()
+            .map(|path_str| -> &Path { path_str.as_ref() });
+        let mut all_locations = cli_option_location.chain(default_locations);
+
+        let codeowners_path =
+            all_locations.find_map(|location| locate_codeowners(&repo_root, location));
+
+        codeowners_path.map(|path| {
+            let file = Result::ok(File::open(&path));
+            let owners = file.as_ref().and_then(|f| {
+                let owners_result = codeowners::from_reader(f);
+                if let Err(ref err) = owners_result {
+                    log::error!(
+                        "Found CODEOWNERS file `{}`, but couldn't parse it: {}",
+                        path.to_string_lossy(),
+                        err
+                    );
+                }
+                Result::ok(owners_result)
+            });
+            Self { path, file, owners }
+        })
+    }
+}
+
+const CODEOWNERS: &str = "CODEOWNERS";
+
+fn locate_codeowners<T, U>(repo_root: T, location: U) -> Option<PathBuf>
+where
+    T: AsRef<Path>,
+    U: AsRef<Path>,
+{
+    let file = repo_root.as_ref().join(location).join(CODEOWNERS);
+    if file.is_file() {
+        Some(file)
+    } else {
+        None
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bundler;
 pub mod clients;
+pub mod codeowners;
 pub mod constants;
 pub mod runner;
 pub mod scanner;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -242,6 +242,7 @@ async fn run_upload(
         test_command,
         quarantined_tests: resolved_quarantine_results.quarantine_results.to_vec(),
         os_info: Some(os_info),
+        codeowners,
     };
 
     log::info!("Total files pack and upload: {}", file_counter.get_count());

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -1,5 +1,6 @@
 use crate::{
     clients::get_quarantine_bulk_test_status,
+    codeowners::CodeOwners,
     constants::{EXIT_FAILURE, EXIT_SUCCESS},
     scanner::{BundleRepo, FileSet, FileSetCounter},
     types::{QuarantineBulkTestStatus, QuarantineRunResult, RunResult, Test},
@@ -19,11 +20,11 @@ pub async fn run_test_command(
     args: Vec<&String>,
     output_paths: &[String],
     team: Option<String>,
-    codeowners_path: Option<String>,
+    codeowners: &Option<CodeOwners>,
 ) -> anyhow::Result<RunResult> {
     let exit_code = run_test_and_get_exit_code(command, args).await?;
     log::info!("Command exit code: {}", exit_code);
-    let (file_sets, ..) = build_filesets(repo, output_paths, team, codeowners_path)?;
+    let (file_sets, ..) = build_filesets(repo, output_paths, team, codeowners)?;
     let failures = if exit_code != EXIT_SUCCESS {
         let start = SystemTime::now();
         extract_failed_tests(&file_sets, Some(start)).await?
@@ -61,7 +62,7 @@ pub fn build_filesets(
     repo: &BundleRepo,
     junit_paths: &[String],
     team: Option<String>,
-    codeowners_path: Option<String>,
+    codeowners: &Option<CodeOwners>,
 ) -> anyhow::Result<(Vec<FileSet>, FileSetCounter)> {
     let mut file_counter = FileSetCounter::default();
     let mut file_sets = junit_paths
@@ -72,7 +73,7 @@ pub fn build_filesets(
                 path.to_string(),
                 &mut file_counter,
                 team.clone(),
-                codeowners_path.clone(),
+                codeowners,
             )
         })
         .collect::<anyhow::Result<Vec<FileSet>>>()?;
@@ -92,7 +93,7 @@ pub fn build_filesets(
                     path.to_string(),
                     &mut file_counter,
                     team.clone(),
-                    codeowners_path.clone(),
+                    codeowners,
                 )
             })
             .collect::<anyhow::Result<Vec<FileSet>>>()?;

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -1,7 +1,10 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::scanner::{BundleRepo, FileSet};
+use crate::{
+    codeowners::CodeOwners,
+    scanner::{BundleRepo, FileSet},
+};
 
 pub struct RunResult {
     pub exit_code: i32,
@@ -182,6 +185,7 @@ pub struct BundleMeta {
     pub test_command: Option<String>,
     pub os_info: Option<String>,
     pub quarantined_tests: Vec<QuarantineResult>,
+    pub codeowners: Option<CodeOwners>,
 }
 
 #[cfg(test)]

--- a/codeowners/src/lib.rs
+++ b/codeowners/src/lib.rs
@@ -59,7 +59,7 @@ const CODEOWNERS: &str = "CODEOWNERS";
 ///   raw
 /// );
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Owner {
     /// Owner in the form @username
     Username(String),
@@ -102,7 +102,7 @@ impl FromStr for Owner {
 }
 
 /// Mappings of owners to path patterns
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Owners {
     paths: Vec<(Pattern, Vec<Owner>)>,
 }


### PR DESCRIPTION
Ensures we only find and parse `CODEOWNERS` once and reuse the parsed owners for `BundledFile`s. Addtionally, throws the `CODEOWNERS` file into the root of the tarball and adds the original path as metadata.