### PR TITLE
[TRUNK-13509] Remove onboarding link

### DIFF
--- a/cli/src/validate.rs
+++ b/cli/src/validate.rs
@@ -181,10 +181,6 @@ fn print_summary_success(num_reports: usize, num_suboptimal_reports: usize) {
         num_validation_warnings_str,
         Emoji(" ✅", ""),
     );
-    println!(
-        "Navigate to https://app.trunk.io/onboarding?intent=flaky+tests to continue using Trunk Flaky Tests!{}",
-        Emoji(" 🚀🧪", ""),
-    );
 }
 
 fn print_validation_errors(report_validations: &JunitFileToValidation) -> (usize, usize) {


### PR DESCRIPTION
[TRUNK-13509](https://linear.app/trunk/issue/TRUNK-13509/remove-link-to-flaky-tests-from-cli-output)

Usability testers suggested the link led them to a confusing location. Removing for now