### PR TITLE
(Fix): Use proper pnpm pack

### DIFF
--- a/.github/actions/upload_to_s3/action.yaml
+++ b/.github/actions/upload_to_s3/action.yaml
@@ -13,10 +13,6 @@ inputs:
   role-to-assume:
     description: ARN of the role to assume
     required: false
-  compress:
-    description: Whether to compress the artifact before uploading
-    required: false
-    default: "true"
   s3-flags:
     description: Additional flags to pass to the `aws s3 cp` command
     required: false
@@ -31,21 +27,12 @@ runs:
         role-skip-session-tagging: true
         aws-region: us-west-2
 
-    - name: Compress input
-      shell: bash
-      if: ${{ inputs.compress == 'true' }}
-      run: |
-        TAR_FILE="${{ inputs.name }}"
-        tar -czvf "${TAR_FILE}" -C ${{ inputs.path }} .
-        echo "Compressed folder ${{ inputs.path }} to ${TAR_FILE}"
-        echo TAR_FILE=${TAR_FILE}>> $GITHUB_ENV
-
     - name: Upload artifact to S3
       shell: bash
       run: |
         GIT_SHA=$(git rev-parse --short HEAD)
         DATE=$(date "+%Y-%m-%d")
-        LOCAL_FILE=${TAR_FILE:-${{ inputs.path }}}
+        LOCAL_FILE=${{ inputs.path }}
         TARGET_PATH="${{ inputs.bucket }}/${DATE}/${GIT_SHA}/${{ inputs.name }}"
 
         aws s3 cp ${{ inputs.s3-flags }} ${LOCAL_FILE} s3://${TARGET_PATH}

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -96,7 +96,6 @@ jobs:
           path: dist
           s3-flags: --recursive
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
-          compress: "false"
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -137,7 +136,6 @@ jobs:
           path: dist
           s3-flags: --recursive
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
-          compress: "false"
   sdist:
     # TODO(TRUNK-13050): update to `ubuntu-latest` when `maturin-action` gets updated to support it
     # https://github.com/PyO3/maturin-action/issues/291
@@ -167,4 +165,3 @@ jobs:
           name: wheels-sdist.tar.gz
           path: dist/context_py-0.1.0.tar.gz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
-          compress: "false"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -43,7 +43,7 @@ jobs:
         if: "!cancelled() && github.event_name != 'pull_request'"
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
-          name: context-js-1.0.0.tgz
-          path: context-js/pkg/context-js-1.0.0.tgz
+          name: context-js-0.1.0.tgz
+          path: context-js/pkg/context-js-0.1.0.tgz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
           compress: "false"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Package wasm package
         if: "!cancelled()"
-        run: pnpm pack --dir ./context-js
+        run: pnpm pack --dir ./context-js/pkg
 
       - name: Upload wasm package to S3
         uses: ./.github/actions/upload_to_s3
@@ -44,6 +44,6 @@ jobs:
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
           name: context-js-1.0.0.tgz
-          path: context-js/context-js-1.0.0.tgz
+          path: context-js/pkg/context-js-1.0.0.tgz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
           compress: "false"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -34,11 +34,16 @@ jobs:
         if: "!cancelled()"
         run: pnpm run --dir ./context-js test
 
+      - name: Package wasm package
+        if: "!cancelled()"
+        run: pnpm pack --dir ./context-js
+
       - name: Upload wasm package to S3
         uses: ./.github/actions/upload_to_s3
         if: "!cancelled() && github.event_name != 'pull_request'"
         with:
           bucket: ${{ secrets.S3_ASSET_BUCKET }}
-          name: js.tar.gz
-          path: context-js/pkg
+          name: context-js-1.0.0.tgz
+          path: context-js/context-js-1.0.0.tgz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
+          compress: "false"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -46,4 +46,3 @@ jobs:
           name: context-js-0.1.0.tgz
           path: context-js/pkg/context-js-0.1.0.tgz
           role-to-assume: ${{ secrets.S3_UPLOAD_ROLE_ARN }}
-          compress: "false"

--- a/context-js/package.json
+++ b/context-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-js",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "build": "wasm-pack build --target nodejs",


### PR DESCRIPTION
In reality this is a no-op, but it's more idiomatic to use `pnpm pack`. This also corrects a version mismatch and unifies compression behavior across the different uploaders.