### PR TITLE
fix pyo3/maturin sdist build

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -110,7 +110,9 @@ jobs:
           path: dist
 
   sdist:
-    runs-on: ubuntu-latest
+    # TODO(TRUNK-13050): update to `ubuntu-latest` when `maturin-action` gets updated to support it
+    # https://github.com/PyO3/maturin-action/issues/291
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist


### PR DESCRIPTION
Looks like an update to `ubuntu-latest` broke `maturin-action`'s `sdist` (source distribution) build:
https://github.com/PyO3/maturin-action/issues/291

I filed a follow-up ticket:
https://linear.app/trunk/issue/TRUNK-13050/switch-to-using-ubuntu-latest-for-analytics-cli-when-maturin-action-is