### PR TITLE
[TRUNK-12896] Include bundle_upload_id in meta.json on test bundle upload

### DIFF
--- a/cli/src/clients.rs
+++ b/cli/src/clients.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 
 use crate::types::{
-    BundleUploadLocation, CreateBundleUploadRequest, CreateRepoRequest,
+    CreateBundleUploadResponse, CreateBundleUploadRequest, CreateRepoRequest,
     GetQuarantineBulkTestStatusRequest, QuarantineConfig, Repo,
 };
 use crate::utils::status_code_help;
@@ -48,12 +48,12 @@ pub async fn create_trunk_repo(
     Ok(())
 }
 
-pub async fn get_bundle_upload_location(
+pub async fn create_bundle_upload_intent(
     origin: &str,
     api_token: &str,
     org_slug: &str,
     repo: &Repo,
-) -> anyhow::Result<Option<BundleUploadLocation>> {
+) -> anyhow::Result<Option<CreateBundleUploadResponse>> {
     let client = reqwest::Client::new();
     let resp = match client
         .post(format!("{}/v1/metrics/createBundleUpload", origin))
@@ -73,7 +73,7 @@ pub async fn get_bundle_upload_location(
 
     if resp.status().is_success() {
         return resp
-            .json::<Option<BundleUploadLocation>>()
+            .json::<Option<CreateBundleUploadResponse>>()
             .await
             .context("Failed to get response body as json");
     }

--- a/cli/src/clients.rs
+++ b/cli/src/clients.rs
@@ -53,7 +53,7 @@ pub async fn create_bundle_upload_intent(
     api_token: &str,
     org_slug: &str,
     repo: &Repo,
-) -> anyhow::Result<Option<CreateBundleUploadResponse>> {
+) -> anyhow::Result<CreateBundleUploadResponse> {
     let client = reqwest::Client::new();
     let resp = match client
         .post(format!("{}/v1/metrics/createBundleUpload", origin))
@@ -71,27 +71,16 @@ pub async fn create_bundle_upload_intent(
         Err(e) => return Err(anyhow::anyhow!(e).context("Failed to create bundle upload")),
     };
 
-    if resp.status().is_success() {
-        return resp
-            .json::<Option<CreateBundleUploadResponse>>()
-            .await
-            .context("Failed to get response body as json");
+    if resp.status() != reqwest::StatusCode::OK {
+        return Err(
+            anyhow::anyhow!("{}: {}", resp.status(), status_code_help(resp.status()))
+                .context("Failed to create bundle upload"),
+        );
     }
 
-    if resp.status().is_client_error() {
-        return Err(anyhow::anyhow!(
-            "Organization not found. Please double check the provided organization token and url slug: {}",
-            org_slug
-        )
-        .context("Failed to create bundle upload"));
-    }
-
-    log::warn!(
-        "Failed to create bundle upload. {}: {}",
-        resp.status(),
-        status_code_help(resp.status())
-    );
-    Ok(None)
+    resp.json::<CreateBundleUploadResponse>()
+        .await
+        .context("Failed to get response body as json")
 }
 
 pub async fn get_quarantining_config(

--- a/cli/src/clients.rs
+++ b/cli/src/clients.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 
 use crate::types::{
-    CreateBundleUploadResponse, CreateBundleUploadRequest, CreateRepoRequest,
+    CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
     GetQuarantineBulkTestStatusRequest, QuarantineConfig, Repo,
 };
 use crate::utils::status_code_help;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
 use trunk_analytics_cli::bundler::BundlerUtil;
 use trunk_analytics_cli::clients::{
-    create_trunk_repo, create_bundle_upload_intent, put_bundle_to_s3,
+    create_bundle_upload_intent, create_trunk_repo, put_bundle_to_s3,
 };
 use trunk_analytics_cli::codeowners::CodeOwners;
 use trunk_analytics_cli::constants::{

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
@@ -242,12 +241,10 @@ async fn run_upload(
     let envs = EnvScanner::scan_env();
     let os_info: String = env::consts::OS.to_string();
 
-    let upload_op = Retry::spawn(default_delay(), || {
+    let upload = Retry::spawn(default_delay(), || {
         create_bundle_upload_intent(&api_address, &token, &org_url_slug, &repo.repo)
     })
     .await?;
-
-    let upload = upload_op.context("Failed to create bundle upload.")?;
 
     let meta = BundleMeta {
         version: META_VERSION.to_string(),

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -100,7 +100,8 @@ pub struct QuarantineConfig {
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
-pub struct BundleUploadLocation {
+pub struct CreateBundleUploadResponse {
+    pub id: String,
     pub url: String,
     pub key: String,
 }
@@ -204,6 +205,7 @@ pub struct BundleMeta {
     pub cli_version: String,
     pub org: String,
     pub repo: BundleRepo,
+    pub bundle_upload_id: String,
     pub tags: Vec<CustomTag>,
     pub file_sets: Vec<FileSet>,
     pub envs: std::collections::HashMap<String, String>,

--- a/cli/tests/test_utils/mock_server.rs
+++ b/cli/tests/test_utils/mock_server.rs
@@ -14,7 +14,7 @@ use tempfile::tempdir;
 use tokio::net::TcpListener;
 use tokio::spawn;
 use trunk_analytics_cli::types::{
-    BundleUploadLocation, CreateBundleUploadRequest, CreateRepoRequest,
+    CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
     GetQuarantineBulkTestStatusRequest, QuarantineConfig,
 };
 
@@ -100,7 +100,7 @@ async fn repo_create_handler(
 async fn create_bundle_handler(
     State(state): State<SharedMockServerState>,
     Json(create_bundle_upload_request): Json<CreateBundleUploadRequest>,
-) -> Json<BundleUploadLocation> {
+) -> Json<CreateBundleUploadResponse> {
     state
         .requests
         .lock()
@@ -109,7 +109,8 @@ async fn create_bundle_handler(
             create_bundle_upload_request,
         ));
     let host = &state.host;
-    Json(BundleUploadLocation {
+    Json(CreateBundleUploadResponse {
+        id: String::from("test-bundle-upload-id"),
         url: format!("{host}/s3upload"),
         key: String::from("unused"),
     })

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -120,6 +120,7 @@ async fn upload_bundle() {
         bundle_meta.repo.repo_head_author_email,
         "your.email@example.com"
     );
+    assert_eq!(bundle_meta.bundle_upload_id, "test-bundle-upload-id");
     assert_eq!(bundle_meta.tags, &[]);
     assert_eq!(bundle_meta.file_sets.len(), 1);
     assert_eq!(bundle_meta.envs.get("CI"), Some(&String::from("1")));


### PR DESCRIPTION
Includes `bundle_upload_id` in the `meta.json` metadata file to help facilitate making that value accessible by the ETL job. Also renames a couple function / type names