### PR TITLE
Revert "Update BundleUpload status for observability"

### DIFF
--- a/cli/src/clients.rs
+++ b/cli/src/clients.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 
 use crate::types::{
-    BundleUploadStatus, CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
-    GetQuarantineBulkTestStatusRequest, QuarantineConfig, Repo, UpdateBundleUploadRequest,
+    CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
+    GetQuarantineBulkTestStatusRequest, QuarantineConfig, Repo,
 };
 use crate::utils::status_code_help;
 
@@ -43,35 +43,6 @@ pub async fn create_trunk_repo(
             org_slug
         )
         .context("Failed to validate trunk repo"));
-    }
-
-    Ok(())
-}
-pub async fn update_bundle_upload_status(
-    origin: &str,
-    api_token: &str,
-    id: &str,
-    upload_status: &BundleUploadStatus,
-) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
-    let resp = client
-        .patch(format!("{}/v1/metrics/updateBundleUpload", origin))
-        .timeout(TRUNK_API_TIMEOUT)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header(TRUNK_API_TOKEN_HEADER, api_token)
-        .json(&UpdateBundleUploadRequest {
-            id: id.to_owned(),
-            upload_status: upload_status.to_owned(),
-        })
-        .send()
-        .await
-        .map_err(|e| anyhow::anyhow!(e).context("Failed to update bundle upload status"))?;
-
-    if resp.status() != reqwest::StatusCode::OK {
-        return Err(
-            anyhow::anyhow!("{}: {}", resp.status(), status_code_help(resp.status()))
-                .context("Failed to update bundle upload status"),
-        );
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
 use trunk_analytics_cli::bundler::BundlerUtil;
 use trunk_analytics_cli::clients::{
-    create_bundle_upload_intent, create_trunk_repo, put_bundle_to_s3, update_bundle_upload_status,
+    create_bundle_upload_intent, create_trunk_repo, put_bundle_to_s3,
 };
 use trunk_analytics_cli::codeowners::CodeOwners;
 use trunk_analytics_cli::constants::{
@@ -18,8 +18,7 @@ use trunk_analytics_cli::runner::{
 };
 use trunk_analytics_cli::scanner::{BundleRepo, EnvScanner};
 use trunk_analytics_cli::types::{
-    BundleMeta, BundleUploadStatus, QuarantineBulkTestStatus, QuarantineRunResult, RunResult,
-    META_VERSION,
+    BundleMeta, QuarantineBulkTestStatus, QuarantineRunResult, RunResult, META_VERSION,
 };
 use trunk_analytics_cli::utils::{from_non_empty_or_default, parse_custom_tags};
 
@@ -257,7 +256,7 @@ async fn run_upload(
         ),
         org: org_url_slug.clone(),
         repo: repo.clone(),
-        bundle_upload_id: upload.id.clone(),
+        bundle_upload_id: upload.id,
         tags,
         file_sets,
         envs,
@@ -296,42 +295,14 @@ async fn run_upload(
     log::info!("Flushed temporary tarball to {:?}", bundle_time_file);
 
     if dry_run {
-        if let Err(e) = update_bundle_upload_status(
-            &api_address,
-            &token,
-            &upload.id,
-            &BundleUploadStatus::DryRun,
-        )
-        .await
-        {
-            log::warn!("Failed to update bundle upload status: {}", e);
-        } else {
-            log::debug!("Updated bundle upload status to DRY_RUN");
-        }
         log::info!("Dry run, skipping upload.");
         return Ok(exit_code);
     }
 
-    let upload_status = Retry::spawn(default_delay(), || {
+    Retry::spawn(default_delay(), || {
         put_bundle_to_s3(&upload.url, &bundle_time_file)
     })
-    .await
-    .map(|_| BundleUploadStatus::UploadComplete)
-    .unwrap_or_else(|e| {
-        log::error!("Failed to upload bundle to S3 after retries: {}", e);
-        BundleUploadStatus::UploadFailed
-    });
-    if let Err(e) =
-        update_bundle_upload_status(&api_address, &token, &upload.id, &upload_status).await
-    {
-        log::warn!(
-            "Failed to update bundle upload status to {:#?}: {}",
-            upload_status,
-            e
-        )
-    } else {
-        log::debug!("Updated bundle upload status to {:#?}", upload_status)
-    }
+    .await?;
 
     let remote_urls = vec![repo.repo_url.clone()];
     Retry::spawn(default_delay(), || {

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -34,25 +34,6 @@ pub struct CreateBundleUploadRequest {
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
-pub enum BundleUploadStatus {
-    #[serde(rename = "PENDING")]
-    Pending,
-    #[serde(rename = "UPLOAD_COMPLETE")]
-    UploadComplete,
-    #[serde(rename = "UPLOAD_FAILED")]
-    UploadFailed,
-    #[serde(rename = "DRY_RUN")]
-    DryRun,
-}
-
-#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
-pub struct UpdateBundleUploadRequest {
-    pub id: String,
-    #[serde(rename = "uploadStatus")]
-    pub upload_status: BundleUploadStatus,
-}
-
-#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
 pub struct GetQuarantineBulkTestStatusRequest {
     pub repo: Repo,
     #[serde(rename = "orgUrlSlug")]

--- a/cli/tests/test_utils/mock_server.rs
+++ b/cli/tests/test_utils/mock_server.rs
@@ -8,21 +8,20 @@ use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Response;
-use axum::routing::{any, patch, post, put};
+use axum::routing::{any, post, put};
 use axum::{Json, Router};
 use tempfile::tempdir;
 use tokio::net::TcpListener;
 use tokio::spawn;
 use trunk_analytics_cli::types::{
     CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
-    GetQuarantineBulkTestStatusRequest, QuarantineConfig, UpdateBundleUploadRequest,
+    GetQuarantineBulkTestStatusRequest, QuarantineConfig,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequestPayload {
     CreateRepo(CreateRepoRequest),
     CreateBundleUpload(CreateBundleUploadRequest),
-    UpdateBundleUpload(UpdateBundleUploadRequest),
     GetQuarantineBulkTestStatus(GetQuarantineBulkTestStatusRequest),
     S3Upload(PathBuf),
 }
@@ -54,10 +53,6 @@ pub async fn spawn_mock_server() -> SharedMockServerState {
         .route(
             "/v1/metrics/createBundleUpload",
             post(create_bundle_handler),
-        )
-        .route(
-            "/v1/metrics/updateBundleUpload",
-            patch(update_bundle_handler),
         )
         .route(
             "/v1/metrics/getQuarantineConfig",
@@ -119,22 +114,6 @@ async fn create_bundle_handler(
         url: format!("{host}/s3upload"),
         key: String::from("unused"),
     })
-}
-
-#[allow(dead_code)] // TODO: move this to its own crate to get rid of the need for this
-#[axum::debug_handler]
-async fn update_bundle_handler(
-    State(state): State<SharedMockServerState>,
-    Json(update_bundle_upload_request): Json<UpdateBundleUploadRequest>,
-) -> Response<String> {
-    state
-        .requests
-        .lock()
-        .unwrap()
-        .push(RequestPayload::UpdateBundleUpload(
-            update_bundle_upload_request,
-        ));
-    Response::new(String::from("OK"))
 }
 
 #[allow(dead_code)] // TODO: move this to its own crate to get rid of the need for this

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -10,8 +10,8 @@ use test_utils::mock_git_repo::setup_repo_with_commit;
 use test_utils::mock_server::{spawn_mock_server, RequestPayload};
 use trunk_analytics_cli::codeowners::CodeOwners;
 use trunk_analytics_cli::types::{
-    BundleMeta, BundleUploadStatus, CreateBundleUploadRequest, CreateRepoRequest, FileSetType,
-    GetQuarantineBulkTestStatusRequest, Repo, UpdateBundleUploadRequest,
+    BundleMeta, CreateBundleUploadRequest, CreateRepoRequest, FileSetType,
+    GetQuarantineBulkTestStatusRequest, Repo,
 };
 
 mod test_utils;
@@ -65,7 +65,7 @@ async fn upload_bundle() {
         .failure();
 
     let requests = state.requests.lock().unwrap().clone();
-    assert_eq!(requests.len(), 5);
+    assert_eq!(requests.len(), 4);
     let mut requests_iter = requests.into_iter();
 
     assert_eq!(
@@ -155,14 +155,6 @@ async fn upload_bundle() {
     assert_eq!(time_since_junit_modified.num_minutes(), 0);
     assert_eq!(bundled_file.owners, ["@user"]);
     assert_eq!(bundled_file.team, None);
-
-    assert_eq!(
-        requests_iter.next().unwrap(),
-        RequestPayload::UpdateBundleUpload(UpdateBundleUploadRequest {
-            id: "test-bundle-upload-id".to_string(),
-            upload_status: BundleUploadStatus::UploadComplete
-        }),
-    );
 
     assert_eq!(
         requests_iter.next().unwrap(),


### PR DESCRIPTION
Reverts trunk-io/analytics-cli#99

I've narrowed down a breakage to [this PR](https://github.com/trunk-io/analytics-cli/pull/99) since that's the first time it fails in the check (and it makes changes to the area of code in question).
https://github.com/trunk-io/analytics-cli/actions/runs/11113171931/job/30876881217#step:9:26

It wasn't caught because we're returning exit code 0 even when the upload fails. So the job looked like it passed. We need to add a mode that forces fail on any error so we can better test the cli.

I'm putting up a revert in case the actual fix is non trivial. Feel free to close this if we can get a proper fix in in a timely manner.