### PR TITLE
(Fix): Reduce duplicate compression of python package

### DIFF
--- a/.github/actions/upload_to_s3/action.yaml
+++ b/.github/actions/upload_to_s3/action.yaml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       if: ${{ inputs.compress == 'true' }}
       run: |
-        TAR_FILE="${{ inputs.name }}.tar.gz"
+        TAR_FILE="${{ inputs.name }}"
         tar -czvf "${TAR_FILE}" -C ${{ inputs.path }} .
         echo "Compressed folder ${{ inputs.path }} to ${TAR_FILE}"
         echo TAR_FILE=${TAR_FILE}>> $GITHUB_ENV
@@ -43,6 +43,5 @@ runs:
         GIT_SHA=$(git rev-parse --short HEAD)
         DATE=$(date "+%Y-%m-%d")
         LOCAL_FILE=${TAR_FILE:-${{ inputs.path }}}
-        UPLOAD_NAME=${TAR_FILE:-${{ inputs.name }}}
 
-        aws s3 cp ${LOCAL_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${UPLOAD_NAME}
+        aws s3 cp ${LOCAL_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${{ inputs.name }}

--- a/.github/actions/upload_to_s3/action.yaml
+++ b/.github/actions/upload_to_s3/action.yaml
@@ -13,6 +13,10 @@ inputs:
   role-to-assume:
     description: ARN of the role to assume
     required: false
+  compress:
+    description: Whether to compress the artifact before uploading
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -26,6 +30,7 @@ runs:
 
     - name: Compress input
       shell: bash
+      if: ${{ inputs.compress == 'true' }}
       run: |
         TAR_FILE="${{ inputs.name }}.tar.gz"
         tar -czvf "${TAR_FILE}" -C ${{ inputs.path }} .
@@ -38,4 +43,4 @@ runs:
         GIT_SHA=$(git rev-parse --short HEAD)
         DATE=$(date "+%Y-%m-%d")
 
-        aws s3 cp ${TAR_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TAR_FILE}
+        aws s3 cp ${TAR_FILE:-${{ inputs.path }}} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TAR_FILE}

--- a/.github/actions/upload_to_s3/action.yaml
+++ b/.github/actions/upload_to_s3/action.yaml
@@ -45,4 +45,4 @@ runs:
         LOCAL_FILE=${TAR_FILE:-${{ inputs.path }}}
         UPLOAD_NAME=${TAR_FILE:-${{ inputs.name }}}
 
-        aws s3 cp ${LOCAL_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TARGET_NAME}
+        aws s3 cp ${LOCAL_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${UPLOAD_NAME}

--- a/.github/actions/upload_to_s3/action.yaml
+++ b/.github/actions/upload_to_s3/action.yaml
@@ -16,7 +16,7 @@ inputs:
   compress:
     description: Whether to compress the artifact before uploading
     required: false
-    default: "false"
+    default: "true"
 
 runs:
   using: composite
@@ -42,5 +42,7 @@ runs:
       run: |
         GIT_SHA=$(git rev-parse --short HEAD)
         DATE=$(date "+%Y-%m-%d")
+        LOCAL_FILE=${TAR_FILE:-${{ inputs.path }}}
+        UPLOAD_NAME=${TAR_FILE:-${{ inputs.name }}}
 
-        aws s3 cp ${TAR_FILE:-${{ inputs.path }}} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TAR_FILE}
+        aws s3 cp ${LOCAL_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TARGET_NAME}

--- a/.github/actions/upload_to_s3/action.yaml
+++ b/.github/actions/upload_to_s3/action.yaml
@@ -13,10 +13,6 @@ inputs:
   role-to-assume:
     description: ARN of the role to assume
     required: false
-  compress:
-    description: Whether to compress the artifact before uploading
-    required: false
-    default: "false"
 
 runs:
   using: composite
@@ -30,7 +26,6 @@ runs:
 
     - name: Compress input
       shell: bash
-      if: ${{ inputs.compress == 'true' }}
       run: |
         TAR_FILE="${{ inputs.name }}.tar.gz"
         tar -czvf "${TAR_FILE}" -C ${{ inputs.path }} .
@@ -43,4 +38,4 @@ runs:
         GIT_SHA=$(git rev-parse --short HEAD)
         DATE=$(date "+%Y-%m-%d")
 
-        aws s3 cp ${TAR_FILE:-${{ inputs.path }}} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TAR_FILE}
+        aws s3 cp ${TAR_FILE} s3://${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${TAR_FILE}

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -148,3 +148,4 @@ jobs:
           name: wheels-sdist
           path: dist/context_py-0.1.0.tar.gz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
+          compress: "false"

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -87,7 +87,7 @@ jobs:
         if: "!cancelled() && github.event_name != 'pull_request'"
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}.tar.gz
           path: dist
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
 
@@ -121,7 +121,7 @@ jobs:
         if: "!cancelled() && github.event_name != 'pull_request'"
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-macos-${{ matrix.platform.target }}.tar.gz
           path: dist
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
   sdist:
@@ -145,7 +145,7 @@ jobs:
         if: "!cancelled() && github.event_name != 'pull_request'"
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
-          name: wheels-sdist
+          name: wheels-sdist.tar.gz
           path: dist/context_py-0.1.0.tar.gz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
           compress: "false"

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -146,5 +146,5 @@ jobs:
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
           name: wheels-sdist
-          path: dist
+          path: dist/context_py-0.1.0.tar.gz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -39,6 +39,6 @@ jobs:
         if: "!cancelled() && github.event_name != 'pull_request'"
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
-          name: js
+          name: js.tar.gz
           path: context-js/pkg
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,3 +42,4 @@ jobs:
           name: js
           path: context-js/pkg
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
+          compress: "true"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,4 +42,3 @@ jobs:
           name: js
           path: context-js/pkg
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
-          compress: "true"


### PR DESCRIPTION
The sdist package comes pre-tar'd. I've cleaned this up so we can install it directly from S3!

It's still missing typings/stubs so I'm handling that as a follow-up.