### PR TITLE
(Fix): Add more stubs

### DIFF
--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 use thiserror::Error;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
@@ -46,7 +46,7 @@ mod ci_platform_env_key {
     pub const DRONE: &str = "DRONE";
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CIPlatform {
@@ -304,7 +304,7 @@ impl<'a> CIInfoParser<'a> {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all), gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CIInfo {
@@ -322,7 +322,7 @@ pub struct CIInfo {
     pub title: Option<String>,
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BranchClass {

--- a/context/src/env/validator.rs
+++ b/context/src/env/validator.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 use thiserror::Error;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
@@ -14,7 +14,7 @@ pub const MAX_BRANCH_NAME_LEN: usize = 36;
 pub const MAX_EMAIL_LEN: usize = 254;
 pub const MAX_FIELD_LEN: usize = 1000;
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EnvValidationLevel {
@@ -261,7 +261,7 @@ pub fn validate(ci_info: &CIInfo) -> EnvValidation {
     env_validation
 }
 
-#[cfg_attr(feature = "pyo3", pyclass, gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EnvValidation {
@@ -269,7 +269,7 @@ pub struct EnvValidation {
     issues: Vec<EnvValidationIssue>,
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EnvValidationFlatIssue {

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -4,14 +4,14 @@ use chrono::DateTime;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 use quick_junit::{
     NonSuccessKind, Property, Report, TestCase, TestCaseStatus, TestRerun, TestSuite,
 };
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all), gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsReport {
@@ -86,7 +86,7 @@ impl Into<Report> for BindingsReport {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestSuite {
@@ -215,7 +215,7 @@ impl Into<TestSuite> for BindingsTestSuite {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsProperty {
@@ -242,7 +242,7 @@ impl Into<Property> for BindingsProperty {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestCase {
@@ -355,7 +355,7 @@ impl TryInto<TestCase> for BindingsTestCase {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestCaseStatus {
@@ -440,7 +440,7 @@ impl TryInto<TestCaseStatus> for BindingsTestCaseStatus {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BindingsTestCaseStatusStatus {
@@ -449,7 +449,7 @@ pub enum BindingsTestCaseStatusStatus {
     Skipped,
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestCaseStatusSuccess {
@@ -468,7 +468,7 @@ impl Into<TestCaseStatus> for BindingsTestCaseStatusSuccess {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestCaseStatusNonSuccess {
@@ -498,7 +498,7 @@ impl Into<TestCaseStatus> for BindingsTestCaseStatusNonSuccess {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestCaseStatusSkipped {
@@ -522,7 +522,7 @@ impl Into<TestCaseStatus> for BindingsTestCaseStatusSkipped {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
 pub struct BindingsTestRerun {
@@ -594,7 +594,7 @@ impl Into<TestRerun> for BindingsTestRerun {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BindingsNonSuccessKind {

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -190,7 +190,7 @@ pub fn validate(report: &Report) -> JunitReportValidation {
     report_validation
 }
 
-#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq, get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitReportValidation {

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 use quick_junit::Report;
 use thiserror::Error;
 #[cfg(feature = "wasm")]
@@ -17,7 +17,7 @@ pub const MAX_FIELD_LEN: usize = 1_000;
 const TIMESTAMP_OLD_DAYS: u32 = 30;
 const TIMESTAMP_STALE_HOURS: u32 = 1;
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum JunitValidationLevel {
@@ -190,14 +190,14 @@ pub fn validate(report: &Report) -> JunitReportValidation {
     report_validation
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq), gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitReportValidation {
     test_suites: Vec<JunitTestSuiteValidation>,
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitReportValidationFlatIssue {
@@ -317,7 +317,7 @@ impl ToString for JunitTestSuiteValidationIssue {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitTestSuiteValidation {
@@ -406,7 +406,7 @@ impl ToString for JunitTestCaseValidationIssue {
     }
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JunitTestCaseValidation {

--- a/context/src/repo/mod.rs
+++ b/context/src/repo/mod.rs
@@ -23,7 +23,7 @@ struct BundleRepoOptions {
     repo_head_commit_epoch: Option<i64>,
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all), gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BundleRepo {
@@ -221,7 +221,7 @@ impl BundleRepo {
 
 /// The [`Repo` common type](https://github.com/trunk-io/trunk/blob/518397f/trunk/services/common/types/repo.ts#L10)
 // NOTE: This is named `RepoUrlParts` to prevent confusion as to its purpose
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RepoUrlParts {

--- a/context/src/repo/validator.rs
+++ b/context/src/repo/validator.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum};
 use thiserror::Error;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
@@ -18,7 +18,7 @@ pub const MAX_FIELD_LEN: usize = 1000;
 const TIMESTAMP_OLD_DAYS: u32 = 30;
 const TIMESTAMP_STALE_HOURS: u32 = 1;
 
-#[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RepoValidationLevel {
@@ -177,7 +177,7 @@ pub fn validate(bundle_repo: &BundleRepo) -> RepoValidation {
     repo_validation
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(eq), gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RepoValidation {
@@ -185,7 +185,7 @@ pub struct RepoValidation {
     issues: Vec<RepoValidationIssue>,
 }
 
-#[cfg_attr(feature = "pyo3", pyclass(get_all))]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RepoValidationFlatIssue {


### PR DESCRIPTION
Follow-up to #142. Turns out order matters, such that
```rust
#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
```
is correct in order to actually generate types for the structs. I added stubs/types for more structs, but I wasn't able to address all of them. For example, `RepoValidation` depends on non-simple enum `RepoValidationIssue`, which the built-in macro doesn't support, and I couldn't get the `#[pyo3(get)]` to play nice. Regardless, this is a big step forward, and we can easily update these whenever we need to.