### PR TITLE
[TRUNK-13166] More accurate log message for failed test run w/ --use-quarantining enabled

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -168,7 +168,7 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
         .unwrap_or(run_exit_code);
 
     let exec_start = run_result.exec_start;
-    match run_upload(
+    if let Err(e) = run_upload(
         upload_args,
         Some(command.join(" ")),
         None, // don't re-run quarantine checks
@@ -177,10 +177,7 @@ async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
     )
     .await
     {
-        Ok(EXIT_SUCCESS) => (),
-        Ok(code) => log::error!("Error uploading test results: {}", code),
-        // TODO(TRUNK-12558): We should fail on configuration error _prior_ to running a test
-        Err(e) => log::error!("Error uploading test results: {:?}", e),
+        log::error!("Error uploading test results: {:?}", e)
     };
 
     Ok(exit_code)

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -287,7 +287,14 @@ pub async fn run_upload(
         })
         .await?;
 
-    log::info!("Done");
+    if exit_code == EXIT_SUCCESS {
+        log::info!("Done");
+    } else {
+        log::info!(
+            "Upload successful; returning unsuccessful exit code of test run: {}",
+            exit_code
+        )
+    }
     Ok(exit_code)
 }
 


### PR DESCRIPTION
[TRUNK-13166](https://linear.app/trunk/issue/TRUNK-13166/qa-bug-cli-prints-error-uploading-test-results-even-when-it-succeeds)

Only logs `"Error uploading test results: ..."` when the upload step itself actually errors. When the upload step succeeds, but the test run contains non-quarantined failures with `--use-quarantining` enabled, logs `"Upload successful; returning unsuccessful exit code of test run: {exit_code}"`

Before:

```
~/src/analytics-cli/target/x86_64-unknown-linux-musl/release/trunk-analytics-cli test --token <redacted> --org-url-slug trunk --junit-paths **/jest_junit_test.xml --use-quarantining npm run jest-test

...

Ran all test suites matching /javascript\/tests\/jest\/__tests__\/jest.js/i.
2024-11-05T15:34:44 [INFO] - Command exit code: 1
2024-11-05T15:34:45 [INFO] - Checking if failed tests can be quarantined
2024-11-05T15:34:45 [INFO] - Quarantining is not enabled, not quarantining any tests
2024-11-05T15:34:45 [INFO] - Checking if failed tests can be quarantined
2024-11-05T15:34:45 [INFO] - Quarantining is not enabled, not quarantining any tests
2024-11-05T15:34:46 [INFO] - Total files pack and upload: 1
2024-11-05T15:34:46 [INFO] - Total bytes in: 8388, total bytes out: 2572 (size reduction: 69.34%)
2024-11-05T15:34:46 [INFO] - Flushed temporary tarball to "/tmp/.tmpbl5RrT/bundle.tar.zstd"
2024-11-05T15:34:46 [INFO] - Done
2024-11-05T15:34:46 [ERROR] - Error uploading test results: 1
```

After:

```
max@max-cloudtop:~/src/flake-factory$ ~/src/analytics-cli/target/x86_64-unknown-linux-musl/release/trunk-analytics-cli test --token <redacted> --org-url-slug trunk --junit-paths **/jest_junit_test.xml --use-quarantining npm run jest-test

...

Ran all test suites matching /javascript\/tests\/jest\/__tests__\/jest.js/i.
2024-11-05T15:32:28 [INFO] - Command exit code: 1
2024-11-05T15:32:28 [INFO] - Checking if failed tests can be quarantined
2024-11-05T15:32:29 [INFO] - Quarantining is not enabled, not quarantining any tests
2024-11-05T15:32:29 [INFO] - Checking if failed tests can be quarantined
2024-11-05T15:32:29 [INFO] - Quarantining is not enabled, not quarantining any tests
2024-11-05T15:32:29 [INFO] - Total files pack and upload: 1
2024-11-05T15:32:29 [INFO] - Total bytes in: 8392, total bytes out: 2576 (size reduction: 69.30%)
2024-11-05T15:32:29 [INFO] - Flushed temporary tarball to "/tmp/.tmpNIFN29/bundle.tar.zstd"
2024-11-05T15:32:30 [INFO] - Upload successful; returning unsuccessful exit code of test run: 1
```