### PR TITLE
Set quarantining default exit code to failure for failed tests

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -197,7 +197,11 @@ async fn run_upload(
         Some(
             run_quarantine(
                 RunResult {
-                    exit_code: EXIT_SUCCESS,
+                    exit_code: if failures.is_empty() {
+                        EXIT_SUCCESS
+                    } else {
+                        EXIT_FAILURE
+                    },
                     failures,
                 },
                 &api_address,


### PR DESCRIPTION
This will ensure that the quarantining step will fail if we have failed tests, and those tests were not quarantined.