### PR TITLE
(Fix): Set 0.0.0 so release script can set CLI version correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bundle"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "constants"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "context"
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "xcresult"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "trunk-analytics-cli"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "api",

--- a/bundle/Cargo.toml
+++ b/bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bundle"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "trunk-analytics-cli"
 edition = "2021"
-version = "0.1.0"
+# Must be 0.0.0 in order for release workflow to update
+version = "0.0.0"
 
 [[bin]]
 name = "trunk-analytics-cli"

--- a/constants/Cargo.toml
+++ b/constants/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "constants"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"

--- a/context-js/Cargo.toml
+++ b/context-js/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "context-js"
+# Needs to match package.json
 version = "0.1.0"
 edition = "2021"
 

--- a/xcresult/Cargo.toml
+++ b/xcresult/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xcresult"
 edition = "2021"
-version = "0.1.0"
+version = "0.0.0"
 
 [lib]
 name = "xcresult"


### PR DESCRIPTION
Fixes bug introduced in https://github.com/trunk-io/analytics-cli/pull/161/files#diff-6057d83fb675b27e99f187fa354690b6597018c390cbd50eac854a56233d2addL4