### PR TITLE
5. add python + js bindings for context crate

### DIFF
--- a/.github/actions/build_target/action.yaml
+++ b/.github/actions/build_target/action.yaml
@@ -23,7 +23,7 @@ runs:
 
     - name: Compile binary
       shell: bash
-      run: cargo build -q --all --profile=${{ inputs.profile }} --target ${{ inputs.target }}
+      run: cargo build -q --workspace ${{ contains(inputs.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --profile=${{ inputs.profile }} --target ${{ inputs.target }}
 
     - name: Create binary with debug info
       shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,11 +44,11 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run tests
-        run: cargo nextest run --profile=ci
+        run: cargo nextest run --workspace ${{ contains(matrix.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --profile=ci
 
       - name: Build ${{ matrix.target }} target
         if: "!cancelled()"
-        run: cargo build -q --all --release --target ${{ matrix.target }}
+        run: cargo build -q --workspace ${{ contains(matrix.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --release --target ${{ matrix.target }}
 
       - name: Upload results using action from ${{ matrix.target }}
         env:
@@ -88,7 +88,7 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Run tests
-        run: cargo nextest run --profile=ci
+        run: cargo nextest run --workspace ${{ contains(matrix.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --profile=ci
 
       - name: Build ${{ matrix.target }} target
         uses: ./.github/actions/build_target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build ${{ matrix.target }} target
         if: "!cancelled()"
-        run: cargo build -q --all --profile=release-with-debug --target ${{ matrix.target }}
+        run: cargo build -q --workspace ${{ contains(matrix.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --profile=release-with-debug --target ${{ matrix.target }}
 
       - name: Strip debug info
         run: strip target/${{ matrix.target }}/release-with-debug/trunk-analytics-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "gix",
+ "js-sys",
  "junit-mock",
  "openssl",
  "pretty_assertions",
@@ -470,16 +471,24 @@ dependencies = [
  "tempfile",
  "test_utils",
  "thiserror",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "context-js"
+version = "0.1.0"
+dependencies = [
+ "context",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "context-py"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "context",
  "pyo3",
- "quick-junit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "junit-mock",
  "openssl",
  "pretty_assertions",
+ "pyo3",
  "quick-junit",
  "quick-xml",
  "regex",
@@ -469,6 +470,16 @@ dependencies = [
  "tempfile",
  "test_utils",
  "thiserror",
+]
+
+[[package]]
+name = "context-py"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "context",
+ "pyo3",
+ "quick-junit",
 ]
 
 [[package]]
@@ -1477,6 +1488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "ipnet"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1884,6 +1910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +1983,69 @@ name = "prodash"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
+
+[[package]]
+name = "pyo3"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "quick-junit"
@@ -2653,6 +2748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,6 +3067,12 @@ name = "unicode-xid"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "cli",
   "codeowners",
   "context",
+  "context-js",
   "context-py",
   "junit-mock",
   "test_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["api", "cli", "codeowners", "context", "junit-mock", "test_utils"]
+members = [
+  "api",
+  "cli",
+  "codeowners",
+  "context",
+  "context-py",
+  "junit-mock",
+  "test_utils",
+]
 resolver = "2"
 
 [profile.release]

--- a/context-js/.gitignore
+++ b/context-js/.gitignore
@@ -1,0 +1,4 @@
+# wasm-pack
+bin/
+pkg/
+wasm-pack.log

--- a/context-js/Cargo.toml
+++ b/context-js/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "context-js"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+context = { path = "../context", default-features = false, features = ["wasm"] }
+js-sys = "0.3.70"
+wasm-bindgen = "0.2.84"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "context-py"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "context_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+chrono = "0.4.33"
+context = { path = "../context" }
+quick-junit = "0.5.0"
+pyo3 = "0.20.0"

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 chrono = "0.4.33"
-context = { path = "../context" }
+context = { path = "../context", features = ["git-access", "pyo3"] }
 quick-junit = "0.5.0"
 pyo3 = "0.20.0"

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -9,7 +9,5 @@ name = "context_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-chrono = "0.4.33"
 context = { path = "../context", features = ["git-access", "pyo3"] }
-quick-junit = "0.5.0"
 pyo3 = "0.20.0"

--- a/context-py/pyproject.toml
+++ b/context-py/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["maturin>=1.5,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "context-py"
+requires-python = ">=3.8"
+classifiers = [
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["version"]
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/context-py/src/junit_report.rs
+++ b/context-py/src/junit_report.rs
@@ -1,0 +1,597 @@
+use std::{collections::HashMap, time::Duration};
+
+use chrono::DateTime;
+use pyo3::{exceptions::PyTypeError, prelude::*};
+use quick_junit::{
+    NonSuccessKind, Property, Report, TestCase, TestCaseStatus, TestRerun, TestSuite,
+};
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyReport {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub uuid: Option<String>,
+    #[pyo3(get)]
+    pub timestamp: Option<i64>,
+    #[pyo3(get)]
+    pub time: Option<f64>,
+    #[pyo3(get)]
+    pub tests: usize,
+    #[pyo3(get)]
+    pub failures: usize,
+    #[pyo3(get)]
+    pub errors: usize,
+    #[pyo3(get)]
+    pub test_suites: Vec<PyTestSuite>,
+}
+
+impl From<Report> for PyReport {
+    fn from(
+        Report {
+            name,
+            uuid,
+            timestamp,
+            time,
+            tests,
+            failures,
+            errors,
+            test_suites,
+        }: Report,
+    ) -> Self {
+        Self {
+            name: name.into_string(),
+            uuid: uuid.map(|u| u.to_string()),
+            timestamp: timestamp.map(|t| t.timestamp()),
+            time: time.map(|t| t.as_secs_f64()),
+            tests,
+            failures,
+            errors,
+            test_suites: test_suites.into_iter().map(PyTestSuite::from).collect(),
+        }
+    }
+}
+
+impl Into<Report> for PyReport {
+    fn into(self) -> Report {
+        let Self {
+            name,
+            uuid,
+            timestamp,
+            time,
+            tests,
+            failures,
+            errors,
+            test_suites,
+        } = self;
+        // NOTE: Cannot make a UUID without a `&'static str`
+        let _ = uuid;
+        Report {
+            name: name.into(),
+            uuid: None,
+            timestamp: timestamp
+                .and_then(|secs| DateTime::from_timestamp(secs, 0))
+                .map(|dt| dt.fixed_offset()),
+            time: time.map(|secs| Duration::from_secs_f64(secs)),
+            tests,
+            failures,
+            errors,
+            test_suites: test_suites.into_iter().map(PyTestSuite::into).collect(),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestSuite {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub tests: usize,
+    #[pyo3(get)]
+    pub disabled: usize,
+    #[pyo3(get)]
+    pub errors: usize,
+    #[pyo3(get)]
+    pub failures: usize,
+    #[pyo3(get)]
+    pub timestamp: Option<i64>,
+    #[pyo3(get)]
+    pub time: Option<f64>,
+    #[pyo3(get)]
+    pub test_cases: Vec<PyTestCase>,
+    #[pyo3(get)]
+    pub properties: Vec<PyProperty>,
+    #[pyo3(get)]
+    pub system_out: Option<String>,
+    #[pyo3(get)]
+    pub system_err: Option<String>,
+    #[pyo3(get)]
+    pub extra: HashMap<String, String>,
+}
+
+impl From<TestSuite> for PyTestSuite {
+    fn from(
+        TestSuite {
+            name,
+            tests,
+            disabled,
+            errors,
+            failures,
+            timestamp,
+            time,
+            test_cases,
+            properties,
+            system_out,
+            system_err,
+            extra,
+            // NOTE: The above should be all fields, but here may be more added in the future due to
+            // `#[non_exhaustive]`
+            ..
+        }: TestSuite,
+    ) -> Self {
+        Self {
+            name: name.into_string(),
+            tests,
+            disabled,
+            errors,
+            failures,
+            timestamp: timestamp.map(|t| t.timestamp()),
+            time: time.map(|t| t.as_secs_f64()),
+            test_cases: test_cases.into_iter().map(PyTestCase::from).collect(),
+            properties: properties.into_iter().map(PyProperty::from).collect(),
+            system_out: system_out.map(|s| s.to_string()),
+            system_err: system_err.map(|s| s.to_string()),
+            extra: HashMap::from_iter(
+                extra
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string())),
+            ),
+        }
+    }
+}
+
+impl Into<TestSuite> for PyTestSuite {
+    fn into(self) -> TestSuite {
+        let Self {
+            name,
+            tests,
+            disabled,
+            errors,
+            failures,
+            timestamp,
+            time,
+            test_cases,
+            properties,
+            system_out,
+            system_err,
+            extra,
+        } = self;
+        let mut test_suite = TestSuite::new(name);
+        test_suite.tests = tests;
+        test_suite.disabled = disabled;
+        test_suite.errors = errors;
+        test_suite.failures = failures;
+        test_suite.timestamp = timestamp
+            .and_then(|secs| DateTime::from_timestamp(secs, 0))
+            .map(|dt| dt.fixed_offset());
+        test_suite.time = time.map(|secs| Duration::from_secs_f64(secs));
+        test_suite.test_cases = test_cases
+            .into_iter()
+            .map(PyTestCase::try_into)
+            .filter_map(|t| {
+                // Removes any invalid test cases that could not be parsed correctly
+                t.ok()
+            })
+            .collect();
+        test_suite.properties = properties.into_iter().map(PyProperty::into).collect();
+        test_suite.system_out = system_out.map(|s| s.into());
+        test_suite.system_err = system_err.map(|s| s.into());
+        test_suite.extra = extra
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        test_suite
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyProperty {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub value: String,
+}
+
+impl From<Property> for PyProperty {
+    fn from(Property { name, value }: Property) -> Self {
+        Self {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
+    }
+}
+
+impl Into<Property> for PyProperty {
+    fn into(self) -> Property {
+        let Self { name, value } = self;
+        Property {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestCase {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub classname: Option<String>,
+    #[pyo3(get)]
+    pub assertions: Option<usize>,
+    #[pyo3(get)]
+    pub timestamp: Option<i64>,
+    #[pyo3(get)]
+    pub time: Option<f64>,
+    #[pyo3(get)]
+    pub status: PyTestCaseStatus,
+    #[pyo3(get)]
+    pub system_out: Option<String>,
+    #[pyo3(get)]
+    pub system_err: Option<String>,
+    #[pyo3(get)]
+    pub extra: HashMap<String, String>,
+    #[pyo3(get)]
+    pub properties: Vec<PyProperty>,
+}
+
+impl From<TestCase> for PyTestCase {
+    fn from(
+        TestCase {
+            name,
+            classname,
+            assertions,
+            timestamp,
+            time,
+            status,
+            system_out,
+            system_err,
+            extra,
+            properties,
+            // NOTE: The above should be all fields, but here may be more added in the future due to
+            // `#[non_exhaustive]`
+            ..
+        }: TestCase,
+    ) -> Self {
+        Self {
+            name: name.into_string(),
+            classname: classname.map(|c| c.to_string()),
+            assertions,
+            timestamp: timestamp.map(|t| t.timestamp()),
+            time: time.map(|t| t.as_secs_f64()),
+            status: PyTestCaseStatus::from(status),
+            system_out: system_out.map(|s| s.to_string()),
+            system_err: system_err.map(|s| s.to_string()),
+            extra: HashMap::from_iter(
+                extra
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string())),
+            ),
+            properties: properties.into_iter().map(PyProperty::from).collect(),
+        }
+    }
+}
+
+impl TryInto<TestCase> for PyTestCase {
+    type Error = PyErr;
+
+    fn try_into(self) -> Result<TestCase, PyErr> {
+        let Self {
+            name,
+            classname,
+            assertions,
+            timestamp,
+            time,
+            status,
+            system_out,
+            system_err,
+            extra,
+            properties,
+        } = self;
+        let mut test_case = TestCase::new(name, status.try_into()?);
+        test_case.classname = classname.map(|c| c.into());
+        test_case.assertions = assertions;
+        test_case.timestamp = timestamp
+            .and_then(|secs| DateTime::from_timestamp(secs, 0))
+            .map(|dt| dt.fixed_offset());
+        test_case.time = time.map(|secs| Duration::from_secs_f64(secs));
+        test_case.system_out = system_out.map(|s| s.into());
+        test_case.system_err = system_err.map(|s| s.into());
+        test_case.extra = extra
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        test_case.properties = properties.into_iter().map(PyProperty::into).collect();
+        Ok(test_case)
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestCaseStatus {
+    #[pyo3(get)]
+    pub status: PyTestCaseStatusStatus,
+    #[pyo3(get)]
+    pub success: Option<PyTestCaseStatusSuccess>,
+    #[pyo3(get)]
+    pub non_success: Option<PyTestCaseStatusNonSuccess>,
+    #[pyo3(get)]
+    pub skipped: Option<PyTestCaseStatusSkipped>,
+}
+
+impl From<TestCaseStatus> for PyTestCaseStatus {
+    fn from(value: TestCaseStatus) -> Self {
+        match value {
+            TestCaseStatus::Success { flaky_runs } => Self {
+                status: PyTestCaseStatusStatus::Success,
+                success: Some(PyTestCaseStatusSuccess {
+                    flaky_runs: flaky_runs.into_iter().map(PyTestRerun::from).collect(),
+                }),
+                non_success: None,
+                skipped: None,
+            },
+            TestCaseStatus::NonSuccess {
+                kind,
+                message,
+                ty,
+                description,
+                reruns,
+            } => Self {
+                status: PyTestCaseStatusStatus::NonSuccess,
+                success: None,
+                non_success: Some(PyTestCaseStatusNonSuccess {
+                    kind: PyNonSuccessKind::from(kind),
+                    message: message.map(|m| m.into_string()),
+                    ty: ty.map(|t| t.into_string()),
+                    description: description.map(|d| d.into_string()),
+                    reruns: reruns.into_iter().map(PyTestRerun::from).collect(),
+                }),
+                skipped: None,
+            },
+            TestCaseStatus::Skipped {
+                message,
+                ty,
+                description,
+            } => Self {
+                status: PyTestCaseStatusStatus::Skipped,
+                success: None,
+                non_success: None,
+                skipped: Some(PyTestCaseStatusSkipped {
+                    message: message.map(|m| m.into_string()),
+                    ty: ty.map(|t| t.into_string()),
+                    description: description.map(|d| d.into_string()),
+                }),
+            },
+        }
+    }
+}
+
+impl TryInto<TestCaseStatus> for PyTestCaseStatus {
+    type Error = PyErr;
+
+    fn try_into(self) -> Result<TestCaseStatus, PyErr> {
+        let Self {
+            status,
+            success,
+            non_success,
+            skipped,
+        } = self;
+        match (status, success, non_success, skipped) {
+            (PyTestCaseStatusStatus::Success, Some(success_fields), None, None) => {
+                Ok(success_fields.into())
+            }
+            (PyTestCaseStatusStatus::NonSuccess, None, Some(non_success_fields), None) => {
+                Ok(non_success_fields.into())
+            }
+            (PyTestCaseStatusStatus::Skipped, None, None, Some(skipped_fields)) => {
+                Ok(skipped_fields.into())
+            }
+            _ => Err(PyTypeError::new_err(
+                "Could not convert PyTestCaseStatus into TestCaseStatus",
+            )),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub enum PyTestCaseStatusStatus {
+    Success,
+    NonSuccess,
+    Skipped,
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestCaseStatusSuccess {
+    #[pyo3(get)]
+    pub flaky_runs: Vec<PyTestRerun>,
+}
+
+impl Into<TestCaseStatus> for PyTestCaseStatusSuccess {
+    fn into(self) -> TestCaseStatus {
+        let Self { flaky_runs } = self;
+        TestCaseStatus::Success {
+            flaky_runs: flaky_runs.into_iter().map(PyTestRerun::into).collect(),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestCaseStatusNonSuccess {
+    #[pyo3(get)]
+    pub kind: PyNonSuccessKind,
+    #[pyo3(get)]
+    pub message: Option<String>,
+    #[pyo3(get)]
+    pub ty: Option<String>,
+    #[pyo3(get)]
+    pub description: Option<String>,
+    #[pyo3(get)]
+    pub reruns: Vec<PyTestRerun>,
+}
+
+impl Into<TestCaseStatus> for PyTestCaseStatusNonSuccess {
+    fn into(self) -> TestCaseStatus {
+        let Self {
+            kind,
+            message,
+            ty,
+            description,
+            reruns,
+        } = self;
+        TestCaseStatus::NonSuccess {
+            kind: kind.into(),
+            message: message.map(|m| m.into()),
+            ty: ty.map(|t| t.into()),
+            description: description.map(|d| d.into()),
+            reruns: reruns.into_iter().map(PyTestRerun::into).collect(),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestCaseStatusSkipped {
+    #[pyo3(get)]
+    message: Option<String>,
+    #[pyo3(get)]
+    ty: Option<String>,
+    #[pyo3(get)]
+    description: Option<String>,
+}
+
+impl Into<TestCaseStatus> for PyTestCaseStatusSkipped {
+    fn into(self) -> TestCaseStatus {
+        let Self {
+            message,
+            ty,
+            description,
+        } = self;
+        TestCaseStatus::Skipped {
+            message: message.map(|m| m.into()),
+            ty: ty.map(|t| t.into()),
+            description: description.map(|d| d.into()),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTestRerun {
+    #[pyo3(get)]
+    pub kind: PyNonSuccessKind,
+    #[pyo3(get)]
+    pub timestamp: Option<i64>,
+    #[pyo3(get)]
+    pub time: Option<f64>,
+    #[pyo3(get)]
+    pub message: Option<String>,
+    #[pyo3(get)]
+    pub ty: Option<String>,
+    #[pyo3(get)]
+    pub stack_trace: Option<String>,
+    #[pyo3(get)]
+    pub system_out: Option<String>,
+    #[pyo3(get)]
+    pub system_err: Option<String>,
+    #[pyo3(get)]
+    pub description: Option<String>,
+}
+
+impl From<TestRerun> for PyTestRerun {
+    fn from(
+        TestRerun {
+            kind,
+            timestamp,
+            time,
+            message,
+            ty,
+            stack_trace,
+            system_out,
+            system_err,
+            description,
+        }: TestRerun,
+    ) -> Self {
+        Self {
+            kind: PyNonSuccessKind::from(kind),
+            timestamp: timestamp.map(|t| t.timestamp()),
+            time: time.map(|t| t.as_secs_f64()),
+            message: message.map(|m| m.to_string()),
+            ty: ty.map(|t| t.to_string()),
+            stack_trace: stack_trace.map(|st| st.to_string()),
+            system_out: system_out.map(|s| s.to_string()),
+            system_err: system_err.map(|s| s.to_string()),
+            description: description.map(|d| d.to_string()),
+        }
+    }
+}
+
+impl Into<TestRerun> for PyTestRerun {
+    fn into(self) -> TestRerun {
+        let Self {
+            kind,
+            timestamp,
+            time,
+            message,
+            ty,
+            stack_trace,
+            system_out,
+            system_err,
+            description,
+        } = self;
+        TestRerun {
+            kind: kind.into(),
+            timestamp: timestamp
+                .and_then(|secs| DateTime::from_timestamp(secs, 0))
+                .map(|dt| dt.fixed_offset()),
+            time: time.map(|secs| Duration::from_secs_f64(secs)),
+            message: message.map(|m| m.into()),
+            ty: ty.map(|t| t.into()),
+            stack_trace: stack_trace.map(|st| st.into()),
+            system_out: system_out.map(|s| s.into()),
+            system_err: system_err.map(|s| s.into()),
+            description: description.map(|d| d.into()),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PyNonSuccessKind {
+    Failure,
+    Error,
+}
+
+impl From<NonSuccessKind> for PyNonSuccessKind {
+    fn from(value: NonSuccessKind) -> Self {
+        match value {
+            NonSuccessKind::Failure => PyNonSuccessKind::Failure,
+            NonSuccessKind::Error => PyNonSuccessKind::Error,
+        }
+    }
+}
+
+impl Into<NonSuccessKind> for PyNonSuccessKind {
+    fn into(self) -> NonSuccessKind {
+        match self {
+            PyNonSuccessKind::Failure => NonSuccessKind::Failure,
+            PyNonSuccessKind::Error => NonSuccessKind::Error,
+        }
+    }
+}

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -1,0 +1,77 @@
+use std::{collections::HashMap, io::BufReader};
+
+use context::{env, junit, repo};
+use junit_report::PyReport;
+use pyo3::{exceptions::PyTypeError, prelude::*};
+
+pub mod junit_report;
+
+#[pyfunction]
+fn env_parse(env_vars: HashMap<String, String>) -> PyResult<Option<env::parser::CIInfo>> {
+    let mut env_parser = env::parser::EnvParser::new();
+    if env_parser.parse(&env_vars).is_err() {
+        let error_message = env_parser
+            .errors()
+            .into_iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<String>>()
+            .join("\n");
+        return Err(PyTypeError::new_err(error_message));
+    }
+
+    let ci_info_class = env_parser
+        .into_ci_info_parser()
+        .map(|ci_info_parser| ci_info_parser.info_ci_info());
+
+    Ok(ci_info_class)
+}
+
+#[pyfunction]
+fn env_validate(ci_info: env::parser::CIInfo) -> env::validator::EnvValidation {
+    env::validator::validate(&ci_info)
+}
+
+#[pyfunction]
+fn junit_parse(xml: Vec<u8>) -> PyResult<Vec<PyReport>> {
+    let mut junit_parser = junit::parser::JunitParser::new();
+    if junit_parser.parse(BufReader::new(&xml[..])).is_err() {
+        let error_message = junit_parser
+            .errors()
+            .into_iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<String>>()
+            .join("\n");
+        return Err(PyTypeError::new_err(error_message));
+    }
+
+    Ok(junit_parser
+        .into_reports()
+        .into_iter()
+        .map(PyReport::from)
+        .collect())
+}
+
+#[pyfunction]
+fn junit_validate(report: PyReport) -> junit::validator::JunitReportValidation {
+    junit::validator::validate(&report.into())
+}
+
+#[pyfunction]
+fn repo_validate(bundle_repo: repo::BundleRepo) -> repo::validator::RepoValidation {
+    repo::validator::validate(&bundle_repo)
+}
+
+#[pymodule]
+fn context_py(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(env_parse, m)?)?;
+    m.add_function(wrap_pyfunction!(env_validate, m)?)?;
+
+    m.add_class::<PyReport>()?;
+    m.add_function(wrap_pyfunction!(junit_parse, m)?)?;
+    m.add_function(wrap_pyfunction!(junit_validate, m)?)?;
+
+    m.add_class::<repo::BundleRepo>()?;
+    m.add_class::<repo::RepoUrlParts>()?;
+    m.add_function(wrap_pyfunction!(repo_validate, m)?)?;
+    Ok(())
+}

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -12,7 +12,9 @@ tempfile = "3.2.0"
 [dependencies]
 anyhow = "1.0.44"
 chrono = "0.4.33"
-gix = { version = "0.63.0", default-features = false, features = [], optional = true }
+gix = { version = "0.63.0", default-features = false, features = [
+], optional = true }
+js-sys = { version = "0.3.70", optional = true }
 openssl = { version = "0.10.66", features = ["vendored"], optional = true }
 pyo3 = { version = "0.20.0", optional = true }
 quick-junit = "0.5.0"
@@ -22,8 +24,11 @@ serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = "1.0.68"
 speedate = "0.14.4"
 thiserror = "1.0.63"
+wasm-bindgen = { version = "0.2.84", optional = true }
 
 [features]
 default = ["git-access"]
 git-access = ["dep:gix", "dep:openssl"]
-pyo3 = ["dep:pyo3"]
+bindings = []
+pyo3 = ["bindings", "dep:pyo3"]
+wasm = ["bindings", "dep:wasm-bindgen", "dep:js-sys"]

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -12,9 +12,9 @@ tempfile = "3.2.0"
 [dependencies]
 anyhow = "1.0.44"
 chrono = "0.4.33"
-gix = { version = "0.63.0", default-features = false, features = [] }
-openssl = { version = "0.10.66", features = ["vendored"] }
-pyo3 = "0.20.0"
+gix = { version = "0.63.0", default-features = false, features = [], optional = true }
+openssl = { version = "0.10.66", features = ["vendored"], optional = true }
+pyo3 = { version = "0.20.0", optional = true }
 quick-junit = "0.5.0"
 quick-xml = "0.36.2"
 regex = { version = "1.10.3", default-features = false, features = ["std"] }
@@ -22,3 +22,8 @@ serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = "1.0.68"
 speedate = "0.14.4"
 thiserror = "1.0.63"
+
+[features]
+default = ["git-access"]
+git-access = ["dep:gix", "dep:openssl"]
+pyo3 = ["dep:pyo3"]

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.44"
 chrono = "0.4.33"
 gix = { version = "0.63.0", default-features = false, features = [] }
 openssl = { version = "0.10.66", features = ["vendored"] }
+pyo3 = "0.20.0"
 quick-junit = "0.5.0"
 quick-xml = "0.36.2"
 regex = { version = "1.10.3", default-features = false, features = ["std"] }

--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use thiserror::Error;
 
@@ -41,7 +42,7 @@ mod ci_platform_env_key {
     pub const DRONE: &str = "DRONE";
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CIPlatform {
     GitHubActions,
@@ -298,36 +299,25 @@ impl<'a> CIInfoParser<'a> {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass(get_all))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CIInfo {
-    #[pyo3(get)]
     pub platform: CIPlatform,
-    #[pyo3(get)]
     pub job_url: Option<String>,
-    #[pyo3(get)]
     pub branch: Option<String>,
-    #[pyo3(get)]
     pub branch_class: Option<BranchClass>,
-    #[pyo3(get)]
     pub pr_number: Option<usize>,
-    #[pyo3(get)]
     pub actor: Option<String>,
-    #[pyo3(get)]
     pub committer_name: Option<String>,
-    #[pyo3(get)]
     pub committer_email: Option<String>,
-    #[pyo3(get)]
     pub author_name: Option<String>,
-    #[pyo3(get)]
     pub author_email: Option<String>,
-    #[pyo3(get)]
     pub commit_message: Option<String>,
-    #[pyo3(get)]
     pub title: Option<String>,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
+#[wasm_bindgen]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BranchClass {
     PullRequest,

--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -1,3 +1,4 @@
+use pyo3::prelude::*;
 use thiserror::Error;
 
 use crate::string_safety::safe_truncate_string;
@@ -40,6 +41,7 @@ mod ci_platform_env_key {
     pub const DRONE: &str = "DRONE";
 }
 
+#[pyclass]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CIPlatform {
     GitHubActions,
@@ -296,22 +298,36 @@ impl<'a> CIInfoParser<'a> {
     }
 }
 
+#[pyclass]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CIInfo {
+    #[pyo3(get)]
     pub platform: CIPlatform,
+    #[pyo3(get)]
     pub job_url: Option<String>,
+    #[pyo3(get)]
     pub branch: Option<String>,
+    #[pyo3(get)]
     pub branch_class: Option<BranchClass>,
+    #[pyo3(get)]
     pub pr_number: Option<usize>,
+    #[pyo3(get)]
     pub actor: Option<String>,
+    #[pyo3(get)]
     pub committer_name: Option<String>,
+    #[pyo3(get)]
     pub committer_email: Option<String>,
+    #[pyo3(get)]
     pub author_name: Option<String>,
+    #[pyo3(get)]
     pub author_email: Option<String>,
+    #[pyo3(get)]
     pub commit_message: Option<String>,
+    #[pyo3(get)]
     pub title: Option<String>,
 }
 
+#[pyclass]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BranchClass {
     PullRequest,

--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use thiserror::Error;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
 
 use crate::string_safety::safe_truncate_string;
 
@@ -43,6 +45,7 @@ mod ci_platform_env_key {
 }
 
 #[cfg_attr(feature = "pyo3", pyclass)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CIPlatform {
     GitHubActions,
@@ -300,6 +303,7 @@ impl<'a> CIInfoParser<'a> {
 }
 
 #[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CIInfo {
     pub platform: CIPlatform,
@@ -317,7 +321,7 @@ pub struct CIInfo {
 }
 
 #[cfg_attr(feature = "pyo3", pyclass)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BranchClass {
     PullRequest,

--- a/context/src/env/validator.rs
+++ b/context/src/env/validator.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use thiserror::Error;
 
@@ -9,7 +10,7 @@ pub const MAX_BRANCH_NAME_LEN: usize = 36;
 pub const MAX_EMAIL_LEN: usize = 254;
 pub const MAX_FIELD_LEN: usize = 1000;
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EnvValidationLevel {
     Valid = 0,
@@ -255,14 +256,14 @@ pub fn validate(ci_info: &CIInfo) -> EnvValidation {
     env_validation
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EnvValidation {
     level: EnvValidationLevel,
     issues: Vec<EnvValidationIssue>,
 }
 
-#[pymethods]
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl EnvValidation {
     pub fn level(&self) -> EnvValidationLevel {
         self.level

--- a/context/src/junit/mod.rs
+++ b/context/src/junit/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bindings")]
+pub mod bindings;
 mod date_parser;
 pub mod parser;
 pub mod validator;

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, FixedOffset, Utc};
+#[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use quick_junit::Report;
 use thiserror::Error;
@@ -12,7 +13,7 @@ pub const MAX_FIELD_LEN: usize = 1_000;
 const TIMESTAMP_OLD_DAYS: u32 = 30;
 const TIMESTAMP_STALE_HOURS: u32 = 1;
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum JunitValidationLevel {
     Valid = 0,
@@ -162,13 +163,13 @@ pub fn validate(report: &Report) -> JunitReportValidation {
     report_validation
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitReportValidation {
     test_suites: Vec<JunitTestSuiteValidation>,
 }
 
-#[pymethods]
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl JunitReportValidation {
     /// Only used for python bindings
     fn test_suites_owned(&self) -> Vec<JunitTestSuiteValidation> {
@@ -211,7 +212,7 @@ impl ToString for JunitTestSuiteValidationIssue {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitTestSuiteValidation {
     level: JunitValidationLevel,
@@ -219,7 +220,7 @@ pub struct JunitTestSuiteValidation {
     test_cases: Vec<JunitTestCaseValidation>,
 }
 
-#[pymethods]
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl JunitTestSuiteValidation {
     pub fn level(&self) -> JunitValidationLevel {
         self.level
@@ -295,14 +296,14 @@ impl ToString for JunitTestCaseValidationIssue {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitTestCaseValidation {
     level: JunitValidationLevel,
     issues: Vec<JunitTestCaseValidationIssue>,
 }
 
-#[pymethods]
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl JunitTestCaseValidation {
     pub fn level(&self) -> JunitValidationLevel {
         self.level

--- a/context/src/repo/mod.rs
+++ b/context/src/repo/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use gix::Repository;
+use pyo3::prelude::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -18,16 +19,26 @@ struct BundleRepoOptions {
     repo_head_commit_epoch: Option<i64>,
 }
 
+#[pyclass]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BundleRepo {
+    #[pyo3(get)]
     pub repo: RepoUrlParts,
+    #[pyo3(get)]
     pub repo_root: String,
+    #[pyo3(get)]
     pub repo_url: String,
+    #[pyo3(get)]
     pub repo_head_sha: String,
+    #[pyo3(get)]
     pub repo_head_branch: String,
+    #[pyo3(get)]
     pub repo_head_commit_epoch: i64,
+    #[pyo3(get)]
     pub repo_head_commit_message: String,
+    #[pyo3(get)]
     pub repo_head_author_name: String,
+    #[pyo3(get)]
     pub repo_head_author_email: String,
 }
 
@@ -136,10 +147,42 @@ impl BundleRepo {
     }
 }
 
+#[pymethods]
+impl BundleRepo {
+    #[new]
+    fn py_new(
+        repo: RepoUrlParts,
+        repo_root: String,
+        repo_url: String,
+        repo_head_sha: String,
+        repo_head_branch: String,
+        repo_head_commit_epoch: i64,
+        repo_head_commit_message: String,
+        repo_head_author_name: String,
+        repo_head_author_email: String,
+    ) -> Self {
+        Self {
+            repo,
+            repo_root,
+            repo_url,
+            repo_head_sha,
+            repo_head_branch,
+            repo_head_commit_epoch,
+            repo_head_commit_message,
+            repo_head_author_name,
+            repo_head_author_email,
+        }
+    }
+}
+
+#[pyclass]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RepoUrlParts {
+    #[pyo3(get)]
     pub host: String,
+    #[pyo3(get)]
     pub owner: String,
+    #[pyo3(get)]
     pub name: String,
 }
 
@@ -196,5 +239,13 @@ impl RepoUrlParts {
         }
 
         Ok(Self { host, owner, name })
+    }
+}
+
+#[pymethods]
+impl RepoUrlParts {
+    #[new]
+    fn py_new(host: String, owner: String, name: String) -> Self {
+        Self { host, owner, name }
     }
 }

--- a/context/src/repo/validator.rs
+++ b/context/src/repo/validator.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+#[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use thiserror::Error;
 
@@ -13,7 +14,7 @@ pub const MAX_FIELD_LEN: usize = 1000;
 const TIMESTAMP_OLD_DAYS: u32 = 30;
 const TIMESTAMP_STALE_HOURS: u32 = 1;
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RepoValidationLevel {
     Valid = 0,
@@ -171,14 +172,14 @@ pub fn validate(bundle_repo: &BundleRepo) -> RepoValidation {
     repo_validation
 }
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RepoValidation {
     level: RepoValidationLevel,
     issues: Vec<RepoValidationIssue>,
 }
 
-#[pymethods]
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl RepoValidation {
     pub fn level(&self) -> RepoValidationLevel {
         self.level


### PR DESCRIPTION
depends on #110 

Adds bindings for Python and JS that can be used elsewhere in our apps and services. As a follow up, we need to figure out how to test, build, and publish these bindings.

[`maturin`](https://www.maturin.rs/) is used for Python bindings
[`wasm-pack`](https://rustwasm.github.io/docs/wasm-pack/) is used for JS bindings