### PR TITLE
(Fix): Improve compatibility of python bindings

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -43,9 +43,9 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ./context-py/Cargo.toml
-          manylinux: auto
+          manylinux: 2014/2_17
           # DONOTLAND: TODO: TYLER MAKE SURE THIS WORKS LOCALLY FOR 3.12
-          container: 2014/2_17
+          container: quay.io/pypa/manylinux2014_x86_64:latest
           before-script-linux: |
             # Needed for `openssl-sys`:
             # https://docs.rs/openssl/latest/openssl/

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ./context-py/Cargo.toml
-          manylinux: 2014/2_17
+          manylinux: auto
           # DONOTLAND: TODO: TYLER MAKE SURE THIS WORKS LOCALLY FOR 3.12
           container: quay.io/pypa/manylinux2014_x86_64:latest
           before-script-linux: |

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -52,7 +52,7 @@ jobs:
             if [ -f /usr/bin/yum ]; then
               # quay.io/pypa/manylinux2014_x86_64:latest
               /usr/bin/yum -y upgrade
-              /usr/bin/yum -y install perl-IPC-Cmd openssl-devel python3-pip
+              /usr/bin/yum -y install perl-IPC-Cmd perl-List-MoreUtils openssl-devel python3-pip
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
 
               # /usr/bin/yum -y upgrade

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -49,14 +49,18 @@ jobs:
           before-script-linux: |
             # Needed for `openssl-sys`:
             # https://docs.rs/openssl/latest/openssl/
-            if [ -f /usr/bin/dnf ]; then
-              # quay.io/pypa/manylinux_2_28_x86_64:latest
-              /usr/bin/dnf -y upgrade
-              /usr/bin/dnf -y install pkgconf perl-IPC-Cmd openssl-devel python3-pip
+            if [ -f /usr/bin/yum ]; then
+              # quay.io/pypa/manylinux2014_x86_64:latest
+              /usr/bin/yum -y upgrade
+              /usr/bin/yum -y install perl-IPC-Cmd openssl-devel python3-pip
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
-              /usr/bin/ln -sf /usr/bin/python3.11 /usr/bin/python3
+
+              # /usr/bin/yum -y upgrade
+              # /usr/bin/yum -y install pkgconf perl-IPC-Cmd openssl-devel python3-pip
+              # /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
+              # /usr/bin/ln -sf /usr/bin/python3.11 /usr/bin/python3
             elif [ -f /usr/bin/apt ]; then
-              # ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+              # ghcr.io/rust-cross/manylinux2014-cross:aarch64
               /usr/bin/apt update
               /usr/bin/apt install -y pkg-config libssl-dev
             fi

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -44,18 +44,19 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ./context-py/Cargo.toml
           manylinux: auto
-          container: "2_28"
+          # DONOTLAND: TODO: TYLER MAKE SURE THIS WORKS LOCALLY FOR 3.12
+          container: 2014/2_17
           before-script-linux: |
             # Needed for `openssl-sys`:
             # https://docs.rs/openssl/latest/openssl/
             if [ -f /usr/bin/dnf ]; then
-              # quay.io/pypa/manylinux_2_28_x86_64:latest
+              # 	quay.io/pypa/manylinux2014_x86_64:latest
               /usr/bin/dnf -y upgrade
               /usr/bin/dnf -y install pkgconf perl-IPC-Cmd openssl-devel python3-pip
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
               /usr/bin/ln -sf /usr/bin/python3.11 /usr/bin/python3
             elif [ -f /usr/bin/apt ]; then
-              # ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+              # ghcr.io/rust-cross/manylinux2014-cross:aarch64
               /usr/bin/apt update
               /usr/bin/apt install -y pkg-config libssl-dev
             fi

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -44,19 +44,19 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ./context-py/Cargo.toml
           manylinux: auto
-          # DONOTLAND: TODO: TYLER MAKE SURE THIS WORKS LOCALLY FOR 3.12
-          container: quay.io/pypa/manylinux2014_x86_64:latest
+          container: "2_17"
+          # DONOTLAND: CLEAN UP
           before-script-linux: |
             # Needed for `openssl-sys`:
             # https://docs.rs/openssl/latest/openssl/
             if [ -f /usr/bin/dnf ]; then
-              # 	quay.io/pypa/manylinux2014_x86_64:latest
+              # quay.io/pypa/manylinux_2_28_x86_64:latest
               /usr/bin/dnf -y upgrade
               /usr/bin/dnf -y install pkgconf perl-IPC-Cmd openssl-devel python3-pip
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
               /usr/bin/ln -sf /usr/bin/python3.11 /usr/bin/python3
             elif [ -f /usr/bin/apt ]; then
-              # ghcr.io/rust-cross/manylinux2014-cross:aarch64
+              # ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
               /usr/bin/apt update
               /usr/bin/apt install -y pkg-config libssl-dev
             fi

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -44,8 +44,8 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ./context-py/Cargo.toml
           manylinux: auto
+          # Required version in order to support Glue
           container: "2_17"
