### PR TITLE
fix linking to python

### DIFF
--- a/.github/actions/build_target/action.yaml
+++ b/.github/actions/build_target/action.yaml
@@ -23,7 +23,8 @@ runs:
 
     - name: Compile binary
       shell: bash
-      run: cargo build -q --workspace ${{ contains(inputs.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --profile=${{ inputs.profile }} --target ${{ inputs.target }}
+      # NOTE: DO NOT BUILD WORKSPACE OTHERWISE THE CLI MAY BE LINKED TO UNNECESSARY LIBRARIES
+      run: cargo build -q -p trunk-analytics-cli --profile=${{ inputs.profile }} --target ${{ inputs.target }}
 
     - name: Create binary with debug info
       shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,7 +60,8 @@ jobs:
 
       - name: Build ${{ matrix.target }} target
         if: "!cancelled()"
-        run: cargo build -q --workspace ${{ contains(matrix.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --release --target ${{ matrix.target }}
+        # NOTE: DO NOT BUILD WORKSPACE OTHERWISE THE CLI MAY BE LINKED TO UNNECESSARY LIBRARIES
+        run: cargo build -q -p trunk-analytics-cli --release --target ${{ matrix.target }}
 
       - name: Upload results using action from ${{ matrix.target }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,20 @@ jobs:
 
       - name: Build ${{ matrix.target }} target
         if: "!cancelled()"
-        run: cargo build -q --workspace ${{ contains(matrix.target, 'musl') && '--exclude context-js --exclude context-py' || '' }} --profile=release-with-debug --target ${{ matrix.target }}
+        # NOTE: DO NOT BUILD WORKSPACE OTHERWISE THE CLI MAY BE LINKED TO UNNECESSARY LIBRARIES
+        run: cargo build -q -p trunk-analytics-cli --profile=release-with-debug --target ${{ matrix.target }}
+
+      - name: Check dynamic deps
+        shell: bash
+        run: |
+          set +e
+          shared_libs="$(otool -L target/${{ matrix.target }}/release-with-debug/trunk-analytics-cli)"
+          echo "$shared_libs"
+          if echo "$shared_libs" | grep -qi python; then
+            echo "trunk-analytics-cli has dynamic Python deps - we expect it not to be linked to Python"
+            exit 1
+          fi
+          exit 0
 
       - name: Strip debug info
         run: strip target/${{ matrix.target }}/release-with-debug/trunk-analytics-cli


### PR DESCRIPTION
Originally, I added the `--workspace` flag to build all crates and ensure that our bindings crates don't break via CI. The problem is that if one builds the workspace, each crate is built with the combination of features needed by all other crates—in this case our bindings. I haven't seen any documentation that points to this online, but it should be a huge warning to using the `--workspace` flag 🤦 

To prevent this issue, we just need to build the CLI without the bindings. Bindings have their own tests and workflows now for Python (and soon wasm), so building the entire workspace is no longer needed.

You can inspect the result of these changes with this run:
https://github.com/trunk-io/analytics-cli/actions/runs/11524015493?pr=136

As a follow up, I'm planning to clean up the various branching paths in our GitHub Actions here:
https://github.com/trunk-io/analytics-cli/pull/135