### PR TITLE
add gitlab codeowners parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,10 +403,16 @@ name = "codeowners"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "assert_matches",
+ "const_format",
+ "fancy-regex",
  "glob",
+ "indexmap",
  "lazy_static",
  "pretty_assertions",
+ "rand",
  "regex",
+ "thiserror",
 ]
 
 [[package]]
@@ -399,6 +420,26 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "core-foundation"
@@ -533,6 +574,17 @@ checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
 dependencies = [
  "deunicode",
  "rand",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2830,6 +2882,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "untrusted"

--- a/codeowners/Cargo.toml
+++ b/codeowners/Cargo.toml
@@ -4,10 +4,16 @@ edition = "2018"
 version = "0.1.3"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 pretty_assertions = "0.6"
+rand = "0.8.5"
 
 [dependencies]
 glob = "0.3"
 regex = "1.2"
 lazy_static = "1.4"
 anyhow = "1.0.86"
+thiserror = "1.0.63"
+const_format = "0.2.33"
+fancy-regex = "0.13.0"
+indexmap = "2.5.0"

--- a/codeowners/src/gitlab/entry.rs
+++ b/codeowners/src/gitlab/entry.rs
@@ -1,0 +1,353 @@
+use std::{
+    collections::BTreeSet,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::Arc,
+};
+
+use anyhow::Result;
+
+use super::{ReferenceExtractor, Section};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Data {
+    pub pattern: String,
+    pub owner_line: String,
+    pub section: String,
+    pub optional: bool,
+    pub approvals_required: usize,
+}
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/lib/gitlab/code_owners/entry.rb
+#[derive(Debug, Clone, Default, PartialOrd, Ord)]
+pub struct Entry {
+    data: Data,
+    users: Option<BTreeSet<String>>,
+    groups: Option<BTreeSet<String>>,
+    // NOTE: making this `pub` is not part of the reference implementation, but needed to extract
+    // owners.
+    pub(crate) extractor: Arc<ReferenceExtractor>,
+    names: Option<BTreeSet<String>>,
+}
+
+impl Entry {
+    pub fn new(
+        pattern: String,
+        owner_line: String,
+        section: Option<String>,
+        optional: Option<bool>,
+        approvals_required: Option<usize>,
+    ) -> Self {
+        Self {
+            data: Data {
+                pattern,
+                owner_line: owner_line.clone(),
+                section: section.unwrap_or_else(|| String::from(Section::DEFAULT)),
+                optional: optional.unwrap_or_default(),
+                approvals_required: approvals_required.unwrap_or_default(),
+            },
+            extractor: Arc::new(ReferenceExtractor::new(owner_line)),
+            ..Default::default()
+        }
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn users(&self) -> Result<BTreeSet<String>> {
+        self.users.clone().ok_or_else(|| {
+            anyhow::Error::msg(format!("CodeOwners for {} not loaded", &self.owner_line))
+        })
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn groups(&self) -> Result<BTreeSet<String>> {
+        self.groups.clone().ok_or_else(|| {
+            anyhow::Error::msg(format!(
+                "CodeOwners groups for {} not loaded",
+                &self.owner_line
+            ))
+        })
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn add_matching_groups_from(&mut self, new_groups: Vec<String>) {
+        for group in new_groups.into_iter() {
+            if self.matching_group(&group) {
+                self.groups
+                    .get_or_insert_with(Default::default)
+                    .insert(group.to_lowercase());
+            }
+        }
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn add_matching_users_from(&mut self, new_users: Vec<String>) {
+        for user in new_users.into_iter() {
+            if self.matching_user(&user) {
+                self.users.get_or_insert_with(Default::default).insert(user);
+            }
+        }
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    fn names(&mut self) -> &BTreeSet<String> {
+        let extractor = self.extractor.clone();
+        self.names.get_or_insert_with(|| {
+            extractor
+                .names()
+                .iter()
+                .map(|name| name.to_lowercase())
+                .collect()
+        })
+    }
+
+    fn matching_group<T: AsRef<str>>(&mut self, group: T) -> bool {
+        self.names().contains(&group.as_ref().to_lowercase())
+    }
+
+    fn matching_user<T: AsRef<str>>(&mut self, user: T) -> bool {
+        self.names().contains(&user.as_ref().to_lowercase())
+    }
+}
+
+impl Deref for Entry {
+    type Target = Data;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl PartialEq for Entry {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.owner_line == other.owner_line
+    }
+}
+
+impl Eq for Entry {}
+
+impl Hash for Entry {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.pattern.hash(state);
+        self.owner_line.hash(state);
+    }
+}
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/lib/gitlab/code_owners/entry_spec.rb
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, iter::FromIterator};
+
+    use lazy_static::lazy_static;
+
+    use crate::gitlab::entry::Entry;
+
+    lazy_static! {
+        static ref ENTRY: Entry = Entry::new(
+            String::from("/**/file"),
+            String::from("@user jane@gitlab.org @group @group/nested-group"),
+            Some(String::from("Documentation")),
+            None,
+            None
+        );
+    }
+
+    #[test]
+    fn is_uniq_by_the_pattern_and_owner_line() {
+        let equal_entry = ENTRY.clone();
+        let other_entry = Entry::new(
+            String::from("/**/other_file"),
+            String::from("@user jane@gitlab.org @group"),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(equal_entry, ENTRY.clone());
+        assert_eq!(
+            BTreeSet::from_iter([ENTRY.clone(), equal_entry.clone(), other_entry.clone()].iter()),
+            BTreeSet::from_iter([equal_entry, other_entry].iter())
+        );
+    }
+
+    mod users {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::entry::tests::ENTRY;
+
+        #[test]
+        fn raises_an_error_if_no_users_have_been_added() {
+            assert!(ENTRY
+                .users()
+                .unwrap_err()
+                .to_string()
+                .contains("not loaded"));
+        }
+
+        #[test]
+        fn returns_the_users_in_an_array() {
+            let mut entry = ENTRY.clone();
+
+            let user = String::from("@user");
+            entry.add_matching_users_from(vec![user.clone()]);
+
+            assert_eq!(
+                entry.users().unwrap(),
+                BTreeSet::from_iter(vec![user].into_iter())
+            );
+        }
+    }
+
+    mod all_users {
+        use crate::gitlab::entry::tests::ENTRY;
+
+        #[test]
+        fn raises_an_error_if_users_have_not_been_loaded_for_groups() {
+            let mut entry = ENTRY.clone();
+
+            let group = String::from("@group");
+            entry.add_matching_groups_from(vec![group]);
+
+            assert!(ENTRY
+                .users()
+                .unwrap_err()
+                .to_string()
+                .contains("not loaded"));
+        }
+    }
+
+    mod groups {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::entry::tests::ENTRY;
+
+        #[test]
+        fn raises_an_error_if_no_groups_have_been_added() {
+            assert!(ENTRY
+                .groups()
+                .unwrap_err()
+                .to_string()
+                .contains("not loaded"));
+        }
+
+        #[test]
+        fn returns_mentioned_groups() {
+            let mut entry = ENTRY.clone();
+
+            let group = String::from("@group");
+            entry.add_matching_groups_from(vec![group.clone()]);
+
+            assert_eq!(
+                entry.groups().unwrap(),
+                BTreeSet::from_iter(vec![group].into_iter())
+            );
+        }
+    }
+
+    mod add_matching_groups_from {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::entry::tests::ENTRY;
+
+        #[test]
+        fn returns_only_mentioned_groups_case_insensitively() {
+            let mut entry = ENTRY.clone();
+
+            let group = String::from("@group");
+            let group2 = String::from("@Group");
+            let nested_group = format!("{group}/nested-group");
+            entry.add_matching_groups_from(vec![group.clone(), group2, nested_group.clone()]);
+
+            assert_eq!(
+                entry.groups().unwrap(),
+                BTreeSet::from_iter(vec![group, nested_group].into_iter())
+            );
+        }
+    }
+
+    mod add_matching_users_from {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::entry::tests::ENTRY;
+
+        #[test]
+        fn does_not_add_the_same_user_twice() {
+            let mut entry = ENTRY.clone();
+
+            let user = String::from("@user");
+            for _ in 0..2 {
+                entry.add_matching_users_from(vec![user.clone()]);
+            }
+
+            assert_eq!(
+                entry.users().unwrap(),
+                BTreeSet::from_iter(vec![user].into_iter())
+            );
+        }
+
+        #[test]
+        fn only_adds_users_mentioned_in_the_owner_line() {
+            let mut entry = ENTRY.clone();
+
+            let other_user = String::from("@other_user");
+            let user = String::from("@user");
+            entry.add_matching_users_from(vec![other_user, user.clone()]);
+
+            assert_eq!(
+                entry.users().unwrap(),
+                BTreeSet::from_iter(vec![user].into_iter())
+            );
+        }
+
+        #[test]
+        fn adds_users_by_username_case_insensitively() {
+            let mut entry = ENTRY.clone();
+
+            let user = String::from("@USER");
+            entry.add_matching_users_from(vec![user.clone()]);
+
+            assert_eq!(
+                entry.users().unwrap(),
+                BTreeSet::from_iter(vec![user].into_iter())
+            );
+        }
+    }
+
+    mod approvals_required {
+        mod when_there_has_approvals_required_params_approvals_required {
+            use crate::gitlab::Entry;
+
+            #[test]
+            fn returns_2() {
+                let entry = Entry::new(
+                    String::from("/**/file"),
+                    String::from("@user jane@gitlab.org @group @group/nested-group"),
+                    Some(String::from("Documentation")),
+                    Some(false),
+                    Some(2),
+                );
+                assert_eq!(entry.approvals_required, 2);
+            }
+        }
+
+        mod when_there_has_no_approvals_required_params {
+            use crate::gitlab::Entry;
+
+            #[test]
+            fn returns_0() {
+                let entry = Entry::new(
+                    String::from("/**/file"),
+                    String::from("@user jane@gitlab.org @group @group/nested-group"),
+                    Some(String::from("Documentation")),
+                    None,
+                    None,
+                );
+                assert_eq!(entry.approvals_required, 0);
+            }
+        }
+    }
+}

--- a/codeowners/src/gitlab/error.rs
+++ b/codeowners/src/gitlab/error.rs
@@ -1,0 +1,51 @@
+use std::{error, fmt, path::PathBuf};
+
+use thiserror::Error;
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/lib/gitlab/code_owners/error.rb
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum ErrorType {
+    #[error("invalid section owner format")]
+    InvalidSectionOwnerFormat,
+    #[error("missing entry owner")]
+    MissingEntryOwner,
+    #[error("invalid entry owner format")]
+    InvalidEntryOwnerFormat,
+    #[error("missing section name")]
+    MissingSectionName,
+    #[error("invalid approval requirement")]
+    InvalidApprovalRequirement,
+    #[error("invalid section format")]
+    InvalidSectionFormat,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+    message: String,
+    line_number: usize,
+    path: PathBuf,
+}
+
+impl Error {
+    pub fn new(message: String, line_number: usize, path: PathBuf) -> Self {
+        Self {
+            message,
+            line_number,
+            path,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self {
+            message,
+            line_number,
+            path,
+        } = &self;
+        let inner = format!("{}:{line_number}\t{message}", path.to_string_lossy());
+        f.write_str(inner.as_str())
+    }
+}
+
+impl error::Error for Error {}

--- a/codeowners/src/gitlab/file.rs
+++ b/codeowners/src/gitlab/file.rs
@@ -1,0 +1,1071 @@
+use std::{io::BufRead, path::PathBuf};
+
+use fancy_regex::Regex;
+use indexmap::IndexMap;
+use lazy_static::lazy_static;
+
+use crate::gitlab::{ErrorType, ReferenceExtractor};
+
+use super::{Entry, Error, Section, SectionParser};
+
+pub type ParsedData = IndexMap<String, IndexMap<String, Entry>>;
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/lib/gitlab/code_owners/file.rb
+#[derive(Debug, Clone, Default)]
+pub struct File {
+    path: PathBuf,
+    errors: Vec<Error>,
+    parsed_data: ParsedData,
+}
+
+impl File {
+    pub fn new<B: BufRead>(buf_read: B, path: Option<PathBuf>) -> Self {
+        let mut file = Self {
+            path: path.unwrap_or_default(),
+            errors: Vec::new(),
+            ..Default::default()
+        };
+
+        file.parsed_data = file.get_parsed_data(buf_read);
+
+        file
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn parsed_data(&self) -> ParsedData {
+        self.parsed_data.clone()
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn empty(&self) -> bool {
+        self.parsed_data.values().all(|v| v.is_empty())
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn sections(&self) -> Vec<String> {
+        self.parsed_data.keys().cloned().collect()
+    }
+
+    // NOTE: Allow reference implementation methods for double-checking
+    #[allow(dead_code)]
+    pub fn optional_section(&self, section: String) -> bool {
+        self.parsed_data
+            .get(&section)
+            .map(|patterns| patterns.values().all(|entry| entry.optional))
+            .unwrap_or_default()
+    }
+
+    pub fn entries_for_path(&self, path: String) -> Vec<Entry> {
+        let path = if path.starts_with('/') {
+            path
+        } else {
+            format!("/{path}")
+        };
+        self.parsed_data
+            .iter()
+            .filter_map(|(_, section_entries)| {
+                section_entries
+                    .iter()
+                    .rev()
+                    .find(|(pattern, ..)| File::path_matches(pattern, &path))
+                    .map(|(_, entry)| entry)
+                    .cloned()
+            })
+            .collect()
+    }
+
+    pub fn valid(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    pub fn errors(&self) -> Vec<Error> {
+        self.errors.clone()
+    }
+
+    fn get_parsed_data<B: BufRead>(&mut self, blob: B) -> ParsedData {
+        let mut current_section = Section::new(String::from(Section::DEFAULT), None, None, None);
+        let mut parsed_sectional_data = ParsedData::new();
+        parsed_sectional_data.insert(current_section.name.clone(), Default::default());
+
+        for (i, possible_line) in blob.lines().enumerate() {
+            let line_number = i;
+            if let Ok(line) = possible_line {
+                let line = line.trim();
+                if File::skip(line) {
+                    continue;
+                }
+
+                let mut section_parser =
+                    SectionParser::new(String::from(line), &parsed_sectional_data);
+                let parsed_section = section_parser.execute();
+
+                if !section_parser.valid() {
+                    section_parser.errors.iter().for_each(|error| {
+                        self.add_error(error.to_string(), line_number);
+                    });
+                }
+
+                if let Some(new_parsed_section) = parsed_section {
+                    current_section = new_parsed_section;
+                    parsed_sectional_data
+                        .entry(current_section.name.clone())
+                        .or_default();
+
+                    continue;
+                }
+
+                self.parse_entry(
+                    String::from(line),
+                    &mut parsed_sectional_data,
+                    &current_section,
+                    line_number,
+                );
+            }
+        }
+
+        parsed_sectional_data
+    }
+
+    fn parse_entry(
+        &mut self,
+        line: String,
+        parsed: &mut ParsedData,
+        section: &Section,
+        line_number: usize,
+    ) {
+        lazy_static! {
+            static ref LINE_PARTITION: Regex = Regex::new(r"(?<!\\)\s+").unwrap();
+        }
+        let (pattern, entry_owners) = LINE_PARTITION
+            .find(&line)
+            .ok()
+            .flatten()
+            .map(|r#match| r#match.range())
+            .map_or_else(
+                || (line.clone(), String::default()),
+                |range| {
+                    let mut pattern = line.clone();
+                    let mut separator_and_entry_owners = pattern.split_off(range.start);
+                    let entry_owners =
+                        separator_and_entry_owners.split_off(range.end - range.start);
+                    (pattern, entry_owners)
+                },
+            );
+        let normalized_pattern = File::normalize_pattern(pattern.clone());
+
+        if !entry_owners.is_empty()
+            && ReferenceExtractor::new(entry_owners.clone())
+                .references()
+                .is_empty()
+        {
+            self.add_error(ErrorType::InvalidEntryOwnerFormat.to_string(), line_number);
+        }
+
+        let owners = if !entry_owners.is_empty() {
+            entry_owners
+        } else {
+            section.default_owners.clone()
+        };
+
+        if owners.is_empty() {
+            self.add_error(ErrorType::MissingEntryOwner.to_string(), line_number);
+        }
+
+        parsed.entry(section.name.clone()).or_default().insert(
+            normalized_pattern,
+            Entry::new(
+                pattern,
+                owners,
+                Some(section.name.clone()),
+                Some(section.optional),
+                Some(section.approvals),
+            ),
+        );
+    }
+
+    fn skip<T: AsRef<str>>(line: T) -> bool {
+        line.as_ref().is_empty() || line.as_ref().starts_with('#')
+    }
+
+    fn normalize_pattern(pattern: String) -> String {
+        if pattern == "*" {
+            return String::from("/**/*");
+        }
+
+        lazy_static! {
+            static ref POUND_ESCAPE: Regex = Regex::new(r"\A\\#").unwrap();
+            static ref WHITESPACE_ESCAPE: Regex = Regex::new(r"\\\s+").unwrap();
+        }
+
+        let mut pattern = String::from(POUND_ESCAPE.replace(&pattern, "#"));
+        pattern = String::from(WHITESPACE_ESCAPE.replace_all(&pattern, " "));
+
+        if !pattern.starts_with('/') {
+            pattern = format!("/**/{pattern}");
+        }
+
+        if pattern.ends_with('/') {
+            pattern = format!("{pattern}**/*");
+        }
+
+        pattern
+    }
+
+    fn path_matches<T: AsRef<str>, U: AsRef<str>>(pattern: T, path: U) -> bool {
+        glob::Pattern::new(pattern.as_ref())
+            .ok()
+            .map(|p| {
+                p.matches_with(
+                    path.as_ref(),
+                    glob::MatchOptions {
+                        case_sensitive: true,
+                        require_literal_leading_dot: false,
+                        require_literal_separator: true,
+                    },
+                )
+            })
+            .unwrap_or_default()
+    }
+
+    fn add_error(&mut self, message: String, line_number: usize) {
+        self.errors
+            .push(Error::new(message, line_number, self.path.clone()));
+    }
+}
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/lib/gitlab/code_owners/file_spec.rb
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use lazy_static::lazy_static;
+
+    use crate::gitlab::File;
+
+    /// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/fixtures/codeowners_example
+    const CODEOWNERS_EXAMPLE: &[u8] =
+        include_bytes!("../../test_fixtures/gitlab/codeowners_example");
+
+    /// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/fixtures/mixed_case_sectional_codeowners_example
+    const MIXED_CASE_SECTIONAL_CODEOWNERS_EXAMPLE: &[u8] =
+        include_bytes!("../../test_fixtures/gitlab/mixed_case_sectional_codeowners_example");
+
+    /// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/fixtures/sectional_codeowners_example
+    const SECTIONAL_CODEOWNERS_EXAMPLE: &[u8] =
+        include_bytes!("../../test_fixtures/gitlab/sectional_codeowners_example");
+
+    lazy_static! {
+        static ref FILE: File = File::new(CODEOWNERS_EXAMPLE, Some(PathBuf::from("CODEOWNERS")));
+        static ref FILE_MIXED_CASE_SECTIONAL_CODEOWNERS_EXAMPLE: File = File::new(
+            MIXED_CASE_SECTIONAL_CODEOWNERS_EXAMPLE,
+            Some(PathBuf::from("CODEOWNERS"))
+        );
+        static ref FILE_SECTIONAL_CODEOWNERS_EXAMPLE: File = File::new(
+            SECTIONAL_CODEOWNERS_EXAMPLE,
+            Some(PathBuf::from("CODEOWNERS"))
+        );
+    }
+
+    fn owner_line<T: AsRef<str>>(pattern: T) -> String {
+        FILE.parsed_data()
+            .get("codeowners")
+            .unwrap()
+            .get(pattern.as_ref())
+            .unwrap()
+            .owner_line
+            .clone()
+    }
+
+    mod parsed_data {
+        mod when_codeowners_file_contains_no_sections {
+            use crate::gitlab::file::tests::{owner_line, FILE};
+
+            #[test]
+            fn parses_all_the_required_lines() {
+                let expected_patterns = vec![
+                    "/**/*",
+                    "/**/*.rb",
+                    "/**/#file_with_pound.rb",
+                    "/**/CODEOWNERS",
+                    "/**/LICENSE",
+                    "/docs/**/*",
+                    "/docs/*",
+                    "/**/lib/**/*",
+                    "/config/**/*",
+                    "/**/path with spaces/**/*",
+                ];
+
+                assert_eq!(
+                    FILE.parsed_data()
+                        .get("codeowners")
+                        .unwrap()
+                        .keys()
+                        .collect::<Vec<&String>>(),
+                    expected_patterns
+                );
+            }
+
+            #[test]
+            fn allows_usernames_and_emails() {
+                let owner_line = owner_line("/**/LICENSE");
+                assert!(owner_line.contains("legal"));
+                assert!(owner_line.contains("janedoe@gitlab.com"))
+            }
+        }
+
+        mod when_handling_a_sectional_codeowners_file {
+            use crate::gitlab::{
+                file::tests::{
+                    FILE, FILE_MIXED_CASE_SECTIONAL_CODEOWNERS_EXAMPLE,
+                    FILE_SECTIONAL_CODEOWNERS_EXAMPLE,
+                },
+                Section,
+            };
+
+            mod creates_expected_parsed_sectional_results {
+                use std::{collections::HashSet, iter::FromIterator};
+
+                use crate::gitlab::File;
+
+                pub fn shared_examples(file: &File) {
+                    is_a_hash_sorted_by_sections_without_duplicates(file);
+                    assigns_the_correct_paths_to_each_section(file);
+                    assigns_the_correct_owners_for_each_entry(file);
+                }
+
+                fn is_a_hash_sorted_by_sections_without_duplicates(file: &File) {
+                    let data = file.parsed_data();
+
+                    assert_eq!(data.keys().len(), 7);
+                    assert_eq!(
+                        data.keys().collect::<Vec<&String>>(),
+                        vec![
+                            "codeowners",
+                            "Documentation",
+                            "Database",
+                            "Two Words",
+                            "Double::Colon",
+                            "DefaultOwners",
+                            "OverriddenOwners"
+                        ]
+                    );
+                }
+
+                const CODEOWNERS_SECTION_PATHS: &[&str] = &[
+                    "/**/*",
+                    "/**/*.rb",
+                    "/**/#file_with_pound.rb",
+                    "/**/CODEOWNERS",
+                    "/**/LICENSE",
+                    "/docs/**/*",
+                    "/docs/*",
+                    "/**/lib/**/*",
+                    "/config/**/*",
+                    "/**/path with spaces/**/*",
+                ];
+
+                const CODEOWNERS_SECTION_OWNERS: &[&str] = &[
+                    "@all-docs",
+                    "@config-owner",
+                    "@default-codeowner",
+                    "@legal this does not match janedoe@gitlab.com",
+                    "@lib-owner",
+                    "@multiple @owners\t@tab-separated",
+                    "@owner-file-with-pound",
+                    "@root-docs",
+                    "@ruby-owner",
+                    "@space-owner",
+                ];
+
+                const WHERE: &[(&str, &[&str], &[&str])] = &[
+                    (
+                        "codeowners",
+                        CODEOWNERS_SECTION_PATHS,
+                        CODEOWNERS_SECTION_OWNERS,
+                    ),
+                    (
+                        "Documentation",
+                        &["/**/ee/docs", "/**/docs", "/**/README.md"],
+                        &["@gl-docs"],
+                    ),
+                    (
+                        "Database",
+                        &["/**/README.md", "/**/model/db"],
+                        &["@gl-database"],
+                    ),
+                    (
+                        "Two Words",
+                        &["/**/README.md", "/**/model/db"],
+                        &["@gl-database"],
+                    ),
+                    (
+                        "Double::Colon",
+                        &["/**/README.md", "/**/model/db"],
+                        &["@gl-database"],
+                    ),
+                    (
+                        "DefaultOwners",
+                        &["/**/README.md", "/**/model/db"],
+                        &["@config-owner @gl-docs"],
+                    ),
+                    (
+                        "OverriddenOwners",
+                        &["/**/README.md", "/**/model/db"],
+                        &["@gl-docs"],
+                    ),
+                ];
+
+                fn assigns_the_correct_paths_to_each_section(file: &File) {
+                    for (section, patterns, ..) in Vec::from(WHERE) {
+                        assert_eq!(
+                            file.parsed_data()
+                                .get(section)
+                                .unwrap()
+                                .keys()
+                                .collect::<Vec<&String>>(),
+                            patterns
+                        );
+                        assert_eq!(
+                            file.parsed_data()
+                                .get(section)
+                                .unwrap()
+                                .values()
+                                .find(|entry| { entry.section != section }),
+                            None
+                        );
+                    }
+                }
+
+                fn assigns_the_correct_owners_for_each_entry(file: &File) {
+                    for (section, _, owners) in Vec::from(WHERE) {
+                        assert_eq!(
+                            file.parsed_data()
+                                .get(section)
+                                .unwrap()
+                                .values()
+                                .map(|entry| { entry.owner_line.clone() })
+                                .collect::<HashSet<String>>(),
+                            HashSet::from_iter(
+                                Vec::from_iter(owners.iter().cloned().map(String::from))
+                                    .into_iter()
+                            )
+                        );
+                    }
+                }
+            }
+
+            #[test]
+            fn populates_a_hash_with_a_single_default_section() {
+                let data = FILE.parsed_data();
+
+                assert_eq!(data.keys().len(), 1);
+                assert_eq!(
+                    data.keys().collect::<Vec<&String>>(),
+                    vec![Section::DEFAULT]
+                );
+            }
+
+            mod when_codeowners_file_contains_sections_at_the_middle_of_a_line {
+                use lazy_static::lazy_static;
+
+                use crate::gitlab::File;
+
+                const FILE_CONTENT: &str = r#"
+                    [Required]
+                    *_spec.rb @gl-test
+
+                    ^[Optional]
+                    *_spec.rb @gl-test
+
+                    Something before [Partially optional]
+                    *.md @gl-docs
+
+                    Additional content before ^[Another partially optional]
+                    doc/* @gl-docs
+                "#;
+
+                lazy_static! {
+                    static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+                }
+
+                #[test]
+                fn parses_only_sections_that_start_at_the_beginning_of_a_line() {
+                    assert_eq!(
+                        FILE.parsed_data().keys().collect::<Vec<&String>>(),
+                        vec!["codeowners", "Required", "Optional"]
+                    );
+                }
+            }
+
+            #[test]
+            fn when_codeowners_file_contains_multiple_sections() {
+                creates_expected_parsed_sectional_results::shared_examples(
+                    &FILE_SECTIONAL_CODEOWNERS_EXAMPLE,
+                );
+            }
+
+            #[test]
+            fn when_codeowners_file_contains_multiple_sections_with_mixed_case_names() {
+                creates_expected_parsed_sectional_results::shared_examples(
+                    &FILE_MIXED_CASE_SECTIONAL_CODEOWNERS_EXAMPLE,
+                );
+            }
+
+            mod when_codeowners_file_contains_approvals_required {
+                use lazy_static::lazy_static;
+
+                use crate::gitlab::File;
+
+                const FILE_CONTENT: &str = r#"
+                    [Required][2]
+                    *_spec.rb @gl-test
+
+                    [Another required]
+                    *_spec.rb @gl-test
+
+                    [Required with default owners] @config-owner
+                    *_spec.rb @gl-test
+
+                    ^[Optional][2] @gl-docs @config-owner
+                    *_spec.rb
+
+                    [Required with non-numbers][q]
+                    *_spec.rb @gl-test
+
+                    ^[Optional with non-numbers][.] @not-matching
+                    *_spec.rb @gl-test
+                "#;
+
+                lazy_static! {
+                    static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+                }
+
+                #[test]
+                fn parses_the_approvals_required() {
+                    let data = FILE.parsed_data();
+
+                    let entry = data.get("Required").unwrap().get("/**/*_spec.rb").unwrap();
+                    assert_eq!(entry.approvals_required, 2);
+                    assert_eq!(entry.owner_line, "@gl-test");
+
+                    let entry = data
+                        .get("Another required")
+                        .unwrap()
+                        .get("/**/*_spec.rb")
+                        .unwrap();
+                    assert_eq!(entry.approvals_required, 0);
+                    assert_eq!(entry.owner_line, "@gl-test");
+
+                    let entry = data
+                        .get("Required with default owners")
+                        .unwrap()
+                        .get("/**/*_spec.rb")
+                        .unwrap();
+                    assert_eq!(entry.approvals_required, 0);
+                    assert_eq!(entry.owner_line, "@gl-test");
+
+                    let entry = data.get("Optional").unwrap().get("/**/*_spec.rb").unwrap();
+                    assert_eq!(entry.approvals_required, 2);
+                    assert_eq!(entry.owner_line, "@gl-docs @config-owner");
+
+                    let entry = data
+                        .get("Required with non-numbers")
+                        .unwrap()
+                        .get("/**/*_spec.rb")
+                        .unwrap();
+                    assert_eq!(entry.approvals_required, 0);
+                    assert_eq!(entry.owner_line, "@gl-test");
+
+                    let entry = data
+                        .get("Optional with non-numbers")
+                        .unwrap()
+                        .get("/**/*_spec.rb")
+                        .unwrap();
+                    assert_eq!(entry.approvals_required, 0);
+                    assert_eq!(entry.owner_line, "@gl-test");
+                }
+            }
+        }
+    }
+
+    mod empty {
+        use crate::gitlab::{file::tests::FILE, File};
+
+        #[test]
+        fn is_not_empty() {
+            assert!(!FILE.empty())
+        }
+
+        #[test]
+        fn when_there_is_no_content() {
+            let file = File::new("".as_bytes(), None);
+
+            assert!(file.empty())
+        }
+
+        #[test]
+        fn when_the_file_is_binary() {
+            let file = File::new(&[][..], None);
+
+            assert!(file.empty())
+        }
+
+        #[test]
+        fn when_the_file_did_not_exist() {
+            let file = File::new(&[][..], None);
+
+            assert!(file.empty())
+        }
+    }
+
+    mod path {
+        mod when_the_blob_exists {
+            use crate::gitlab::file::tests::FILE;
+
+            #[test]
+            fn returns_the_path_to_the_file() {
+                assert_eq!(FILE.path.to_str(), Some("CODEOWNERS"));
+            }
+        }
+
+        mod when_the_path_is_none {
+            use crate::gitlab::file::File;
+
+            #[test]
+            fn returns_empty() {
+                let file = File::new(&[][..], None);
+                assert_eq!(file.path.to_str(), Some(""));
+            }
+        }
+    }
+
+    mod sections {
+        mod when_codeowners_file_contains_sections {
+            use lazy_static::lazy_static;
+
+            use crate::gitlab::File;
+
+            const FILE_CONTENT: &str = r#"
+                *.rb @ruby-owner
+
+                [Documentation]
+                *.md @gl-docs
+
+                [Test]
+                *_spec.rb @gl-test
+
+                [Documentation]
+                doc/* @gl-docs
+            "#;
+
+            lazy_static! {
+                static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+            }
+
+            #[test]
+            fn returns_unique_sections() {
+                assert_eq!(FILE.sections(), vec!["codeowners", "Documentation", "Test"]);
+            }
+        }
+
+        mod when_codeowners_file_is_missing {
+            use crate::gitlab::File;
+
+            #[test]
+            fn returns_a_default_section() {
+                let file = File::new(&[][..], None);
+
+                assert_eq!(file.sections(), vec!["codeowners"]);
+            }
+        }
+    }
+
+    mod optional_section {
+        use lazy_static::lazy_static;
+
+        use crate::gitlab::File;
+
+        const FILE_CONTENT: &str = r#"
+            *.rb @ruby-owner
+
+            [Required]
+            *_spec.rb @gl-test
+
+            ^[Optional]
+            *_spec.rb @gl-test
+
+            [Partially optional]
+            *.md @gl-docs
+
+            ^[Partially optional]
+            doc/* @gl-docs
+        "#;
+
+        lazy_static! {
+            static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+        }
+
+        #[test]
+        fn returns_whether_a_section_is_optional() {
+            assert!(!FILE.optional_section(String::from("Required")));
+            assert!(FILE.optional_section(String::from("Optional")));
+            assert!(!FILE.optional_section(String::from("Partially optional")));
+            assert!(!FILE.optional_section(String::from("Does not exist")));
+        }
+    }
+
+    mod entries_for_path {
+        use crate::gitlab::file::tests::FILE;
+
+        mod returns_expected_matches {
+            use crate::gitlab::File;
+
+            pub fn shared_examples(file: &File) {
+                for_a_path_without_matches::returns_an_empty_array_for_an_unmatched_path();
+                matches_random_files_to_a_pattern(file);
+                uses_the_last_pattern_if_multiple_patterns_match(file);
+                returns_the_usernames_for_a_file_matching_a_pattern_with_a_glob(file);
+                allows_specifying_multiple_users(file);
+                returns_emails_and_usernames_for_a_matched_pattern(file);
+                allows_escaping_the_pound_sign_used_for_comments(file);
+                returns_the_usernames_for_a_file_nested_in_a_directory(file);
+                returns_the_usernames_for_a_pattern_matched_with_a_glob_in_a_folder(file);
+                allows_matching_files_nested_anywhere_in_the_repository(file);
+                allows_allows_limiting_the_matching_files_to_the_root_of_the_repository_aggregate_failure(file);
+                correctly_matches_paths_with_spaces(file);
+                paths_with_whitespaces_and_username_lookalikes::parses_correctly();
+                a_glob_on_the_root_directory::matches_files_in_the_root_directory();
+                a_glob_on_the_root_directory::does_not_match_nested_files();
+                a_glob_on_the_root_directory::partial_matches::does_not_match_a_file_in_a_folder_that_looks_the_same();
+                a_glob_on_the_root_directory::partial_matches::matches_the_file_in_any_folder();
+            }
+
+            mod for_a_path_without_matches {
+                use lazy_static::lazy_static;
+
+                use crate::gitlab::File;
+
+                const FILE_CONTENT: &str = r#"
+                    # Simulating a CODOWNERS without entries
+                "#;
+
+                lazy_static! {
+                    static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+                }
+
+                pub fn returns_an_empty_array_for_an_unmatched_path() {
+                    let entry = FILE.entries_for_path(String::from("no_matches"));
+
+                    assert_eq!(entry, []);
+                }
+            }
+
+            fn matches_random_files_to_a_pattern(file: &File) {
+                let entries = file.entries_for_path(String::from("app/assets/something.vue"));
+                let entry = entries.first().unwrap();
+
+                assert_eq!(entry.pattern, "*");
+                assert!(entry.owner_line.contains("default-codeowner"));
+            }
+
+            fn uses_the_last_pattern_if_multiple_patterns_match(file: &File) {
+                let entries = file.entries_for_path(String::from("hello.rb"));
+                let entry = entries.first().unwrap();
+
+                assert_eq!(entry.pattern, "*.rb");
+                assert_eq!(entry.owner_line, "@ruby-owner");
+            }
+
+            fn returns_the_usernames_for_a_file_matching_a_pattern_with_a_glob(file: &File) {
+                let entries = file.entries_for_path(String::from("app/models/repository.rb"));
+                let entry = entries.first().unwrap();
+
+                assert_eq!(entry.owner_line, "@ruby-owner");
+            }
+
+            fn allows_specifying_multiple_users(file: &File) {
+                let entries = file.entries_for_path(String::from("CODEOWNERS"));
+                let entry = entries.first().unwrap();
+
+                for owner in ["multiple", "owners", "tab-separated"] {
+                    assert!(entry.owner_line.contains(owner));
+                }
+            }
+
+            fn returns_emails_and_usernames_for_a_matched_pattern(file: &File) {
+                let entries = file.entries_for_path(String::from("LICENSE"));
+                let entry = entries.first().unwrap();
+
+                for owner in ["legal", "janedoe@gitlab.com"] {
+                    assert!(entry.owner_line.contains(owner));
+                }
+            }
+
+            fn allows_escaping_the_pound_sign_used_for_comments(file: &File) {
+                let entries = file.entries_for_path(String::from("examples/#file_with_pound.rb"));
+                let entry = entries.first().unwrap();
+
+                assert!(entry.owner_line.contains("owner-file-with-pound"));
+            }
+
+            fn returns_the_usernames_for_a_file_nested_in_a_directory(file: &File) {
+                let entries = file.entries_for_path(String::from("docs/projects/index.md"));
+                let entry = entries.first().unwrap();
+
+                assert!(entry.owner_line.contains("all-docs"));
+            }
+
+            fn returns_the_usernames_for_a_pattern_matched_with_a_glob_in_a_folder(file: &File) {
+                let entries = file.entries_for_path(String::from("docs/index.md"));
+                let entry = entries.first().unwrap();
+
+                assert!(entry.owner_line.contains("root-docs"));
+            }
+
+            fn allows_matching_files_nested_anywhere_in_the_repository(file: &File) {
+                let lib_entries =
+                    file.entries_for_path(String::from("lib/gitlab/git/repository.rb"));
+                let lib_entry = lib_entries.first().unwrap();
+                let other_lib_entries =
+                    file.entries_for_path(String::from("ee/lib/gitlab/git/repository.rb"));
+                let other_lib_entry = other_lib_entries.first().unwrap();
+
+                // NOTE: matches failure aggregation in reference
+                assert_eq!(
+                    (
+                        lib_entry.owner_line.contains("lib-owner"),
+                        other_lib_entry.owner_line.contains("lib-owner")
+                    ),
+                    (true, true)
+                );
+            }
+
+            fn allows_allows_limiting_the_matching_files_to_the_root_of_the_repository_aggregate_failure(
+                file: &File,
+            ) {
+                let config_entries = file.entries_for_path(String::from("config/database.yml"));
+                let config_entry = config_entries.first().unwrap();
+                let other_config_entries =
+                    file.entries_for_path(String::from("other/config/database.yml"));
+                let other_config_entry = other_config_entries.first().unwrap();
+
+                // NOTE: matches failure aggregation in reference
+                assert_eq!(
+                    (
+                        config_entry.owner_line.contains("config-owner"),
+                        other_config_entry.owner_line.contains("@default-codeowner")
+                    ),
+                    (true, true)
+                );
+            }
+
+            fn correctly_matches_paths_with_spaces(file: &File) {
+                let entries = file.entries_for_path(String::from("path with spaces/docs.md"));
+                let entry = entries.first().unwrap();
+
+                assert_eq!(entry.owner_line, "@space-owner");
+            }
+
+            mod paths_with_whitespaces_and_username_lookalikes {
+                use lazy_static::lazy_static;
+
+                use crate::gitlab::File;
+
+                const FILE_CONTENT: &str = r#"
+                    a/weird\ path\ with/\ @username\ /\ and-email@lookalikes.com\ / @user-1 email@gitlab.org @user-2
+                "#;
+
+                lazy_static! {
+                    static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+                }
+
+                pub fn parses_correctly() {
+                    let entries = FILE.entries_for_path(String::from(
+                        "a/weird path with/ @username / and-email@lookalikes.com /test.rb",
+                    ));
+                    let entry = entries.first().unwrap();
+
+                    for owner in ["user-1", "user-2", "email@gitlab.org"] {
+                        assert!(entry.owner_line.contains(owner));
+                    }
+
+                    for owner in ["username", "and-email@lookalikes.com"] {
+                        assert!(!entry.owner_line.contains(owner));
+                    }
+                }
+            }
+
+            mod a_glob_on_the_root_directory {
+                use lazy_static::lazy_static;
+
+                use crate::gitlab::File;
+
+                const FILE_CONTENT: &str = r#"
+                    /* @user-1 @user-2
+                "#;
+
+                lazy_static! {
+                    static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+                }
+
+                pub fn matches_files_in_the_root_directory() {
+                    let entries = FILE.entries_for_path(String::from("README.md"));
+                    let entry = entries.first().unwrap();
+
+                    for owner in ["user-1", "user-2"] {
+                        assert!(entry.owner_line.contains(owner));
+                    }
+                }
+
+                pub fn does_not_match_nested_files() {
+                    let entries = FILE.entries_for_path(String::from("nested/path/README.md"));
+                    let entry = entries.first();
+
+                    assert_eq!(entry, None);
+                }
+
+                pub mod partial_matches {
+                    use lazy_static::lazy_static;
+
+                    use crate::gitlab::File;
+
+                    const FILE_CONTENT: &str = r#"
+                        foo/* @user-1 @user-2
+                    "#;
+
+                    lazy_static! {
+                        static ref FILE: File = File::new(FILE_CONTENT.as_bytes(), None);
+                    }
+
+                    pub fn does_not_match_a_file_in_a_folder_that_looks_the_same() {
+                        let entries = FILE.entries_for_path(String::from("fufoo/bar"));
+                        let entry = entries.first();
+
+                        assert_eq!(entry, None);
+                    }
+
+                    pub fn matches_the_file_in_any_folder() {
+                        let relative_entries = FILE.entries_for_path(String::from("baz/foo/bar"));
+                        let relative_entry = relative_entries.first().unwrap();
+                        let root_entries = FILE.entries_for_path(String::from("/foo/bar"));
+                        let root_entry = root_entries.first().unwrap();
+
+                        for owner in ["user-1", "user-2"] {
+                            assert!(relative_entry.owner_line.contains(owner));
+                        }
+
+                        for owner in ["user-1", "user-2"] {
+                            assert!(root_entry.owner_line.contains(owner));
+                        }
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn when_codeowners_file_contains_no_sections() {
+            returns_expected_matches::shared_examples(&FILE);
+        }
+
+        mod when_codeowners_file_contains_multiple_sections {
+            use crate::gitlab::file::tests::FILE_SECTIONAL_CODEOWNERS_EXAMPLE;
+
+            #[test]
+            fn returns_expected_matches() {
+                super::returns_expected_matches::shared_examples(
+                    &FILE_SECTIONAL_CODEOWNERS_EXAMPLE,
+                );
+            }
+        }
+    }
+
+    mod valid {
+        mod when_codeowners_file_is_correct {
+            use crate::gitlab::file::tests::FILE;
+
+            #[test]
+            fn does_not_detect_errors() {
+                assert!(FILE.valid());
+                assert_eq!(FILE.errors(), []);
+            }
+        }
+
+        mod when_codeowners_file_has_errors {
+            use std::path::PathBuf;
+
+            use lazy_static::lazy_static;
+
+            use crate::gitlab::{Error, ErrorType, File};
+
+            const FILE_CONTENT: &str = r#"
+                *.rb
+
+                []
+                *_spec.rb @gl-test
+
+                ^[Optional][5]
+                *.txt @user
+
+                [Invalid section
+
+                [OK section header]
+                some_entry not_a_user_not_an_email
+            "#;
+
+            lazy_static! {
+                static ref FILE: File =
+                    File::new(FILE_CONTENT.as_bytes(), Some(PathBuf::from("CODEOWNERS")));
+            }
+
+            #[test]
+            fn detects_syntax_errors() {
+                assert!(!FILE.valid());
+
+                assert_eq!(
+                    FILE.errors(),
+                    [
+                        Error::new(
+                            ErrorType::MissingEntryOwner.to_string(),
+                            1,
+                            PathBuf::from("CODEOWNERS")
+                        ),
+                        Error::new(
+                            ErrorType::MissingSectionName.to_string(),
+                            3,
+                            PathBuf::from("CODEOWNERS")
+                        ),
+                        Error::new(
+                            ErrorType::InvalidApprovalRequirement.to_string(),
+                            6,
+                            PathBuf::from("CODEOWNERS")
+                        ),
+                        Error::new(
+                            ErrorType::InvalidSectionFormat.to_string(),
+                            9,
+                            PathBuf::from("CODEOWNERS")
+                        ),
+                        Error::new(
+                            ErrorType::InvalidEntryOwnerFormat.to_string(),
+                            9,
+                            PathBuf::from("CODEOWNERS")
+                        ),
+                        Error::new(
+                            ErrorType::InvalidEntryOwnerFormat.to_string(),
+                            12,
+                            PathBuf::from("CODEOWNERS")
+                        )
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/codeowners/src/gitlab/mod.rs
+++ b/codeowners/src/gitlab/mod.rs
@@ -1,0 +1,228 @@
+mod entry;
+mod error;
+mod file;
+mod reference_extractor;
+mod section;
+mod section_parser;
+pub mod user;
+
+use std::{
+    fmt, fs,
+    io::{BufReader, Read},
+    path::Path,
+};
+
+use crate::{FromPath, FromReader, OwnersOfPath};
+
+pub use entry::*;
+pub use error::*;
+pub use file::*;
+
+pub use reference_extractor::*;
+pub use section::*;
+pub use section_parser::*;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum GitLabOwner {
+    Name(String),
+    Email(String),
+}
+
+impl fmt::Display for GitLabOwner {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let inner = match *self {
+            GitLabOwner::Name(ref n) => n,
+            GitLabOwner::Email(ref e) => e,
+        };
+        f.write_str(inner.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GitLabOwners {
+    file: File,
+}
+
+impl OwnersOfPath for GitLabOwners {
+    type Owner = GitLabOwner;
+
+    fn of<P>(&self, path: P) -> Option<Vec<Self::Owner>>
+    where
+        P: AsRef<Path>,
+    {
+        self.file
+            .entries_for_path(String::from(path.as_ref().to_string_lossy()))
+            .iter()
+            .try_fold(
+                Vec::new(),
+                |mut acc, entry| -> anyhow::Result<Vec<GitLabOwner>> {
+                    for owner in entry
+                        .extractor
+                        .emails()
+                        .iter()
+                        .map(|e| GitLabOwner::Email(String::from(e)))
+                        .chain(
+                            entry
+                                .extractor
+                                .names()
+                                .iter()
+                                .map(|n| GitLabOwner::Name(String::from(n))),
+                        )
+                    {
+                        acc.push(owner);
+                    }
+                    Ok(acc)
+                },
+            )
+            .ok()
+    }
+}
+
+impl FromPath for GitLabOwners {
+    fn from_path<P>(path: P) -> anyhow::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        Self::from_reader(fs::File::open(path)?)
+    }
+}
+
+impl FromReader for GitLabOwners {
+    fn from_reader<R>(read: R) -> anyhow::Result<Self>
+    where
+        R: Read,
+    {
+        let buf_reader = BufReader::new(read);
+        let file = File::new(buf_reader, None);
+        if !file.valid() {
+            let error_messages: Vec<String> =
+                file.errors().iter().map(ToString::to_string).collect();
+            return Err(anyhow::Error::msg(error_messages.join("\n")));
+        }
+
+        Ok(GitLabOwners { file })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // NOTE: GitLab's CODEOWNERS syntax is a superset of GitHub's
+    const EXAMPLE: &[u8] = include_bytes!("../../test_fixtures/github/codeowners_example");
+
+    #[test]
+    fn owner_displays() {
+        assert!(GitLabOwner::Name("@user".into()).to_string() == "@user");
+        assert!(GitLabOwner::Email("user@domain.com".into()).to_string() == "user@domain.com");
+    }
+
+    #[test]
+    fn owners_owns_wildcard() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        assert_eq!(
+            owners.of("foo.txt"),
+            Some(vec![
+                GitLabOwner::Name("@global-owner1".into()),
+                GitLabOwner::Name("@global-owner2".into()),
+            ])
+        );
+        assert_eq!(
+            owners.of("foo/bar.txt"),
+            Some(vec![
+                GitLabOwner::Name("@global-owner1".into()),
+                GitLabOwner::Name("@global-owner2".into()),
+            ])
+        )
+    }
+
+    #[test]
+    fn owners_owns_js_extention() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        assert_eq!(
+            owners.of("foo.js"),
+            Some(vec![GitLabOwner::Name("@js-owner".into())])
+        );
+        assert_eq!(
+            owners.of("foo/bar.js"),
+            Some(vec![GitLabOwner::Name("@js-owner".into())])
+        )
+    }
+
+    #[test]
+    fn owners_owns_go_extention() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        assert_eq!(
+            owners.of("foo.go"),
+            Some(vec![GitLabOwner::Email("docs@example.com".into())])
+        );
+        assert_eq!(
+            owners.of("foo/bar.go"),
+            Some(vec![GitLabOwner::Email("docs@example.com".into())])
+        )
+    }
+
+    #[test]
+    fn owners_owns_anchored_build_logs() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        // relative to root
+        assert_eq!(
+            owners.of("build/logs/foo.go"),
+            Some(vec![GitLabOwner::Name("@doctocat".into())])
+        );
+        assert_eq!(
+            owners.of("build/logs/foo/bar.go"),
+            Some(vec![GitLabOwner::Name("@doctocat".into())])
+        );
+        // not relative to root
+        assert_eq!(
+            owners.of("foo/build/logs/foo.go"),
+            Some(vec![GitLabOwner::Email("docs@example.com".into())])
+        )
+    }
+
+    #[test]
+    fn owners_owns_unanchored_docs() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        // docs anywhere
+        assert_eq!(
+            owners.of("foo/docs/foo.js"),
+            Some(vec![GitLabOwner::Email("docs@example.com".into())])
+        );
+        assert_eq!(
+            owners.of("foo/bar/docs/foo.js"),
+            Some(vec![GitLabOwner::Email("docs@example.com".into())])
+        );
+        // but not nested
+        assert_eq!(
+            owners.of("foo/bar/docs/foo/foo.js"),
+            Some(vec![GitLabOwner::Name("@js-owner".into())])
+        )
+    }
+
+    #[test]
+    fn owners_owns_unanchored_apps() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        assert_eq!(
+            owners.of("foo/apps/foo.js"),
+            Some(vec![GitLabOwner::Name("@octocat".into())])
+        )
+    }
+
+    #[test]
+    fn owners_owns_anchored_docs() {
+        let owners = GitLabOwners::from_reader(EXAMPLE).unwrap();
+        // relative to root
+        assert_eq!(
+            owners.of("docs/foo.js"),
+            Some(vec![GitLabOwner::Name("@doctocat".into())])
+        )
+    }
+
+    // NOTE: GitHub does this, but GitLab does not
+    #[test]
+    fn no_implied_children_owners() {
+        let owners = GitLabOwners::from_reader("foo/bar @doug".as_bytes()).unwrap();
+        assert_eq!(owners.of("foo/bar/baz.rs"), Some(Vec::new()))
+    }
+}

--- a/codeowners/src/gitlab/reference_extractor.rs
+++ b/codeowners/src/gitlab/reference_extractor.rs
@@ -1,0 +1,219 @@
+use std::{collections::BTreeSet, iter::FromIterator};
+
+pub mod reference_extractor_regex {
+    use fancy_regex::Regex;
+    use lazy_static::lazy_static;
+
+    use crate::gitlab::user;
+
+    lazy_static! {
+        pub static ref EMAIL_REGEXP: Regex =
+            Regex::new(r"[^@\s]{1,100}@[^@\s]{1,255}(?<!\W)").unwrap();
+        pub static ref USER_REGEXP: Regex = user::REFERENCE_PATTERN.clone();
+    }
+}
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/lib/gitlab/code_owners/reference_extractor.rb
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReferenceExtractor {
+    text: String,
+}
+
+impl ReferenceExtractor {
+    pub fn new(text: String) -> Self {
+        Self { text }
+    }
+
+    pub fn names(&self) -> BTreeSet<String> {
+        self.matches().names
+    }
+
+    pub fn emails(&self) -> BTreeSet<String> {
+        self.matches().emails
+    }
+
+    pub fn references(&self) -> BTreeSet<String> {
+        if self.text.is_empty() {
+            return BTreeSet::new();
+        }
+
+        let ReferenceExtractorMatches { emails, names } = self.matches();
+
+        emails.union(&names).cloned().collect()
+    }
+
+    fn matches(&self) -> ReferenceExtractorMatches {
+        let emails = reference_extractor_regex::EMAIL_REGEXP
+            .find_iter(&self.text)
+            .filter_map(|m| m.ok())
+            .map(|m| String::from(m.as_str()));
+        let names = reference_extractor_regex::USER_REGEXP
+            .find_iter(&self.text)
+            .filter_map(|m| m.ok())
+            .map(|m| String::from(m.as_str()));
+
+        ReferenceExtractorMatches {
+            emails: BTreeSet::from_iter(emails),
+            names: BTreeSet::from_iter(names),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ReferenceExtractorMatches {
+    emails: BTreeSet<String>,
+    names: BTreeSet<String>,
+}
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/lib/gitlab/code_owners/reference_extractor_spec.rb
+#[cfg(test)]
+mod tests {
+    use lazy_static::lazy_static;
+
+    use super::ReferenceExtractor;
+
+    const TEXT: &str = r#"
+        This is a long text that mentions some users.
+        @user-1, @user-2 and user@gitlab.org take a walk in the park.
+        There they meet @user-4 that was out with other-user@gitlab.org.
+        @user-1 thought it was late, so went home straight away not to
+        run into some @group @group/nested-on/other-group
+    "#;
+
+    lazy_static! {
+        static ref EXTRACTOR: ReferenceExtractor = ReferenceExtractor::new(String::from(TEXT));
+    }
+
+    mod emails {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::reference_extractor::tests::EXTRACTOR;
+
+        #[test]
+        fn includes_all_mentioned_email_addresses() {
+            assert_eq!(
+                EXTRACTOR.emails(),
+                BTreeSet::from_iter(
+                    vec![
+                        String::from("user@gitlab.org"),
+                        String::from("other-user@gitlab.org")
+                    ]
+                    .into_iter()
+                )
+            );
+        }
+
+        mod redos_vulnerability {
+            use rand::{
+                distributions::{Alphanumeric, DistString},
+                thread_rng,
+            };
+
+            fn generate_email(left_length: usize, right_length: usize) -> String {
+                let mut rng = thread_rng();
+                let left = Alphanumeric.sample_string(&mut rng, left_length);
+                let right = Alphanumeric.sample_string(&mut rng, right_length);
+                format!("{left}@{right}")
+            }
+
+            mod when_valid_email_length {
+                use std::{collections::BTreeSet, iter::FromIterator};
+
+                use crate::gitlab::ReferenceExtractor;
+
+                #[test]
+                fn includes_the_email() {
+                    let email = String::from(super::generate_email(100, 255));
+                    let extractor = ReferenceExtractor::new(email.clone());
+
+                    assert_eq!(
+                        extractor.emails(),
+                        BTreeSet::from_iter(vec![email].into_iter())
+                    );
+                }
+            }
+
+            mod when_invalid_email_first_part_length {
+                use std::{collections::BTreeSet, iter::FromIterator};
+
+                use crate::gitlab::ReferenceExtractor;
+
+                #[test]
+                fn doesnt_include_the_email() {
+                    let email = String::from(super::generate_email(101, 255));
+                    let extractor = ReferenceExtractor::new(email.clone());
+
+                    assert_ne!(
+                        extractor.emails(),
+                        BTreeSet::from_iter(vec![email].into_iter())
+                    );
+                }
+            }
+
+            mod when_invalid_email_second_part_length {
+                use std::{collections::BTreeSet, iter::FromIterator};
+
+                use crate::gitlab::ReferenceExtractor;
+
+                #[test]
+                fn doesnt_include_the_email() {
+                    let email = String::from(super::generate_email(100, 256));
+                    let extractor = ReferenceExtractor::new(email.clone());
+
+                    assert_ne!(
+                        extractor.emails(),
+                        BTreeSet::from_iter(vec![email].into_iter())
+                    );
+                }
+            }
+        }
+    }
+
+    mod names {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::reference_extractor::tests::EXTRACTOR;
+
+        #[test]
+        fn includes_all_mentioned_usernames_and_groupnames() {
+            assert_eq!(
+                EXTRACTOR.names(),
+                BTreeSet::from_iter(
+                    vec![
+                        String::from("@user-1"),
+                        String::from("@user-2"),
+                        String::from("@user-4"),
+                        String::from("@group"),
+                        String::from("@group/nested-on/other-group")
+                    ]
+                    .into_iter()
+                )
+            );
+        }
+    }
+
+    mod references {
+        use std::{collections::BTreeSet, iter::FromIterator};
+
+        use crate::gitlab::reference_extractor::tests::EXTRACTOR;
+
+        #[test]
+        fn includes_all_user_references_once() {
+            assert_eq!(
+                EXTRACTOR.references(),
+                BTreeSet::from_iter(
+                    vec![
+                        String::from("@user-1"),
+                        String::from("@user-2"),
+                        String::from("user@gitlab.org"),
+                        String::from("@user-4"),
+                        String::from("other-user@gitlab.org"),
+                        String::from("@group"),
+                        String::from("@group/nested-on/other-group")
+                    ]
+                    .into_iter()
+                )
+            );
+        }
+    }
+}

--- a/codeowners/src/gitlab/section.rs
+++ b/codeowners/src/gitlab/section.rs
@@ -1,0 +1,28 @@
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/lib/gitlab/code_owners/section.rb
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Section {
+    pub name: String,
+    pub optional: bool,
+    pub approvals: usize,
+    pub default_owners: String,
+}
+
+impl Section {
+    pub const DEFAULT: &'static str = "codeowners";
+
+    pub fn new(
+        name: String,
+        optional: Option<bool>,
+        approvals: Option<usize>,
+        default_owners: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            optional: optional.unwrap_or_default(),
+            approvals: approvals.unwrap_or_default(),
+            default_owners: default_owners
+                .map(|s| String::from(s.trim()))
+                .unwrap_or_default(),
+        }
+    }
+}

--- a/codeowners/src/gitlab/section_parser.rs
+++ b/codeowners/src/gitlab/section_parser.rs
@@ -1,0 +1,358 @@
+use indexmap::IndexMap;
+
+use super::{Entry, ErrorType, ReferenceExtractor, Section};
+
+pub mod section_parser_regex {
+    use fancy_regex::Regex;
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        pub static ref OPTIONAL: Regex = Regex::new(r"(?<optional>\^)?").unwrap();
+        pub static ref NAME: Regex = Regex::new(r"\[(?<name>.*?)\]").unwrap();
+        pub static ref APPROVALS: Regex = Regex::new(r"(?:\[(?<approvals>\d*?)\])?").unwrap();
+        pub static ref DEFAULT_OWNERS: Regex =
+            Regex::new(r"(?<default_owners>\s+[@\w_.\-\/\s+]*)?").unwrap();
+        pub static ref INVALID_NAME: Regex = Regex::new(r"\[[^\]]+?").unwrap();
+        pub static ref HEADER_REGEX: Regex = Regex::new(&format!(
+            r"^{}{}{}{}",
+            OPTIONAL.as_str(),
+            NAME.as_str(),
+            APPROVALS.as_str(),
+            DEFAULT_OWNERS.as_str()
+        ))
+        .unwrap();
+        pub static ref REGEX_INVALID_SECTION: Regex = Regex::new(&format!(
+            r"^{}{}$",
+            OPTIONAL.as_str(),
+            INVALID_NAME.as_str()
+        ))
+        .unwrap();
+    }
+}
+
+pub type SectionalData = IndexMap<String, IndexMap<String, Entry>>;
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/lib/gitlab/code_owners/section_parser.rb
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SectionParser<'a> {
+    line: String,
+    sectional_data: &'a SectionalData,
+    pub errors: Vec<ErrorType>,
+}
+
+impl<'a> SectionParser<'a> {
+    pub fn new(line: String, sectional_data: &'a SectionalData) -> Self {
+        Self {
+            line,
+            sectional_data,
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn execute(&mut self) -> Option<Section> {
+        if let Some(section) = self.fetch_section() {
+            if section.name.is_empty() {
+                self.errors.push(ErrorType::MissingSectionName);
+            }
+            if section.optional && section.approvals > 0 {
+                self.errors.push(ErrorType::InvalidApprovalRequirement);
+            }
+            if !section.default_owners.is_empty()
+                && ReferenceExtractor::new(String::from(&section.default_owners))
+                    .references()
+                    .is_empty()
+            {
+                self.errors.push(ErrorType::InvalidSectionOwnerFormat);
+            }
+            return Some(section);
+        }
+
+        if self.invalid_section() {
+            self.errors.push(ErrorType::InvalidSectionFormat);
+        }
+
+        None
+    }
+
+    pub fn valid(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    fn fetch_section(&self) -> Option<Section> {
+        section_parser_regex::HEADER_REGEX
+            .captures(&self.line)
+            .ok()
+            .flatten()
+            .map(|r#match| {
+                let name = r#match
+                    .name("name")
+                    .map(|m| String::from(m.as_str()))
+                    .unwrap_or_default();
+                let optional = Some(r#match.name("optional").is_some());
+                let approvals = r#match
+                    .name("approvals")
+                    .and_then(|m| m.as_str().parse::<usize>().ok());
+                let default_owners = r#match
+                    .name("default_owners")
+                    .map(|m| String::from(m.as_str()));
+
+                Section::new(
+                    self.find_section_name(name),
+                    optional,
+                    approvals,
+                    default_owners,
+                )
+            })
+    }
+
+    fn find_section_name<T: AsRef<str>>(&self, name: T) -> String {
+        if let Some(last_key) = self.sectional_data.keys().last() {
+            if last_key == Section::DEFAULT {
+                return String::from(name.as_ref());
+            }
+        }
+
+        self.sectional_data
+            .keys()
+            .find(|k| k.eq_ignore_ascii_case(name.as_ref()))
+            .map(String::from)
+            .unwrap_or_else(|| String::from(name.as_ref()))
+    }
+
+    fn invalid_section(&self) -> bool {
+        section_parser_regex::REGEX_INVALID_SECTION
+            .is_match(&self.line)
+            .ok()
+            .unwrap_or_default()
+    }
+}
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/lib/gitlab/code_owners/section_parser_spec.rb
+#[cfg(test)]
+mod tests {
+    use lazy_static::lazy_static;
+
+    use super::{SectionParser, SectionalData};
+
+    lazy_static! {
+        static ref SECTION: SectionalData = SectionalData::new();
+        static ref PARSER: SectionParser<'static> = SectionParser::new(String::new(), &SECTION);
+    }
+
+    mod execute {
+        use crate::gitlab::{section_parser::tests::SECTION, SectionParser};
+
+        #[test]
+        fn when_line_is_not_a_section_header() {
+            let mut parser = SectionParser::new(String::from("foo"), &SECTION);
+            assert_eq!(parser.execute(), None);
+        }
+
+        mod when_line_is_a_section_header {
+            use std::iter::FromIterator;
+
+            use assert_matches::assert_matches;
+
+            use crate::gitlab::{ErrorType, SectionParser, SectionalData};
+
+            #[test]
+            fn parses_all_section_properties() {
+                for (line, name, optional, approvals, default_owners, sectional_data, errors) in
+                    vec![
+                        (
+                            "[]",
+                            "",
+                            false,
+                            0,
+                            "",
+                            SectionalData::new(),
+                            vec![ErrorType::MissingSectionName],
+                        ),
+                        (
+                            "[Doc]",
+                            "Doc",
+                            false,
+                            0,
+                            "",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc]",
+                            "doc",
+                            false,
+                            0,
+                            "",
+                            SectionalData::from_iter(
+                                vec![(String::from("doc"), Default::default())].into_iter(),
+                            ),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc]",
+                            "Doc",
+                            false,
+                            0,
+                            "",
+                            SectionalData::from_iter(
+                                vec![(String::from("foo"), Default::default())].into_iter(),
+                            ),
+                            Vec::new(),
+                        ),
+                        (
+                            "^[Doc]",
+                            "Doc",
+                            true,
+                            0,
+                            "",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc][1]",
+                            "Doc",
+                            false,
+                            1,
+                            "",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "^[Doc][1]",
+                            "Doc",
+                            true,
+                            1,
+                            "",
+                            SectionalData::new(),
+                            vec![ErrorType::InvalidApprovalRequirement],
+                        ),
+                        (
+                            "^[Doc][1] @doc",
+                            "Doc",
+                            true,
+                            1,
+                            "@doc",
+                            SectionalData::new(),
+                            vec![ErrorType::InvalidApprovalRequirement],
+                        ),
+                        (
+                            "^[Doc][1] @doc @dev",
+                            "Doc",
+                            true,
+                            1,
+                            "@doc @dev",
+                            SectionalData::new(),
+                            vec![ErrorType::InvalidApprovalRequirement],
+                        ),
+                        (
+                            "^[Doc][1] @gl/doc-1",
+                            "Doc",
+                            true,
+                            1,
+                            "@gl/doc-1",
+                            SectionalData::new(),
+                            vec![ErrorType::InvalidApprovalRequirement],
+                        ),
+                        (
+                            "[Doc][1] @doc",
+                            "Doc",
+                            false,
+                            1,
+                            "@doc",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc] @doc",
+                            "Doc",
+                            false,
+                            0,
+                            "@doc",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "^[Doc] @doc",
+                            "Doc",
+                            true,
+                            0,
+                            "@doc",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc] @doc @rrr.dev @dev",
+                            "Doc",
+                            false,
+                            0,
+                            "@doc @rrr.dev @dev",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "^[Doc] @doc @rrr.dev @dev",
+                            "Doc",
+                            true,
+                            0,
+                            "@doc @rrr.dev @dev",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc][2] @doc @rrr.dev @dev",
+                            "Doc",
+                            false,
+                            2,
+                            "@doc @rrr.dev @dev",
+                            SectionalData::new(),
+                            Vec::new(),
+                        ),
+                        (
+                            "[Doc] malformed",
+                            "Doc",
+                            false,
+                            0,
+                            "malformed",
+                            SectionalData::new(),
+                            vec![ErrorType::InvalidSectionOwnerFormat],
+                        ),
+                    ]
+                    .into_iter()
+                {
+                    let mut parser = SectionParser::new(String::from(line), &sectional_data);
+                    let section = assert_matches!(parser.execute(), Some(s) => s);
+                    assert_eq!(section.name, String::from(name));
+                    assert_eq!(section.optional, optional);
+                    assert_eq!(section.approvals, approvals);
+                    assert_eq!(section.default_owners, default_owners);
+                    if errors.is_empty() {
+                        assert_eq!(parser.valid(), true);
+                    } else {
+                        assert_eq!(parser.valid(), false);
+                        assert_eq!(parser.errors, errors);
+                    }
+                }
+            }
+        }
+
+        mod when_section_header_is_invalid {
+            use crate::gitlab::{section_parser::tests::SECTION, ErrorType, SectionParser};
+
+            #[test]
+            fn validates_section_correctness() {
+                for (line, status, errors) in vec![
+                    ("^[Invalid", false, vec![ErrorType::InvalidSectionFormat]),
+                    ("[Invalid", false, vec![ErrorType::InvalidSectionFormat]),
+                ]
+                .into_iter()
+                {
+                    let mut parser = SectionParser::new(String::from(line), &SECTION);
+                    assert_eq!(parser.execute(), None);
+
+                    assert_eq!(parser.valid(), status);
+                    assert_eq!(parser.errors, errors);
+                }
+            }
+        }
+    }
+}

--- a/codeowners/src/gitlab/user.rs
+++ b/codeowners/src/gitlab/user.rs
@@ -1,0 +1,37 @@
+use const_format::concatcp;
+use fancy_regex::{escape, Regex};
+use lazy_static::lazy_static;
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/app/models/user.rb#L1025
+pub const REFERENCE_PREFIX: &str = "@";
+
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/app/models/namespace.rb#L39
+const NUMBER_OF_ANCESTORS_ALLOWED: usize = 20;
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/app/models/namespace.rb#L45
+const URL_MAX_LENGTH: usize = 255;
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/lib/gitlab/path_regex.rb#L133
+const PATH_START_CHAR: &str = r"[a-zA-Z0-9_\.]";
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/lib/gitlab/path_regex.rb#L134
+const PATH_REGEX_STR: &str = concatcp!(
+    PATH_START_CHAR,
+    r"[a-zA-Z0-9_\-\.]",
+    "{0,",
+    URL_MAX_LENGTH - 1,
+    "}",
+);
+/// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/lib/gitlab/path_regex.rb#L135
+const NAMESPACE_FORMAT_REGEX_JS: &str = concatcp!(PATH_REGEX_STR, r"[a-zA-Z0-9_\-]|[a-zA-Z0-9_]");
+
+lazy_static! {
+  /// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/lib/gitlab/path_regex.rb#L137
+  static ref NO_SUFFIX_REGEX: Regex = Regex::new(r"(?<!\.git|\.atom)").unwrap();
+
+  /// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/lib/gitlab/path_regex.rb#L138
+  static ref NAMESPACE_FORMAT_REGEX: Regex = Regex::new(&format!(r"(?:{}){}", NAMESPACE_FORMAT_REGEX_JS, NO_SUFFIX_REGEX.as_str())).unwrap();
+
+  /// https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/lib/gitlab/path_regex.rb#L140
+  static ref FULL_NAMESPACE_FORMAT_REGEX: Regex = Regex::new(&format!(r"({}/){{0,{}}}{}", NAMESPACE_FORMAT_REGEX.as_str(), NUMBER_OF_ANCESTORS_ALLOWED, NAMESPACE_FORMAT_REGEX.as_str())).unwrap();
+
+  /// Reference: https://gitlab.com/gitlab-org/gitlab/-/blob/df0d6654bb540cf7321e297554acd8adb3e2e3a4/app/models/user.rb#L1030
+  pub static ref REFERENCE_PATTERN: Regex = Regex::new(&format!(r"(?<!\w){}(?<user>{})", escape(REFERENCE_PREFIX), FULL_NAMESPACE_FORMAT_REGEX.as_str())).unwrap();
+}

--- a/codeowners/src/lib.rs
+++ b/codeowners/src/lib.rs
@@ -1,8 +1,10 @@
 mod github;
+mod gitlab;
 
 use std::{io::Read, path::Path};
 
 pub use github::{GitHubOwner, GitHubOwners};
+pub use gitlab::{GitLabOwner, GitLabOwners};
 
 pub trait OwnersOfPath {
     type Owner;

--- a/codeowners/test_fixtures/gitlab/codeowners_example
+++ b/codeowners/test_fixtures/gitlab/codeowners_example
@@ -1,0 +1,44 @@
+# This is an example code owners file, lines starting with a `#` will
+# be ignored.
+
+# app/ @commented-rule
+
+# We can specify a default match using wildcards:
+* @default-codeowner
+
+# Rules defined later in the file take precedence over the rules
+# defined before.
+# This will match all files for which the file name ends in `.rb`
+*.rb @ruby-owner
+
+# Files with a `#` can still be accessed by escaping the pound sign
+\#file_with_pound.rb @owner-file-with-pound
+
+# Multiple codeowners can be specified, separated by whitespace
+CODEOWNERS @multiple @owners	@tab-separated
+
+# Both usernames or email addresses can be used to match
+# users. Everything else will be ignored. For example this will
+# specify `@legal` and a user with email `janedoe@gitlab.com` as the
+# owner for the LICENSE file
+LICENSE @legal this does not match janedoe@gitlab.com
+
+# Ending a path in a `/` will specify the code owners for every file
+# nested in that directory, on any level
+/docs/ @all-docs
+
+# Ending a path in `/*` will specify code owners for every file in
+# that directory, but not nested deeper. This will match
+# `docs/index.md` but not `docs/projects/index.md`
+/docs/* @root-docs
+
+# This will make a `lib` directory nested anywhere in the repository
+# match
+lib/ @lib-owner
+
+# This will only match a `config` directory in the root of the
+# repository
+/config/ @config-owner
+
+# If the path contains spaces, these need to be escaped like this:
+path\ with\ spaces/ @space-owner

--- a/codeowners/test_fixtures/gitlab/mixed_case_sectional_codeowners_example
+++ b/codeowners/test_fixtures/gitlab/mixed_case_sectional_codeowners_example
@@ -1,0 +1,71 @@
+# This is an example code owners file, lines starting with a `#` will
+# be ignored.
+
+# app/ @commented-rule
+
+# We can specify a default match using wildcards:
+* @default-codeowner
+
+# Rules defined later in the file take precedence over the rules
+# defined before.
+# This will match all files for which the file name ends in `.rb`
+*.rb @ruby-owner
+
+# Files with a `#` can still be accesssed by escaping the pound sign
+\#file_with_pound.rb @owner-file-with-pound
+
+# Multiple codeowners can be specified, separated by whitespace
+CODEOWNERS @multiple @owners	@tab-separated
+
+# Both usernames or email addresses can be used to match
+# users. Everything else will be ignored. For example this will
+# specify `@legal` and a user with email `janedoe@gitlab.com` as the
+# owner for the LICENSE file
+LICENSE @legal this does not match janedoe@gitlab.com
+
+# Ending a path in a `/` will specify the code owners for every file
+# nested in that directory, on any level
+/docs/ @all-docs
+
+# Ending a path in `/*` will specify code owners for every file in
+# that directory, but not nested deeper. This will match
+# `docs/index.md` but not `docs/projects/index.md`
+/docs/* @root-docs
+
+# This will make a `lib` directory nested anywhere in the repository
+# match
+lib/ @lib-owner
+
+# This will only match a `config` directory in the root of the
+# repository
+/config/ @config-owner
+
+# If the path contains spaces, these need to be escaped like this:
+path\ with\ spaces/ @space-owner
+
+[Documentation]
+ee/docs    @gl-docs
+docs       @gl-docs
+
+[Database]
+README.md  @gl-database
+model/db   @gl-database
+
+[dOcUmEnTaTiOn]
+README.md  @gl-docs
+
+[Two Words]
+README.md  @gl-database
+model/db   @gl-database
+
+[Double::Colon]
+README.md  @gl-database
+model/db   @gl-database
+
+[DefaultOwners] @config-owner @gl-docs
+README.md
+model/db
+
+[OverriddenOwners] @config-owner
+README.md  @gl-docs
+model/db   @gl-docs

--- a/codeowners/test_fixtures/gitlab/sectional_codeowners_example
+++ b/codeowners/test_fixtures/gitlab/sectional_codeowners_example
@@ -1,0 +1,71 @@
+# This is an example code owners file, lines starting with a `#` will
+# be ignored.
+
+# app/ @commented-rule
+
+# We can specify a default match using wildcards:
+* @default-codeowner
+
+# Rules defined later in the file take precedence over the rules
+# defined before.
+# This will match all files for which the file name ends in `.rb`
+*.rb @ruby-owner
+
+# Files with a `#` can still be accessed by escaping the pound sign
+\#file_with_pound.rb @owner-file-with-pound
+
+# Multiple codeowners can be specified, separated by whitespace
+CODEOWNERS @multiple @owners	@tab-separated
+
+# Both usernames or email addresses can be used to match
+# users. Everything else will be ignored. For example this will
+# specify `@legal` and a user with email `janedoe@gitlab.com` as the
+# owner for the LICENSE file
+LICENSE @legal this does not match janedoe@gitlab.com
+
+# Ending a path in a `/` will specify the code owners for every file
+# nested in that directory, on any level
+/docs/ @all-docs
+
+# Ending a path in `/*` will specify code owners for every file in
+# that directory, but not nested deeper. This will match
+# `docs/index.md` but not `docs/projects/index.md`
+/docs/* @root-docs
+
+# This will make a `lib` directory nested anywhere in the repository
+# match
+lib/ @lib-owner
+
+# This will only match a `config` directory in the root of the
+# repository
+/config/ @config-owner
+
+# If the path contains spaces, these need to be escaped like this:
+path\ with\ spaces/ @space-owner
+
+[Documentation]
+ee/docs    @gl-docs
+docs       @gl-docs
+
+[Database]
+README.md  @gl-database
+model/db   @gl-database
+
+[Documentation]
+README.md  @gl-docs
+
+[Two Words]
+README.md  @gl-database
+model/db   @gl-database
+
+[Double::Colon]
+README.md  @gl-database
+model/db   @gl-database
+
+[DefaultOwners] @config-owner @gl-docs
+README.md
+model/db
+
+[OverriddenOwners] @config-owner
+README.md  @gl-docs
+model/db   @gl-docs


### PR DESCRIPTION
~depends on #102~

adds code to parse GitLab CODEOWNERS exactly the same way that GitLab does in their services:
https://gitlab.com/gitlab-org/gitlab/-/tree/master/ee/lib/gitlab/code_owners