### PR TITLE
add junit-mock utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -352,6 +354,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +411,16 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
+name = "fake"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+dependencies = [
+ "deunicode",
+ "rand",
+]
 
 [[package]]
 name = "faster-hex"
@@ -1133,6 +1157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,12 +1315,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "junit-mock"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "fake",
+ "humantime",
+ "quick-junit",
+ "rand",
+]
+
+[[package]]
 name = "junit-parser"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea34edfea520d3e9f97b37291a4f4dd67ace50892e41a2180a4f75286dcdae7a"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.35.0",
  "thiserror",
 ]
 
@@ -1414,6 +1467,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "newtype-uuid"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526cb7c660872e401beaf3297f95f548ce3b4b4bdd8121b7c0713771d7c4a6e"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -1655,10 +1717,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
 
 [[package]]
+name = "quick-junit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ffd2f9a162cfae131bed6d9d1ed60adced33be340a94f96952897d7cb0c240"
+dependencies = [
+ "chrono",
+ "indexmap",
+ "newtype-uuid",
+ "quick-xml 0.36.1",
+ "strip-ansi-escapes",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e446ed58cef1bbfe847bc2fda0e2e4ea9f0e57b90c507d4781292590d72a4e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
 ]
@@ -2204,6 +2290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,18 +2376,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2633,6 +2728,26 @@ dependencies = [
  "rustversion",
  "sysinfo",
  "time",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cli", "codeowners"]
+members = ["cli", "codeowners", "junit-mock"]
 resolver = "2"
 
 [profile.release]

--- a/junit-mock/Cargo.toml
+++ b/junit-mock/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "junit-mock"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "junit-mock"
+path = "src/main.rs"
+
+[lib]
+name = "junit_mock"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1.0.44"
+chrono = { version = "0.4.33" }
+clap = { version = "4.4.18", features = ["derive", "env"] }
+fake = "2.9.2"
+humantime = "2.1.0"
+quick-junit = "0.5.0"
+rand = "0.8.5"

--- a/junit-mock/src/lib.rs
+++ b/junit-mock/src/lib.rs
@@ -1,0 +1,452 @@
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use fake::Fake;
+use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
+use rand::prelude::*;
+use rand::rngs::StdRng;
+
+macro_rules! percentages_parser {
+    ($func_name:ident, $num_percentages:literal) => {
+        fn $func_name(argument: &str) -> std::result::Result<Vec<u8>, clap::Error> {
+            argument
+                .split(',')
+                .enumerate()
+                .try_fold((0_u8, Vec::new()), |mut acc, (i, percentage_str)| {
+                    if i >= $num_percentages {
+                        return Err(clap::Error::raw(
+                            clap::error::ErrorKind::InvalidValue,
+                            "More than $num_percentages percentages provided",
+                        ));
+                    }
+                    let percentage = percentage_str
+                        .parse::<u8>()
+                        .map_err(|e| clap::Error::raw(clap::error::ErrorKind::InvalidValue, e))?;
+
+                    if percentage > 100 {
+                        return Err(clap::Error::raw(
+                            clap::error::ErrorKind::InvalidValue,
+                            format!("Percentage at index {} is greater than 100", i),
+                        ));
+                    }
+
+                    acc.0 += percentage;
+
+                    if acc.0 > 100 {
+                        return Err(clap::Error::raw(
+                            clap::error::ErrorKind::InvalidValue,
+                            "Sum of percentages are greater than 100",
+                        ));
+                    }
+
+                    acc.1.push(percentage);
+
+                    Ok(acc)
+                })
+                .map(|v| v.1)
+        }
+    };
+}
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    #[command(flatten, next_help_heading = "Global Options")]
+    pub global: GlobalOptions,
+
+    #[command(flatten, next_help_heading = "Report Options")]
+    pub report: ReportOptions,
+
+    #[command(flatten, next_help_heading = "Test Suite Options")]
+    pub test_suite: TestSuiteOptions,
+
+    #[command(flatten, next_help_heading = "Test Case Options")]
+    pub test_case: TestCaseOptions,
+
+    #[command(flatten, next_help_heading = "Test Rerun Options")]
+    pub test_rerun: TestRerunOptions,
+}
+
+#[derive(Debug, Parser)]
+#[group()]
+pub struct GlobalOptions {
+    /// Seed for all generated data, defaults to randomly generated seed
+    #[arg(long)]
+    pub seed: Option<u64>,
+}
+
+#[derive(Debug, Parser)]
+#[group()]
+pub struct ReportOptions {
+    /// A list of report names to generate (conflicts with --report-random-count)
+    #[arg(long, conflicts_with = "report_random_count")]
+    pub report_names: Option<Vec<String>>,
+
+    /// The number of reports with random names to generate (conflicts with --report-names)
+    #[arg(long, conflicts_with = "report_names", default_value = "1")]
+    pub report_random_count: usize,
+
+    /// Inclusive range of time between report timestamps
+    #[arg(long, num_args = 1..=2, value_names = ["DURATION_RANGE_START", "DURATION_RANGE_END"], default_values = ["5m", "1h"])]
+    pub report_duration_range: Vec<humantime::Duration>,
+}
+
+#[derive(Debug, Parser)]
+#[group()]
+pub struct TestSuiteOptions {
+    /// A list of test suite names to generate (conflicts with --test-suite-random-count)
+    #[arg(
+        long,
+        value_delimiter = ',',
+        conflicts_with = "test_suite_random_count"
+    )]
+    pub test_suite_names: Option<Vec<String>>,
+
+    /// The number of test suites with random names to generate (conflicts with --test-suite-names)
+    #[arg(long, conflicts_with = "test_suite_names", default_value = "50")]
+    pub test_suite_random_count: usize,
+
+    /// The chance of a system out message being added to the test suite
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), default_value = "50")]
+    pub test_suite_sys_out_percentage: u8,
+
+    /// The chance of a system error message being added to the test suite
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), default_value = "50")]
+    pub test_suite_sys_err_percentage: u8,
+}
+
+percentages_parser!(four_percentages_parser, 4);
+
+#[derive(Debug, Parser)]
+#[group()]
+pub struct TestCaseOptions {
+    /// A list of test case names to generate (conflicts with --test-case-random-count, requires --test-case-classnames)
+    #[arg(
+        long,
+        value_delimiter = ',',
+        conflicts_with = "test_case_random_count",
+        requires = "test_case_classnames"
+    )]
+    pub test_case_names: Option<Vec<String>>,
+
+    /// A list of test case classnames to generate (conflicts with --test-case-random-count, requires --test-case-names)
+    #[arg(
+        long,
+        value_delimiter = ',',
+        conflicts_with = "test_case_random_count",
+        requires = "test_case_names"
+    )]
+    pub test_case_classnames: Option<Vec<String>>,
+
+    /// The number of test cases with random names to generate (conflicts with --test-suite-names, --test-suite-classnames)
+    #[arg(long, conflicts_with_all = ["test_case_names", "test_case_classnames"], default_value = "10")]
+    pub test_case_random_count: usize,
+
+    /// The chance of a system out message being added to the test case
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), default_value = "50")]
+    pub test_case_sys_out_percentage: u8,
+
+    /// The chance of a system error message being added to the test case
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), default_value = "50")]
+    pub test_case_sys_err_percentage: u8,
+
+    /// Inclusive range of time between test case timestamps
+    #[arg(long, num_args = 1..=2, value_names = ["DURATION_RANGE_START", "DURATION_RANGE_END"], default_values = ["30s", "1m"])]
+    pub test_case_duration_range: Vec<humantime::Duration>,
+
+    /// The chance of a test case succeeding, skipping, failing, and erroring (must add up to 100)
+    #[arg(long, value_parser = four_percentages_parser, default_value = "25,25,25,25")]
+    pub test_case_success_to_skip_to_fail_to_error_percentage: Vec<Vec<u8>>,
+}
+
+percentages_parser!(two_percentages_parser, 2);
+
+#[derive(Debug, Parser)]
+#[group()]
+pub struct TestRerunOptions {
+    /// Inclusive range of the number of reruns of a test that was not skipped
+    #[arg(long, num_args = 1..=2, value_names = ["COUNT_RANGE_START", "COUNT_RANGE_END"], default_values = ["0", "2"])]
+    pub test_rerun_count_range: Vec<usize>,
+
+    /// The chance of a test rerun failing and erroring (must add up to 100)
+    #[arg(long, value_parser = two_percentages_parser, default_value = "50,50")]
+    pub test_rerun_fail_to_error_percentage: Vec<Vec<u8>>,
+}
+
+pub struct JunitMock {
+    seed: u64,
+    rng: StdRng,
+    options: Options,
+
+    // state for generating reports
+    timestamp: chrono::DateTime<chrono::Utc>,
+    total_duration: Duration,
+}
+
+impl JunitMock {
+    pub fn new(options: Options) -> Self {
+        let (seed, rng) = JunitMock::rng_from_seed(&options);
+        Self {
+            seed,
+            rng,
+            options,
+            timestamp: chrono::Utc::now(),
+            total_duration: Duration::new(0, 0),
+        }
+    }
+
+    fn rng_from_seed(options: &Options) -> (u64, StdRng) {
+        let seed = options.global.seed.unwrap_or_else(rand::random);
+        (seed, StdRng::seed_from_u64(seed))
+    }
+
+    pub fn set_options(&mut self, options: Options) {
+        let (seed, rng) = JunitMock::rng_from_seed(&options);
+        self.seed = seed;
+        self.rng = rng;
+        self.options = options;
+    }
+
+    pub fn get_seed(&self) -> u64 {
+        self.seed
+    }
+
+    pub fn increment_duration(&mut self, duration: Duration) {
+        self.total_duration += duration;
+        self.timestamp += duration;
+    }
+
+    pub fn generate_reports(&mut self) -> Vec<Report> {
+        self.timestamp = chrono::Utc::now();
+
+        self.options
+            .report
+            .report_names
+            .as_ref()
+            .cloned()
+            .map(|mut report_names| {
+                report_names.shuffle(&mut self.rng);
+                report_names
+            })
+            .unwrap_or_else(|| {
+                (0..self.options.report.report_random_count)
+                    .map(|_| fake::faker::company::en::Buzzword().fake_with_rng(&mut self.rng))
+                    .collect()
+            })
+            .iter()
+            .map(|report_name| {
+                let mut report = Report::new(report_name);
+                report.set_timestamp(self.timestamp);
+                self.total_duration = Duration::new(0, 0);
+                report.add_test_suites(self.generate_test_suites());
+                report.set_time(self.total_duration);
+                let duration =
+                    self.fake_duration(self.options.report.report_duration_range.clone());
+                self.increment_duration(duration);
+                report
+            })
+            .collect()
+    }
+
+    pub fn write_reports_to_file<T: AsRef<Path>, U: AsRef<[Report]>>(
+        directory: T,
+        reports: U,
+    ) -> Result<()> {
+        for (i, report) in reports.as_ref().iter().enumerate() {
+            let path = directory.as_ref().join(format!("junit-{}.xml", i));
+            let file = File::create(path)?;
+            report.serialize(file)?;
+        }
+        Ok(())
+    }
+
+    fn generate_test_suites(&mut self) -> Vec<TestSuite> {
+        self.options
+            .test_suite
+            .test_suite_names
+            .as_ref()
+            .cloned()
+            .map(|mut test_suite_names| {
+                test_suite_names.shuffle(&mut self.rng);
+                test_suite_names
+            })
+            .unwrap_or_else(|| {
+                (0..self.options.test_suite.test_suite_random_count)
+                    .map(|_| fake::faker::company::en::Buzzword().fake_with_rng(&mut self.rng))
+                    .collect()
+            })
+            .iter()
+            .map(|test_suite_name| -> TestSuite {
+                let mut test_suite = TestSuite::new(test_suite_name);
+                test_suite.set_timestamp(self.timestamp);
+                let last_duration = self.total_duration;
+                test_suite.add_test_cases(self.generate_test_cases());
+                test_suite.set_time(self.total_duration - last_duration);
+                if self.rand_bool(self.options.test_suite.test_suite_sys_out_percentage) {
+                    test_suite.set_system_out(self.fake_paragraphs());
+                }
+                if self.rand_bool(self.options.test_suite.test_suite_sys_err_percentage) {
+                    test_suite.set_system_err(self.fake_paragraphs());
+                }
+                test_suite
+            })
+            .collect()
+    }
+
+    fn generate_test_cases(&mut self) -> Vec<TestCase> {
+        let classnames = self
+            .options
+            .test_case
+            .test_case_classnames
+            .as_ref()
+            .cloned()
+            .map(|mut test_case_classnames| {
+                test_case_classnames.shuffle(&mut self.rng);
+                test_case_classnames
+            })
+            .unwrap_or_else(|| {
+                (0..self.options.test_case.test_case_random_count)
+                    .map(|_| fake::faker::filesystem::en::DirPath().fake_with_rng(&mut self.rng))
+                    .collect()
+            });
+
+        self.options
+            .test_case
+            .test_case_names
+            .as_ref()
+            .cloned()
+            .map(|mut test_case_names| {
+                test_case_names.shuffle(&mut self.rng);
+                test_case_names
+            })
+            .unwrap_or_else(|| {
+                (0..self.options.test_case.test_case_random_count)
+                    .map(|_| fake::faker::company::en::Buzzword().fake_with_rng(&mut self.rng))
+                    .collect()
+            })
+            .iter()
+            .zip(classnames.iter())
+            .map(|(test_case_name, test_case_classname)| -> TestCase {
+                let mut test_case = TestCase::new(test_case_name, self.generate_test_case_status());
+                test_case.set_classname(format!("{test_case_classname}/{test_case_name}"));
+                test_case.set_assertions(self.rng.gen_range(1..10));
+                test_case.set_timestamp(self.timestamp);
+                let duration =
+                    self.fake_duration(self.options.test_case.test_case_duration_range.clone());
+                test_case.set_time(duration);
+                self.increment_duration(duration);
+                if self.rand_bool(self.options.test_case.test_case_sys_out_percentage) {
+                    test_case.set_system_out(self.fake_paragraphs());
+                }
+                if self.rand_bool(self.options.test_case.test_case_sys_err_percentage) {
+                    test_case.set_system_err(self.fake_paragraphs());
+                }
+                test_case
+            })
+            .collect()
+    }
+
+    fn generate_test_case_status(&mut self) -> TestCaseStatus {
+        let rand_percentage = self.rand_percentage();
+        let mut total = 0_u8;
+        for (i, percentage) in self
+            .options
+            .test_case
+            .test_case_success_to_skip_to_fail_to_error_percentage
+            .iter()
+            .flatten()
+            .enumerate()
+        {
+            let new_total = total + percentage;
+            if (total..=new_total).contains(&rand_percentage) {
+                return match i {
+                    0 => TestCaseStatus::Success {
+                        flaky_runs: self.generate_test_reruns(),
+                    },
+                    1 => TestCaseStatus::skipped(),
+                    2 => TestCaseStatus::NonSuccess {
+                        kind: quick_junit::NonSuccessKind::Failure,
+                        message: Some(self.fake_paragraphs().into()),
+                        ty: None,
+                        description: None,
+                        reruns: self.generate_test_reruns(),
+                    },
+                    3 => TestCaseStatus::NonSuccess {
+                        kind: quick_junit::NonSuccessKind::Error,
+                        message: Some(self.fake_paragraphs().into()),
+                        ty: None,
+                        description: None,
+                        reruns: self.generate_test_reruns(),
+                    },
+                    _ => unreachable!("only 4 percentages are valid"),
+                };
+            }
+            total = new_total;
+        }
+        unreachable!("invalid percentage of test case status")
+    }
+
+    fn generate_test_reruns(&mut self) -> Vec<TestRerun> {
+        let range_start = *self
+            .options
+            .test_rerun
+            .test_rerun_count_range
+            .first()
+            .expect("test rerun count range must have a start");
+        let range_end = *self
+            .options
+            .test_rerun
+            .test_rerun_count_range
+            .get(1)
+            .expect("test rerun count range must have an end");
+        let count = self.rng.gen_range(range_start..=range_end);
+        let failure_to_error_threshold = *self
+            .options
+            .test_rerun
+            .test_rerun_fail_to_error_percentage
+            .iter()
+            .flatten()
+            .next()
+            .expect("test rerun failure percentage must be set");
+        (0..count)
+            .map(|_| {
+                TestRerun::new(if self.rand_percentage() <= failure_to_error_threshold {
+                    NonSuccessKind::Failure
+                } else {
+                    NonSuccessKind::Error
+                })
+            })
+            .collect()
+    }
+
+    fn fake_paragraphs(&mut self) -> String {
+        let paragraphs: Vec<String> =
+            fake::faker::lorem::en::Paragraphs(1..3).fake_with_rng(&mut self.rng);
+        paragraphs.join("\n")
+    }
+
+    fn fake_duration<T: AsRef<[humantime::Duration]>>(&mut self, range: T) -> Duration {
+        let range_start = range
+            .as_ref()
+            .first()
+            .expect("must have start range for duration")
+            .as_nanos();
+        let range_end = range
+            .as_ref()
+            .get(1)
+            .expect("must have end range for duration")
+            .as_nanos();
+        let rand_duration_ns = self.rng.gen_range(range_start..=range_end);
+        Duration::new(0, rand_duration_ns as u32)
+    }
+
+    fn rand_bool<T: Into<f64>>(&mut self, percentage_chance: T) -> bool {
+        self.rng.gen_bool(percentage_chance.into() / 100.0)
+    }
+
+    fn rand_percentage(&mut self) -> u8 {
+        self.rng.gen_range(0..=100)
+    }
+}

