### PR TITLE
6. document and alias `RepoUrlParts` to `Repo`

### DIFF
--- a/cli/src/clients.rs
+++ b/cli/src/clients.rs
@@ -5,7 +5,7 @@ use api::{
     CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
     GetQuarantineBulkTestStatusRequest, QuarantineConfig,
 };
-use context::repo::RepoUrlParts;
+use context::repo::RepoUrlParts as Repo;
 
 use crate::utils::status_code_help;
 
@@ -16,7 +16,7 @@ pub async fn create_trunk_repo(
     origin: &str,
     api_token: &str,
     org_slug: &str,
-    repo: &RepoUrlParts,
+    repo: &Repo,
     remote_urls: &[String],
 ) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
@@ -52,7 +52,7 @@ pub async fn create_bundle_upload_intent(
     origin: &str,
     api_token: &str,
     org_slug: &str,
-    repo: &RepoUrlParts,
+    repo: &Repo,
 ) -> anyhow::Result<CreateBundleUploadResponse> {
     let client = reqwest::Client::new();
     let resp = match client
@@ -87,7 +87,7 @@ pub async fn get_quarantining_config(
     origin: &str,
     api_token: &str,
     org_slug: &str,
-    repo: &RepoUrlParts,
+    repo: &Repo,
 ) -> anyhow::Result<QuarantineConfig> {
     let client = reqwest::Client::new();
     let resp = match client

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -115,7 +115,7 @@ pub struct BundleMeta {
 
 #[cfg(test)]
 mod tests {
-    use context::repo::RepoUrlParts;
+    use context::repo::RepoUrlParts as Repo;
 
     use super::*;
 
@@ -212,7 +212,7 @@ mod tests {
         let file = Some("file".to_string());
         let org_slug = "org_slug";
         let repo = BundleRepo {
-            repo: RepoUrlParts {
+            repo: Repo {
                 host: "host".to_string(),
                 owner: "owner".to_string(),
                 name: "name".to_string(),

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use api::{CreateBundleUploadRequest, CreateRepoRequest, GetQuarantineBulkTestStatusRequest};
 use assert_cmd::Command;
 use assert_matches::assert_matches;
-use context::repo::RepoUrlParts;
+use context::repo::RepoUrlParts as Repo;
 use junit_mock::JunitMock;
 use tempfile::tempdir;
 use test_utils::{
@@ -70,7 +70,7 @@ async fn upload_bundle() {
     assert_eq!(
         requests_iter.next().unwrap(),
         RequestPayload::GetQuarantineBulkTestStatus(GetQuarantineBulkTestStatusRequest {
-            repo: RepoUrlParts {
+            repo: Repo {
                 host: String::from("github.com"),
                 owner: String::from("trunk-io"),
                 name: String::from("analytics-cli"),
@@ -82,7 +82,7 @@ async fn upload_bundle() {
     assert_eq!(
         requests_iter.next().unwrap(),
         RequestPayload::CreateBundleUpload(CreateBundleUploadRequest {
-            repo: RepoUrlParts {
+            repo: Repo {
                 host: String::from("github.com"),
                 owner: String::from("trunk-io"),
                 name: String::from("analytics-cli"),
@@ -101,7 +101,7 @@ async fn upload_bundle() {
     assert_eq!(bundle_meta.org, "test-org");
     assert_eq!(
         bundle_meta.repo.repo,
-        RepoUrlParts {
+        Repo {
             host: String::from("github.com"),
             owner: String::from("trunk-io"),
             name: String::from("analytics-cli"),
@@ -158,7 +158,7 @@ async fn upload_bundle() {
     assert_eq!(
         requests_iter.next().unwrap(),
         RequestPayload::CreateRepo(CreateRepoRequest {
-            repo: RepoUrlParts {
+            repo: Repo {
                 host: String::from("github.com"),
                 owner: String::from("trunk-io"),
                 name: String::from("analytics-cli"),

--- a/context/src/repo/mod.rs
+++ b/context/src/repo/mod.rs
@@ -177,6 +177,8 @@ impl BundleRepo {
     }
 }
 
+/// The [`Repo` common type](https://github.com/trunk-io/trunk/blob/518397f/trunk/services/common/types/repo.ts#L10)
+// NOTE: This is named `RepoUrlParts` to prevent confusion as to its purpose
 #[cfg_attr(feature = "pyo3", pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
depends on #111

fixes nits found in #109:
https://github.com/trunk-io/analytics-cli/pull/109#discussion_r1785072658