### PR TITLE
Update usage statement to reflect trunk flakytests

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,8 @@ use trunk_analytics_cli::{
 #[command(
     version = std::env!("CARGO_PKG_VERSION"),
     name = "trunk-analytics-cli",
-    about = "Trunk Analytics CLI"
+    about = "Trunk Flaky Tests CLI",
+    bin_name = "trunk flakytests",
 )]
 struct Cli {
     #[command(subcommand)]
@@ -52,8 +53,11 @@ struct ValidateArgs {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Upload data to Trunk Flaky Tests
     Upload(UploadArgs),
+    /// Run a test command and upload data to Trunk Flaky Tests
     Test(TestArgs),
+    /// Validate that your test runner output is suitable for Trunk Flaky Tests
     Validate(ValidateArgs),
 }
 
@@ -223,7 +227,7 @@ fn setup_logger() -> anyhow::Result<()> {
 
 fn print_cli_start_info() {
     log::info!(
-        "Starting trunk-analytics-cli {} (git={}) rustc={}",
+        "Starting trunk flakytests {} (git={}) rustc={}",
         env!("CARGO_PKG_VERSION"),
         env!("VERGEN_GIT_SHA"),
         env!("VERGEN_RUSTC_SEMVER")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,7 @@ use trunk_analytics_cli::{
 #[derive(Debug, Parser)]
 #[command(
     version = std::env!("CARGO_PKG_VERSION"),
-    name = "trunk-analytics-cli",
+    name = "trunk flakytests",
     about = "Trunk Flaky Tests CLI",
     bin_name = "trunk flakytests",
 )]


### PR DESCRIPTION
[TRUNK-13341](https://linear.app/trunk/issue/TRUNK-13341/qa-bug-running-trunk-flakytests-gives-usage-examples-that-still-say), [TRUNK-13339](https://linear.app/trunk/issue/TRUNK-13339/add-usage-statement-in-trunk-flakytests-subcommands)

Updates the usage statement to reflect `trunk flakytests` as that's how this will be invoked going forward. Open to suggestions on command descriptions!

```
max@max-cloudtop:~/src/analytics-cli$ ./trunk-analytics-cli --help
Trunk Flaky Tests CLI

Usage: trunk flakytests <COMMAND>

Commands:
  upload    Upload data to Trunk Flaky Tests
  test      Run a test command and upload data to Trunk Flaky Tests
  validate  Validate that your test runner output is suitable for Trunk Flaky Tests
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```