--- a/junit-mock/src/main.rs
+++ b/junit-mock/src/main.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+use junit_mock::JunitMock;
+
+#[derive(Debug, Parser)]
+pub struct Cli {
+    /// Directory to output JUnit XML files
+    #[arg(required = true)]
+    pub directory: PathBuf,
+
+    #[command(flatten)]
+    pub options: junit_mock::Options,
+}
+
+fn main() -> Result<()> {
+    let Cli { directory, options } = Cli::try_parse()?;
+
+    let mut jm = JunitMock::new(options);
+    println!("Using seed `{}` to generate random data.", jm.get_seed());
+
+    let reports = jm.generate_reports();
+
+    JunitMock::write_reports_to_file(directory, &reports)
+}


### PR DESCRIPTION
CLI / lib to mock JUnit files. Helps with testing. See it in action on #95

Related to https://linear.app/trunk/issue/TRUNK-12265/test-validation-flake-generator

```
Usage: junit-mock [OPTIONS] <DIRECTORY>

Arguments:
  <DIRECTORY>  Directory to output JUnit XML files

Options:
  -h, --help  Print help

Global Options:
      --seed <SEED>  Seed for all generated data, defaults to randomly generated seed

Report Options:
      --report-names <REPORT_NAMES>
          A list of report names to generate (conflicts with --report-random-count)
      --report-random-count <REPORT_RANDOM_COUNT>
          The number of reports with random names to generate (conflicts with --report-names) [default: 1]
      --report-duration-range <DURATION_RANGE_START> <DURATION_RANGE_END>
          Inclusive range of time between report timestamps [default: 5m 1h]

Test Suite Options:
      --test-suite-names <TEST_SUITE_NAMES>
          A list of test suite names to generate (conflicts with --test-suite-random-count)
      --test-suite-random-count <TEST_SUITE_RANDOM_COUNT>
          The number of test suites with random names to generate (conflicts with --test-suite-names) [default: 50]
      --test-suite-sys-out-percentage <TEST_SUITE_SYS_OUT_PERCENTAGE>
          The chance of a system out message being added to the test suite [default: 50]
      --test-suite-sys-err-percentage <TEST_SUITE_SYS_ERR_PERCENTAGE>
          The chance of a system error message being added to the test suite [default: 50]

Test Case Options:
      --test-case-names <TEST_CASE_NAMES>                                                                              A list of test case names to generate (conflicts with --test-case-random-count, requires --test-case-classnames)
      --test-case-classnames <TEST_CASE_CLASSNAMES>                                                                    A list of test case classnames to generate (conflicts with --test-case-random-count, requires --test-case-names)
      --test-case-random-count <TEST_CASE_RANDOM_COUNT>                                                                The number of test cases with random names to generate (conflicts with --test-suite-names, --test-suite-classnames) [default: 10]
      --test-case-sys-out-percentage <TEST_CASE_SYS_OUT_PERCENTAGE>                                                    The chance of a system out message being added to the test case [default: 50]
      --test-case-sys-err-percentage <TEST_CASE_SYS_ERR_PERCENTAGE>                                                    The chance of a system error message being added to the test case [default: 50]
      --test-case-duration-range <DURATION_RANGE_START> <DURATION_RANGE_END>                                           Inclusive range of time between test case timestamps [default: 30s 1m]
      --test-case-success-to-skip-to-fail-to-error-percentage <TEST_CASE_SUCCESS_TO_SKIP_TO_FAIL_TO_ERROR_PERCENTAGE>  The chance of a test case succeeding, skipping, failing, and erroring (must add up to 100) [default: 25,25,25,25]

Test Rerun Options:
      --test-rerun-count-range <COUNT_RANGE_START> <COUNT_RANGE_END>
          Inclusive range of the number of reruns of a test that was not skipped [default: 0 2]
      --test-rerun-fail-to-error-percentage <TEST_RERUN_FAIL_TO_ERROR_PERCENTAGE>
          The chance of a test rerun failing and erroring (must add up to 100) [default: 50,50]
```