### PR TITLE
Add clear log message for empty xcresult

### DIFF
--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -123,6 +123,13 @@ pub async fn run_upload(
     {
         let temp_paths = handle_xcresult(&junit_temp_dir, xcresult_path)?;
         junit_paths = [junit_paths.as_slice(), temp_paths.as_slice()].concat();
+        if junit_paths.is_empty() && !allow_missing_junit_files {
+            return Err(anyhow::anyhow!(
+                "No tests found in the provided XCResult path."
+            ));
+        } else if junit_paths.is_empty() && allow_missing_junit_files {
+            log::warn!("No tests found in the provided XCResult path.");
+        }
     }
 
     let (file_sets, file_counter) = build_filesets(


### PR DESCRIPTION
Add a clearer error message for when we are unable to locate tests in the xcresult path.