### PR TITLE
fix: require non empty string value in value parser

### DIFF
--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -37,6 +37,22 @@ fn validate_no_junits() {
 }
 
 #[test]
+fn validate_empty_junit_paths() {
+    let temp_dir = tempdir().unwrap();
+
+    let assert = Command::new(CARGO_RUN.path())
+        .current_dir(&temp_dir)
+        .args(&["validate", "--junit-paths", ""])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "error: a value is required for '--junit-paths <JUNIT_PATHS>' but none was supplied",
+        ));
+
+    println!("{assert}");
+}
+
+#[test]
 fn validate_invalid_junits() {
     let temp_dir = tempdir().unwrap();
     generate_mock_invalid_junit_xmls(&temp_dir);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -44,6 +44,7 @@ struct ValidateArgs {
         long,
         required = true,
         value_delimiter = ',',
+        value_parser = clap::builder::NonEmptyStringValueParser::new(),
         help = "Comma-separated list of glob paths to junit files."
     )]
     junit_paths: Vec<String>,

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -28,6 +28,7 @@ pub struct UploadArgs {
         long,
         required_unless_present = junit_require(),
         value_delimiter = ',',
+        value_parser = clap::builder::NonEmptyStringValueParser::new(),
         help = "Comma-separated list of glob paths to junit files."
     )]
     pub junit_paths: Vec<String>,


### PR DESCRIPTION
Require non empty string value for parsing --junit-paths