### PR TITLE
Fix start time calculations and coalesce the logic

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -197,13 +197,14 @@ async fn run_upload(
     let quarantine_run_results = if use_quarantining && quarantine_results.is_none() {
         Some(
             run_quarantine(
-                RunResult {
+                &RunResult {
                     exit_code: if failures.is_empty() {
                         EXIT_SUCCESS
                     } else {
                         EXIT_FAILURE
                     },
                     failures,
+                    exec_start: None,
                 },
                 &api_address,
                 &token,
@@ -368,6 +369,7 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         RunResult {
             exit_code: EXIT_FAILURE,
             failures: Vec::new(),
+            exec_start: None,
         }
     });
 
@@ -376,7 +378,7 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
     let quarantine_run_result = if *use_quarantining {
         Some(
             run_quarantine(
-                run_result,
+                &run_result,
                 &api_address,
                 token,
                 org_url_slug,
@@ -397,7 +399,7 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
     match run_upload(
         upload_args,
         Some(command.join(" ")),
-        quarantine_run_result,
+        None, // don't re-run quarantine checks
         codeowners,
     )
     .await

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -403,7 +403,6 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         None, // don't re-run quarantine checks
         codeowners,
         run_result.exec_start,
-
     )
     .await
     {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -189,8 +189,9 @@ async fn run_upload(
 
     let tags = parse_custom_tags(&tags)?;
 
-    let (file_sets, file_counter) = build_filesets(&repo, &junit_paths, team.clone(), &codeowners)?;
-    let failures = extract_failed_tests(&repo, &org_url_slug, &file_sets, None).await?;
+    let (file_sets, file_counter) =
+        build_filesets(&repo, &junit_paths, team.clone(), &codeowners, None)?;
+    let failures = extract_failed_tests(&repo, &org_url_slug, &file_sets).await?;
 
     // Run the quarantine step and update the exit code.
     let quarantine_run_results = if use_quarantining && quarantine_results.is_none() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -195,18 +195,16 @@ async fn run_upload(
     let failures = extract_failed_tests(&repo, &org_url_slug, &file_sets).await?;
 
     // Run the quarantine step and update the exit code.
+    let exit_code = if failures.is_empty() {
+        EXIT_SUCCESS
+    } else {
+        EXIT_FAILURE
+    };
     let quarantine_run_results = if use_quarantining && quarantine_results.is_none() {
         Some(
             run_quarantine(
-                &RunResult {
-                    exit_code: if failures.is_empty() {
-                        EXIT_SUCCESS
-                    } else {
-                        EXIT_FAILURE
-                    },
-                    failures,
-                    exec_start: None,
-                },
+                exit_code,
+                failures,
                 &api_address,
                 &token,
                 &org_url_slug,
@@ -375,11 +373,13 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
     });
 
     let run_exit_code = run_result.exit_code;
+    let failures = run_result.failures;
 
     let quarantine_run_result = if *use_quarantining {
         Some(
             run_quarantine(
-                &run_result,
+                run_exit_code,
+                failures,
                 &api_address,
                 token,
                 org_url_slug,
@@ -397,12 +397,13 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         .map(|r| r.exit_code)
         .unwrap_or(run_exit_code);
 
+    let exec_start = run_result.exec_start;
     match run_upload(
         upload_args,
         Some(command.join(" ")),
         None, // don't re-run quarantine checks
         codeowners,
-        run_result.exec_start,
+        exec_start,
     )
     .await
     {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,6 +137,7 @@ async fn run_upload(
     test_command: Option<String>,
     quarantine_results: Option<QuarantineRunResult>,
     codeowners: Option<CodeOwners>,
+    exec_start: Option<SystemTime>,
 ) -> anyhow::Result<i32> {
     let UploadArgs {
         junit_paths,
@@ -190,7 +191,7 @@ async fn run_upload(
     let tags = parse_custom_tags(&tags)?;
 
     let (file_sets, file_counter) =
-        build_filesets(&repo, &junit_paths, team.clone(), &codeowners, None)?;
+        build_filesets(&repo, &junit_paths, team.clone(), &codeowners, exec_start)?;
     let failures = extract_failed_tests(&repo, &org_url_slug, &file_sets).await?;
 
     // Run the quarantine step and update the exit code.
@@ -401,6 +402,8 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         Some(command.join(" ")),
         None, // don't re-run quarantine checks
         codeowners,
+        run_result.exec_start,
+
     )
     .await
     {
@@ -415,7 +418,7 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
 
 async fn run(cli: Cli) -> anyhow::Result<i32> {
     match cli.command {
-        Commands::Upload(upload_args) => run_upload(upload_args, None, None, None).await,
+        Commands::Upload(upload_args) => run_upload(upload_args, None, None, None, None).await,
         Commands::Test(test_args) => run_test(test_args).await,
     }
 }

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -31,6 +31,9 @@ pub async fn run_test_command(
     } else {
         Vec::new()
     };
+    if failures.is_empty() && exit_code != EXIT_SUCCESS {
+        log::warn!("Command failed but no test failures were found!");
+    }
     Ok(RunResult {
         exit_code,
         failures,

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -34,6 +34,7 @@ pub async fn run_test_command(
     Ok(RunResult {
         exit_code,
         failures,
+        exec_start: Some(start),
     })
 }
 
@@ -63,7 +64,7 @@ pub fn build_filesets(
     junit_paths: &[String],
     team: Option<String>,
     codeowners: &Option<CodeOwners>,
-    start: Option<SystemTime>,
+    exec_start: Option<SystemTime>,
 ) -> anyhow::Result<(Vec<FileSet>, FileSetCounter)> {
     let mut file_counter = FileSetCounter::default();
     let mut file_sets = junit_paths
@@ -75,7 +76,7 @@ pub fn build_filesets(
                 &mut file_counter,
                 team.clone(),
                 codeowners,
-                start,
+                exec_start,
             )
         })
         .collect::<anyhow::Result<Vec<FileSet>>>()?;
@@ -96,7 +97,7 @@ pub fn build_filesets(
                     &mut file_counter,
                     team.clone(),
                     codeowners,
-                    start,
+                    exec_start,
                 )
             })
             .collect::<anyhow::Result<Vec<FileSet>>>()?;
@@ -153,7 +154,7 @@ pub async fn extract_failed_tests(
 }
 
 pub async fn run_quarantine(
-    run_result: RunResult,
+    run_result: &RunResult,
     api_address: &str,
     token: &str,
     org_url_slug: &str,
@@ -182,6 +183,7 @@ pub async fn run_quarantine(
     let total_failures = run_result.failures.len();
     quarantine_results.quarantine_results = run_result
         .failures
+        .clone()
         .into_iter()
         .filter_map(|failure| {
             let quarantine_failure = quarantined.contains(&failure.id);

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -3,10 +3,8 @@ use std::collections::HashSet;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    codeowners::CodeOwners,
-    scanner::{BundleRepo, FileSet},
-};
+use crate::codeowners::CodeOwners;
+use crate::scanner::{BundleRepo, FileSet};
 
 pub struct RunResult {
     pub exit_code: i32,

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -9,6 +9,7 @@ use crate::scanner::{BundleRepo, FileSet};
 pub struct RunResult {
     pub exit_code: i32,
     pub failures: Vec<Test>,
+    pub exec_start: Option<std::time::SystemTime>,
 }
 
 pub struct QuarantineRunResult {


### PR DESCRIPTION
When wrapping test execution with `test` we had 3 issues:
1. The start time was calculated after the test had been executed. This meant that every file was skipped when doing the quarantining check.
2. The `test` subcommand invokes `upload`, which caused quarantining checks to happen twice.
3. `test` would skip files that it identified as stale, but the `upload` step wouldn't. This caused debugging to be more difficult.

This PR addresses all of the above.

Next steps:
* write some end to end tests for this logic
* return the default exit code when there are no failures found