### PR TITLE
force sentry to collect events with env dev for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cli-tests"
+version = "0.1.0"
+dependencies = [
+ "api",
+ "assert_cmd",
+ "assert_matches",
+ "chrono",
+ "context",
+ "escargot",
+ "junit-mock",
+ "lazy_static",
+ "serde_json",
+ "tempfile",
+ "test_utils",
+ "tokio",
+ "trunk-analytics-cli",
+]
+
+[[package]]
 name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +638,18 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "escargot"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c000f23e9d459aef148b7267e02b03b94a0aaacf4ec64c65612f67e02f525fb6"
+dependencies = [
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3014,9 +3045,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "api",
- "assert_cmd",
- "assert_matches",
- "axum",
  "chrono",
  "clap",
  "codeowners",
@@ -3035,7 +3063,6 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "test_utils",
  "tokio",
  "tokio-retry",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "escargot",
  "junit-mock",
  "lazy_static",
+ "more-asserts",
  "serde_json",
  "tempfile",
  "test_utils",
@@ -1740,6 +1741,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "native-tls"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,7 +3059,6 @@ dependencies = [
  "env_logger",
  "exitcode",
  "glob",
- "junit-mock",
  "log",
  "openssl",
  "quick-junit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "api",
   "cli",
+  "cli-tests",
   "codeowners",
   "context",
   "context-js",

--- a/cli-tests/Cargo.toml
+++ b/cli-tests/Cargo.toml
@@ -12,6 +12,7 @@ context = { path = "../context" }
 escargot = "0.5.12"
 junit-mock = { path = "../junit-mock" }
 lazy_static = "1.4"
+more-asserts = "0.3.1"
 serde_json = "1.0.68"
 tempfile = "3.2.0"
 test_utils = { path = "../test_utils" }

--- a/cli-tests/Cargo.toml
+++ b/cli-tests/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cli-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+api = { path = "../api" }
+assert_cmd = "2.0.16"
+assert_matches = "1.5.0"
+chrono = "0.4.33"
+context = { path = "../context" }
+escargot = "0.5.12"
+junit-mock = { path = "../junit-mock" }
+lazy_static = "1.4"
+serde_json = "1.0.68"
+tempfile = "3.2.0"
+test_utils = { path = "../test_utils" }
+tokio = { version = "*" }
+trunk-analytics-cli = { path = "../cli", features = ["force-sentry-env-dev"] }

--- a/cli-tests/src/main.rs
+++ b/cli-tests/src/main.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+mod upload;
+
+fn main() {}

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -144,7 +144,7 @@ async fn upload_bundle() {
     assert_eq!(bundle_meta.envs.get("CI"), Some(&String::from("1")));
     let time_since_upload = chrono::Utc::now()
         - chrono::DateTime::from_timestamp(bundle_meta.upload_time_epoch as i64, 0).unwrap();
-    assert!(time_since_upload.num_minutes() <= 5);
+    more_asserts::assert_lt!(time_since_upload.num_minutes(), 5);
     assert_eq!(bundle_meta.test_command, None);
     assert!(bundle_meta.os_info.is_some());
     assert!(bundle_meta.quarantined_tests.is_empty());
@@ -172,7 +172,7 @@ async fn upload_bundle() {
     );
     let time_since_junit_modified = chrono::Utc::now()
         - chrono::DateTime::from_timestamp_nanos(bundled_file.last_modified_epoch_ns as i64);
-    assert!(time_since_junit_modified.num_minutes() <= 5);
+    more_asserts::assert_lt!(time_since_junit_modified.num_minutes(), 5);
     assert_eq!(bundled_file.owners, ["@user"]);
     assert_eq!(bundled_file.team, None);
 

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -144,7 +144,7 @@ async fn upload_bundle() {
     assert_eq!(bundle_meta.envs.get("CI"), Some(&String::from("1")));
     let time_since_upload = chrono::Utc::now()
         - chrono::DateTime::from_timestamp(bundle_meta.upload_time_epoch as i64, 0).unwrap();
-    assert_eq!(time_since_upload.num_minutes(), 0);
+    assert!(time_since_upload.num_minutes() <= 5);
     assert_eq!(bundle_meta.test_command, None);
     assert!(bundle_meta.os_info.is_some());
     assert!(bundle_meta.quarantined_tests.is_empty());
@@ -172,7 +172,7 @@ async fn upload_bundle() {
     );
     let time_since_junit_modified = chrono::Utc::now()
         - chrono::DateTime::from_timestamp_nanos(bundled_file.last_modified_epoch_ns as i64);
-    assert_eq!(time_since_junit_modified.num_minutes(), 0);
+    assert!(time_since_junit_modified.num_minutes() <= 5);
     assert_eq!(bundled_file.owners, ["@user"]);
     assert_eq!(bundled_file.team, None);
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,13 +44,6 @@ openssl = { version = "0.10.66", features = ["vendored"] }
 uuid = { version = "1.10.0", features = ["v5"] }
 quick-junit = "0.5.0"
 
-[dev-dependencies]
-assert_cmd = "2.0.16"
-assert_matches = "1.5.0"
-axum = { version = "0.7.5", features = ["macros"] }
-junit-mock = { path = "../junit-mock" }
-test_utils = { path = "../test_utils" }
-
 [build-dependencies]
 vergen = { version = "8.3.1", features = [
   "build",
@@ -60,3 +53,6 @@ vergen = { version = "8.3.1", features = [
   "rustc",
   "si",
 ] }
+
+[features]
+force-sentry-env-dev = []

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -124,13 +124,15 @@ const RETRY_COUNT: usize = 5;
 // "the Sentry client must be initialized before starting an async runtime or spawning threads"
 // https://docs.sentry.io/platforms/rust/#async-main-function
 fn main() -> anyhow::Result<()> {
-    let _guard = sentry::init((
-        SENTRY_DSN,
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            ..Default::default()
-        },
-    ));
+    let mut options = sentry::ClientOptions::default();
+    options.release = sentry::release_name!();
+
+    #[cfg(feature = "force-sentry-env-dev")]
+    {
+        options.environment = Some("development".into())
+    }
+
+    let _guard = sentry::init((SENTRY_DSN, options));
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
I'm adding more Sentry events and I'm seeing these sometimes get sent using the prod env in tests 😬 

This can happen when `cargo test --release` is used and Sentry defaults its environment based on the [`debug_assertions`](https://doc.rust-lang.org/reference/conditional-compilation.html#debug_assertions) feature flag which is turned off/on by `--release`.