### PR TITLE
add better logging for skipped junit.xml files

### DIFF
--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -5,6 +5,7 @@ use crate::{
     scanner::{BundleRepo, FileSet, FileSetCounter},
     types::{QuarantineBulkTestStatus, QuarantineConfig, QuarantineRunResult, RunResult, Test},
 };
+use chrono::{DateTime, Utc};
 use junit_parser;
 use std::{
     fs::metadata,
@@ -131,8 +132,10 @@ pub async fn extract_failed_tests(
             if let Some(start) = start {
                 if time <= start {
                     log::info!(
-                        "Skipping file because of lack of modification: {}",
-                        file.original_path
+                        "Skipping file `{}` because modified time `{}` is before start time `{}`",
+                        file.original_path,
+                        DateTime::<Utc>::from(time),
+                        DateTime::<Utc>::from(start),
                     );
                     continue;
                 }


### PR DESCRIPTION
It would be good to know the modified time of a file that's being skipped