### PR TITLE
[BB-76] add short-circuit and adjust messaging for disabled quarantine status

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -58,6 +58,8 @@ pub struct GetQuarantineBulkTestStatusRequest {
 pub struct QuarantineConfig {
     #[serde(rename = "isPreview")]
     pub is_preview_mode: bool,
+    #[serde(rename = "isDisabled")]
+    pub is_disabled: bool,
     #[serde(rename = "testIds")]
     pub quarantined_tests: HashSet<String>,
 }

--- a/test_utils/src/mock_server.rs
+++ b/test_utils/src/mock_server.rs
@@ -210,6 +210,7 @@ pub async fn get_quarantining_config_handler(
         ));
     Json(QuarantineConfig {
         is_preview_mode: true,
+        is_disabled: false,
         quarantined_tests: HashSet::new(),
     })
 }


### PR DESCRIPTION
References new field added in https://github.com/trunk-io/trunk/pull/18060, but should handle missing value as falsy and maintain existing behavior. Please let me know if my assumptions around missing values and defaults are incorrect