-          # DONOTLAND: CLEAN UP
           before-script-linux: |
             # Needed for `openssl-sys`:
             # https://docs.rs/openssl/latest/openssl/

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -54,11 +54,6 @@ jobs:
               /usr/bin/yum -y upgrade
               /usr/bin/yum -y install perl-IPC-Cmd perl-List-MoreUtils openssl-devel python3-pip
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
-
-              # /usr/bin/yum -y upgrade
-              # /usr/bin/yum -y install pkgconf perl-IPC-Cmd openssl-devel python3-pip
-              # /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
-              # /usr/bin/ln -sf /usr/bin/python3.11 /usr/bin/python3
             elif [ -f /usr/bin/apt ]; then
               # ghcr.io/rust-cross/manylinux2014-cross:aarch64
               /usr/bin/apt update

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - uses: trunk-io/trunk-action/setup@v1
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "js-sys",
  "junit-mock",
  "openssl",
+ "openssl-src",
  "pretty_assertions",
  "pyo3",
  "pyo3-stub-gen",
@@ -1989,9 +1990,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
@@ -3308,6 +3309,7 @@ dependencies = [
  "lazy_static",
  "log",
  "openssl",
+ "openssl-src",
  "quick-junit",
  "regex",
  "reqwest",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,6 +42,7 @@ codeowners = { path = "../codeowners" }
 xcresult = { path = "../xcresult" }
 sentry = { version = "0.34.0", features = ["debug-images"] }
 openssl = { version = "0.10.66", features = ["vendored"] }
+openssl-src = "=300.3.1+3.3.1"
 uuid = { version = "1.10.0", features = ["v5"] }
 quick-junit = "0.5.0"
 colored = "2.1.0"

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -14,5 +14,5 @@ path = "bin/stub_gen.rs"
 
 [dependencies]
 context = { path = "../context", features = ["git-access", "pyo3"] }
-pyo3 = "0.22.5"
+pyo3 = { version = "0.22.5", features = ["abi3-py39", "extension-module"] }
 pyo3-stub-gen = "0.6.0"

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -14,5 +14,10 @@ path = "bin/stub_gen.rs"
 
 [dependencies]
 context = { path = "../context", features = ["git-access", "pyo3"] }
-pyo3 = { version = "0.22.5", features = ["abi3-py39", "extension-module"] }
 pyo3-stub-gen = "0.6.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+pyo3 = { version = "0.22.5", features = ["abi3-py39", "extension-module"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+pyo3 = { version = "0.22.5", features = ["abi3-py39"] }

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -16,7 +16,10 @@ gix = { version = "0.63.0", default-features = false, features = [
 ], optional = true }
 js-sys = { version = "0.3.70", optional = true }
 openssl = { version = "0.10.66", features = ["vendored"], optional = true }
-pyo3 = { version = "0.22.5", optional = true }
+pyo3 = { version = "0.22.5", optional = true, features = [
+  "abi3-py39",
+  "extension-module",
+] }
 pyo3-stub-gen = { version = "0.6.0", optional = true }
 quick-junit = "0.5.0"
 quick-xml = "0.36.2"

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -16,10 +16,6 @@ gix = { version = "0.63.0", default-features = false, features = [
 ], optional = true }
 js-sys = { version = "0.3.70", optional = true }
 openssl = { version = "0.10.66", features = ["vendored"], optional = true }
-pyo3 = { version = "0.22.5", optional = true, features = [
-  "abi3-py39",
-  "extension-module",
-] }
 pyo3-stub-gen = { version = "0.6.0", optional = true }
 quick-junit = "0.5.0"
 quick-xml = "0.36.2"
@@ -30,6 +26,15 @@ speedate = "0.14.4"
 thiserror = "1.0.63"
 uuid = { version = "1.10.0", features = ["v5"] }
 wasm-bindgen = { version = "0.2.84", optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+pyo3 = { version = "0.22.5", optional = true, features = [
+  "abi3-py39",
+  "extension-module",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+pyo3 = { version = "0.22.5", optional = true, features = ["abi3-py39"] }
 
 [features]
 default = ["git-access"]

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -16,6 +16,7 @@ gix = { version = "0.63.0", default-features = false, features = [
 ], optional = true }
 js-sys = { version = "0.3.70", optional = true }
 openssl = { version = "0.10.66", features = ["vendored"], optional = true }
+openssl-src = { version = "=300.3.1+3.3.1", optional = true }
 pyo3-stub-gen = { version = "0.6.0", optional = true }
 quick-junit = "0.5.0"
 quick-xml = "0.36.2"


### PR DESCRIPTION
Adds features [abi3-py39](https://pyo3.rs/v0.14.5/features.html#abi3-py36--abi3-py37--abi3-py38--abi3-py39), to support more python versions, and [extension-module](https://pyo3.rs/v0.14.5/features.html#extension-module), to skip linking against `libpython.so`. `extension-module` can only be applied on Linux. Also fixes the version to be compatible on Glue (see [openssl note](https://github.com/openssl/openssl/issues/25366)).

Works in our CI setup