### PR TITLE
[TRUNK-12756] Update bundle upload status (round 2)

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,6 +18,25 @@ pub struct CreateBundleUploadResponse {
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+pub enum BundleUploadStatus {
+    #[serde(rename = "PENDING")]
+    Pending,
+    #[serde(rename = "UPLOAD_COMPLETE")]
+    UploadComplete,
+    #[serde(rename = "UPLOAD_FAILED")]
+    UploadFailed,
+    #[serde(rename = "DRY_RUN")]
+    DryRun,
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+pub struct UpdateBundleUploadRequest {
+    pub id: String,
+    #[serde(rename = "uploadStatus")]
+    pub upload_status: BundleUploadStatus,
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
 pub struct CreateRepoRequest {
     pub repo: RepoUrlParts,
     #[serde(rename = "orgUrlSlug")]

--- a/cli/src/clients.rs
+++ b/cli/src/clients.rs
@@ -2,8 +2,8 @@ use std::{format, path::PathBuf};
 
 use anyhow::Context;
 use api::{
-    CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
-    GetQuarantineBulkTestStatusRequest, QuarantineConfig,
+    BundleUploadStatus, CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
+    GetQuarantineBulkTestStatusRequest, QuarantineConfig, UpdateBundleUploadRequest,
 };
 use context::repo::RepoUrlParts as Repo;
 
@@ -43,6 +43,36 @@ pub async fn create_trunk_repo(
             org_slug
         )
         .context("Failed to validate trunk repo"));
+    }
+
+    Ok(())
+}
+
+pub async fn update_bundle_upload_status(
+    origin: &str,
+    api_token: &str,
+    id: &str,
+    upload_status: &BundleUploadStatus,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .patch(format!("{}/v1/metrics/updateBundleUpload", origin))
+        .timeout(TRUNK_API_TIMEOUT)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(TRUNK_API_TOKEN_HEADER, api_token)
+        .json(&UpdateBundleUploadRequest {
+            id: id.to_owned(),
+            upload_status: upload_status.to_owned(),
+        })
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!(e).context("Failed to update bundle upload status"))?;
+
+    if resp.status() != reqwest::StatusCode::OK {
+        return Err(
+            anyhow::anyhow!("{}: {}", resp.status(), status_code_help(resp.status()))
+                .context("Failed to update bundle upload status"),
+        );
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,13 +4,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(target_os = "macos")]
 use xcresult::XCResult;
 
+use api::BundleUploadStatus;
 use clap::{Args, Parser, Subcommand};
 use context::repo::BundleRepo;
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
 use trunk_analytics_cli::bundler::BundlerUtil;
 use trunk_analytics_cli::clients::{
-    create_bundle_upload_intent, create_trunk_repo, put_bundle_to_s3,
+    create_bundle_upload_intent, create_trunk_repo, put_bundle_to_s3, update_bundle_upload_status,
 };
 use trunk_analytics_cli::codeowners::CodeOwners;
 use trunk_analytics_cli::constants::{
@@ -308,7 +309,7 @@ async fn run_upload(
         ),
         org: org_url_slug.clone(),
         repo: repo.clone(),
-        bundle_upload_id: upload.id,
+        bundle_upload_id: upload.id.clone(),
         tags,
         file_sets,
         envs,
@@ -347,14 +348,42 @@ async fn run_upload(
     log::info!("Flushed temporary tarball to {:?}", bundle_time_file);
 
     if dry_run {
+        if let Err(e) = update_bundle_upload_status(
+            &api_address,
+            &token,
+            &upload.id,
+            &BundleUploadStatus::DryRun,
+        )
+        .await
+        {
+            log::warn!("Failed to update bundle upload status: {}", e);
+        } else {
+            log::debug!("Updated bundle upload status to DRY_RUN");
+        }
         log::info!("Dry run, skipping upload.");
         return Ok(exit_code);
     }
 
-    Retry::spawn(default_delay(), || {
+    let upload_status = Retry::spawn(default_delay(), || {
         put_bundle_to_s3(&upload.url, &bundle_time_file)
     })
-    .await?;
+    .await
+    .map(|_| BundleUploadStatus::UploadComplete)
+    .unwrap_or_else(|e| {
+        log::error!("Failed to upload bundle to S3 after retries: {}", e);
+        BundleUploadStatus::UploadFailed
+    });
+    if let Err(e) =
+        update_bundle_upload_status(&api_address, &token, &upload.id, &upload_status).await
+    {
+        log::warn!(
+            "Failed to update bundle upload status to {:#?}: {}",
+            upload_status,
+            e
+        )
+    } else {
+        log::debug!("Updated bundle upload status to {:#?}", upload_status)
+    }
 
     let remote_urls = vec![repo.repo_url.clone()];
     Retry::spawn(default_delay(), || {

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -2,7 +2,10 @@ use std::fs;
 use std::io::BufReader;
 use std::path::Path;
 
-use api::{CreateBundleUploadRequest, CreateRepoRequest, GetQuarantineBulkTestStatusRequest};
+use api::{
+    BundleUploadStatus, CreateBundleUploadRequest, CreateRepoRequest,
+    GetQuarantineBulkTestStatusRequest, UpdateBundleUploadRequest,
+};
 use assert_cmd::Command;
 use assert_matches::assert_matches;
 use context::repo::RepoUrlParts as Repo;
@@ -64,7 +67,7 @@ async fn upload_bundle() {
         .failure();
 
     let requests = state.requests.lock().unwrap().clone();
-    assert_eq!(requests.len(), 4);
+    assert_eq!(requests.len(), 5);
     let mut requests_iter = requests.into_iter();
 
     assert_eq!(
@@ -154,6 +157,14 @@ async fn upload_bundle() {
     assert_eq!(time_since_junit_modified.num_minutes(), 0);
     assert_eq!(bundled_file.owners, ["@user"]);
     assert_eq!(bundled_file.team, None);
+
+    assert_eq!(
+        requests_iter.next().unwrap(),
+        RequestPayload::UpdateBundleUpload(UpdateBundleUploadRequest {
+            id: "test-bundle-upload-id".to_string(),
+            upload_status: BundleUploadStatus::UploadComplete
+        }),
+    );
 
     assert_eq!(
         requests_iter.next().unwrap(),


### PR DESCRIPTION
To be merged after [TRUNK-12943](https://linear.app/trunk/issue/TRUNK-12943/move-bundle-upload-to-self-hosted-flakytests-tsdb) is rolled out to prod