### PR TITLE
mock junits without testsuites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
  "quick-junit",
- "quick-xml",
+ "quick-xml 0.36.2",
  "regex",
  "serde",
  "serde_json",
@@ -1649,6 +1649,7 @@ dependencies = [
  "fake",
  "humantime",
  "quick-junit",
+ "quick-xml 0.37.0",
  "rand",
 ]
 
@@ -2265,7 +2266,7 @@ dependencies = [
  "chrono",
  "indexmap",
  "newtype-uuid",
- "quick-xml",
+ "quick-xml 0.36.2",
  "strip-ansi-escapes",
  "thiserror",
  "uuid",
@@ -2276,6 +2277,15 @@ name = "quick-xml"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
 dependencies = [
  "memchr",
 ]

--- a/cli-tests/src/utils.rs
+++ b/cli-tests/src/utils.rs
@@ -28,7 +28,8 @@ pub fn generate_mock_git_repo<T: AsRef<Path>>(directory: T) {
 pub fn generate_mock_valid_junit_xmls<T: AsRef<Path>>(directory: T) {
     let mut jm = JunitMock::new(junit_mock::Options::default());
     let reports = jm.generate_reports();
-    JunitMock::write_reports_to_file(directory.as_ref(), reports).unwrap();
+    jm.write_reports_to_file(directory.as_ref(), reports)
+        .unwrap();
 }
 
 pub fn generate_mock_invalid_junit_xmls<T: AsRef<Path>>(directory: T) {
@@ -36,7 +37,8 @@ pub fn generate_mock_invalid_junit_xmls<T: AsRef<Path>>(directory: T) {
     jm_options.test_suite.test_suite_names = Some(vec!["".to_string()]);
     let mut jm = JunitMock::new(jm_options);
     let reports = jm.generate_reports();
-    JunitMock::write_reports_to_file(directory.as_ref(), reports).unwrap();
+    jm.write_reports_to_file(directory.as_ref(), reports)
+        .unwrap();
 }
 
 pub fn generate_mock_suboptimal_junit_xmls<T: AsRef<Path>>(directory: T) {
@@ -46,7 +48,8 @@ pub fn generate_mock_suboptimal_junit_xmls<T: AsRef<Path>>(directory: T) {
         .checked_sub_signed(TimeDelta::hours(24));
     let mut jm = JunitMock::new(jm_options);
     let reports = jm.generate_reports();
-    JunitMock::write_reports_to_file(directory.as_ref(), reports).unwrap();
+    jm.write_reports_to_file(directory.as_ref(), reports)
+        .unwrap();
 }
 
 pub fn generate_mock_codeowners<T: AsRef<Path>>(directory: T) {

--- a/junit-mock/Cargo.toml
+++ b/junit-mock/Cargo.toml
@@ -18,4 +18,5 @@ clap = { version = "4.4.18", features = ["derive", "env"] }
 fake = "2.9.2"
 humantime = "2.1.0"
 quick-junit = "0.5.0"
+quick-xml = "0.37.0"
 rand = "0.8.5"

--- a/junit-mock/src/main.rs
+++ b/junit-mock/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
 
     let reports = jm.generate_reports();
 
-    JunitMock::write_reports_to_file(directory, &reports)?;
+    jm.write_reports_to_file(directory, &reports)?;
 
     Ok(())
 }


### PR DESCRIPTION
Some junit reporters don't include a top-level `testsuites` element. This emulates that by removing the top-level `testsuites` element.