### PR TITLE
[TRUNK-13579] patch junit parser

### DIFF
--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -76,6 +76,9 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(env_parse, m)?)?;
     m.add_function(wrap_pyfunction!(env_validate, m)?)?;
 
+    m.add_class::<junit::bindings::BindingsReport>()?;
+    m.add_class::<junit::bindings::BindingsTestSuite>()?;
+    m.add_class::<junit::bindings::BindingsTestCase>()?;
     m.add_class::<junit::bindings::BindingsTestCaseStatusStatus>()?;
     m.add_class::<junit::bindings::BindingsNonSuccessKind>()?;
     m.add_class::<junit::validator::JunitValidationLevel>()?;

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -28,14 +28,133 @@ def test_env_parse_and_validate():
     ], "\n" + "\n".join([issue.error_message for issue in env_validation.issues_flat()])
 
 
-def test_junit_parse_and_validate():
+def test_junit_parse_valid():
     import typing as PT
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timezone
+
+    from context_py import (
+        BindingsNonSuccessKind,
+        BindingsReport,
+        BindingsTestCaseStatusStatus,
+        junit_parse,
+    )
+
+    MICROSECONDS_PER_SECOND = 1_000_000
+
+    valid_timestamp = datetime.now().astimezone(timezone.utc).isoformat()
+    valid_junit_xml = f"""
+    <testsuites name="my-test-run" tests="1" failures="1" errors="0">
+      <testsuite name="my-test-suite" tests="1" disabled="0" errors="0" failures="1" timestamp="{valid_timestamp}">
+        <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="{valid_timestamp}" time="1">
+          <failure message="AssertionError: assert 'testdata' in '# estdata'">
+            FAILURE BODY
+          </failure>
+
+          <error message="       " type="">
+            <!-- Example of a test case with empty error text. -->
+          </error>
+        </testcase>
+      </testsuite>
+    </testsuites>
+   """
+
+    reports: PT.List[BindingsReport] = junit_parse(str.encode(valid_junit_xml))
+
+    assert len(reports) == 1
+    report = reports[0]
+
+    assert len(report.test_suites) == 1
+    test_suite = report.test_suites[0]
+
+    assert test_suite.timestamp == int(
+        datetime.fromisoformat(valid_timestamp).timestamp()
+    )
+    assert (
+        test_suite.timestamp_micros
+        == datetime.fromisoformat(valid_timestamp).timestamp() * MICROSECONDS_PER_SECOND
+    )
+
+    assert len(test_suite.test_cases) == 1
+    test_case = test_suite.test_cases[0]
+
+    assert test_case.status.status == BindingsTestCaseStatusStatus.NonSuccess
+    assert test_case.status.non_success is not None
+    assert test_case.status.non_success.kind == BindingsNonSuccessKind.Failure
+    assert (
+        test_case.status.non_success.message
+        == "AssertionError: assert 'testdata' in '# estdata'"
+    )
+    assert test_case.status.non_success.description == "FAILURE BODY"
+
+
+def test_junit_parse_non_xml():
+    from context_py import junit_parse
+    from pytest import raises
+
+    simple_string = "no reports here!"
+
+    with raises(Exception) as excinfo:
+        _ = junit_parse(str.encode(simple_string))
+
+    assert str(excinfo.value) == "no reports found"
+
+
+def test_junit_parse_broken_xml():
+    from context_py import junit_parse
+    from pytest import raises
+
+    broken_xml = "<testsuites"
+
+    with raises(Exception) as excinfo:
+        _ = junit_parse(str.encode(broken_xml))
+
+    assert (
+        str(excinfo.value)
+        == "syntax error: tag not closed: `>` not found before end of input"
+    )
+
+
+def test_junit_parse_nested_testsuites():
+    import typing as PT
+
+    from context_py import BindingsReport, BindingsTestCaseStatusStatus, junit_parse
+
+    nested_testsuites_xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+        <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
+            <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
+                <testsuite name="EmailTest" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
+                    <testcase name="testCanBeCreatedFromValidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="6" class="EmailTest" classname="EmailTest" assertions="1" time="0.000860"/>
+                    <testcase name="testCannotBeCreatedFromInvalidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="15" class="EmailTest" classname="EmailTest" assertions="1" time="0.000301"/>
+                </testsuite>
+            </testsuite>
+        </testsuite>
+    </testsuites>"""
+
+    reports: PT.List[BindingsReport] = junit_parse(str.encode(nested_testsuites_xml))
+
+    assert len(reports) == 1
+    report = reports[0]
+
+    assert len(report.test_suites) == 1
+    test_suite = report.test_suites[0]
+    assert (
+        test_suite.name
+        == "/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml"
+    )
+
+    assert len(test_suite.test_cases) == 2
+    for test_case in test_suite.test_cases:
+        assert test_case.status.status == BindingsTestCaseStatusStatus.Success
+
+
+def test_junit_validate_valid():
+    import typing as PT
+    from datetime import datetime, timezone
 
     from context_py import (
         BindingsReport,
         JunitValidationLevel,
-        JunitValidationType,
         junit_parse,
         junit_validate,
     )
@@ -45,14 +164,24 @@ def test_junit_parse_and_validate():
     <testsuites name="my-test-run" tests="1" failures="1" errors="0">
       <testsuite name="my-test-suite" tests="1" disabled="0" errors="0" failures="1" timestamp="{valid_timestamp}">
         <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="{valid_timestamp}" time="1">
-          <failure/>
+          <failure message="AssertionError: assert 'testdata' in '# estdata'">
+            FAILURE BODY
+          </failure>
+
+          <error message="       " type="">
+            <!-- Example of a test case with empty error text. -->
+          </error>
         </testcase>
       </testsuite>
     </testsuites>
    """
 
     reports: PT.List[BindingsReport] = junit_parse(str.encode(valid_junit_xml))
-    junit_report_validation = junit_validate(reports[0])
+
+    assert len(reports) == 1
+    report = reports[0]
+
+    junit_report_validation = junit_validate(report)
 
     assert (
         junit_report_validation.max_level() == JunitValidationLevel.Valid
@@ -63,6 +192,19 @@ def test_junit_parse_and_validate():
             for test_case in test_suite.test_cases_owned()
             for issue in test_case.issues_flat()
         ]
+    )
+
+
+def test_junit_validate_suboptimal():
+    import typing as PT
+    from datetime import datetime, timedelta, timezone
+
+    from context_py import (
+        BindingsReport,
+        JunitValidationLevel,
+        JunitValidationType,
+        junit_parse,
+        junit_validate,
     )
 
     stale_timestamp = (
@@ -78,8 +220,12 @@ def test_junit_parse_and_validate():
     </testsuites>
    """
 
-    reports = junit_parse(str.encode(suboptimal_junit_xml))
-    junit_report_validation = junit_validate(reports[0])
+    reports: PT.List[BindingsReport] = junit_parse(str.encode(suboptimal_junit_xml))
+
+    assert len(reports) == 1
+    report = reports[0]
+
+    junit_report_validation = junit_validate(report)
 
     assert (
         junit_report_validation.max_level() == JunitValidationLevel.SubOptimal

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -29,9 +29,11 @@ def test_env_parse_and_validate():
 
 
 def test_junit_parse_and_validate():
+    import typing as PT
     from datetime import datetime, timedelta, timezone
 
     from context_py import (
+        BindingsReport,
         JunitValidationLevel,
         JunitValidationType,
         junit_parse,
@@ -49,8 +51,8 @@ def test_junit_parse_and_validate():
     </testsuites>
    """
 
-    report = junit_parse(str.encode(valid_junit_xml))
-    junit_report_validation = junit_validate(report[0])
+    reports: PT.List[BindingsReport] = junit_parse(str.encode(valid_junit_xml))
+    junit_report_validation = junit_validate(reports[0])
 
     assert (
         junit_report_validation.max_level() == JunitValidationLevel.Valid
@@ -76,8 +78,8 @@ def test_junit_parse_and_validate():
     </testsuites>
    """
 
-    report = junit_parse(str.encode(suboptimal_junit_xml))
-    junit_report_validation = junit_validate(report[0])
+    reports = junit_parse(str.encode(suboptimal_junit_xml))
+    junit_report_validation = junit_validate(reports[0])
 
     assert (
         junit_report_validation.max_level() == JunitValidationLevel.SubOptimal

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -11,6 +11,8 @@ use quick_junit::{
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
+const MICROSECONDS_PER_SECOND: i64 = 1_000_000;
+
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Clone, Debug)]
@@ -18,6 +20,7 @@ pub struct BindingsReport {
     pub name: String,
     pub uuid: Option<String>,
     pub timestamp: Option<i64>,
+    pub timestamp_micros: Option<i64>,
     pub time: Option<f64>,
     pub tests: usize,
     pub failures: usize,
@@ -42,6 +45,7 @@ impl From<Report> for BindingsReport {
             name: name.into_string(),
             uuid: uuid.map(|u| u.to_string()),
             timestamp: timestamp.map(|t| t.timestamp()),
+            timestamp_micros: timestamp.map(|t| t.timestamp_micros()),
             time: time.map(|t| t.as_secs_f64()),
             tests,
             failures,
@@ -59,7 +63,8 @@ impl Into<Report> for BindingsReport {
         let Self {
             name,
             uuid,
-            timestamp,
+            timestamp: _,
+            timestamp_micros,
             time,
             tests,
             failures,
@@ -71,8 +76,13 @@ impl Into<Report> for BindingsReport {
         Report {
             name: name.into(),
             uuid: None,
-            timestamp: timestamp
-                .and_then(|secs| DateTime::from_timestamp(secs, 0))
+            timestamp: timestamp_micros
+                .and_then(|micro_secs| {
+                    DateTime::from_timestamp(
+                        micro_secs / MICROSECONDS_PER_SECOND,
+                        (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                    )
+                })
                 .map(|dt| dt.fixed_offset()),
             time: time.map(|secs| Duration::from_secs_f64(secs)),
             tests,
@@ -96,6 +106,7 @@ pub struct BindingsTestSuite {
     pub errors: usize,
     pub failures: usize,
     pub timestamp: Option<i64>,
+    pub timestamp_micros: Option<i64>,
     pub time: Option<f64>,
     pub test_cases: Vec<BindingsTestCase>,
     pub properties: Vec<BindingsProperty>,
@@ -157,6 +168,7 @@ impl From<TestSuite> for BindingsTestSuite {
             errors,
             failures,
             timestamp: timestamp.map(|t| t.timestamp()),
+            timestamp_micros: timestamp.map(|t| t.timestamp_micros()),
             time: time.map(|t| t.as_secs_f64()),
             test_cases: test_cases.into_iter().map(BindingsTestCase::from).collect(),
             properties: properties.into_iter().map(BindingsProperty::from).collect(),
@@ -179,7 +191,8 @@ impl Into<TestSuite> for BindingsTestSuite {
             disabled,
             errors,
             failures,
-            timestamp,
+            timestamp: _,
+            timestamp_micros,
             time,
             test_cases,
             properties,
@@ -192,8 +205,13 @@ impl Into<TestSuite> for BindingsTestSuite {
         test_suite.disabled = disabled;
         test_suite.errors = errors;
         test_suite.failures = failures;
-        test_suite.timestamp = timestamp
-            .and_then(|secs| DateTime::from_timestamp(secs, 0))
+        test_suite.timestamp = timestamp_micros
+            .and_then(|micro_secs| {
+                DateTime::from_timestamp(
+                    micro_secs / MICROSECONDS_PER_SECOND,
+                    (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                )
+            })
             .map(|dt| dt.fixed_offset());
         test_suite.time = time.map(|secs| Duration::from_secs_f64(secs));
         test_suite.test_cases = test_cases
@@ -250,6 +268,7 @@ pub struct BindingsTestCase {
     pub classname: Option<String>,
     pub assertions: Option<usize>,
     pub timestamp: Option<i64>,
+    pub timestamp_micros: Option<i64>,
     pub time: Option<f64>,
     pub status: BindingsTestCaseStatus,
     pub system_out: Option<String>,
@@ -307,6 +326,7 @@ impl From<TestCase> for BindingsTestCase {
             classname: classname.map(|c| c.to_string()),
             assertions,
             timestamp: timestamp.map(|t| t.timestamp()),
+            timestamp_micros: timestamp.map(|t| t.timestamp_micros()),
             time: time.map(|t| t.as_secs_f64()),
             status: BindingsTestCaseStatus::from(status),
             system_out: system_out.map(|s| s.to_string()),
@@ -329,7 +349,8 @@ impl TryInto<TestCase> for BindingsTestCase {
             name,
             classname,
             assertions,
-            timestamp,
+            timestamp: _,
+            timestamp_micros,
             time,
             status,
             system_out,
@@ -340,8 +361,13 @@ impl TryInto<TestCase> for BindingsTestCase {
         let mut test_case = TestCase::new(name, status.try_into()?);
         test_case.classname = classname.map(|c| c.into());
         test_case.assertions = assertions;
-        test_case.timestamp = timestamp
-            .and_then(|secs| DateTime::from_timestamp(secs, 0))
+        test_case.timestamp = timestamp_micros
+            .and_then(|micro_secs| {
+                DateTime::from_timestamp(
+                    micro_secs / MICROSECONDS_PER_SECOND,
+                    (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                )
+            })
             .map(|dt| dt.fixed_offset());
         test_case.time = time.map(|secs| Duration::from_secs_f64(secs));
         test_case.system_out = system_out.map(|s| s.into());
@@ -528,6 +554,7 @@ impl Into<TestCaseStatus> for BindingsTestCaseStatusSkipped {
 pub struct BindingsTestRerun {
     pub kind: BindingsNonSuccessKind,
     pub timestamp: Option<i64>,
+    pub timestamp_micros: Option<i64>,
     pub time: Option<f64>,
     pub message: Option<String>,
     pub ty: Option<String>,
@@ -554,6 +581,7 @@ impl From<TestRerun> for BindingsTestRerun {
         Self {
             kind: BindingsNonSuccessKind::from(kind),
             timestamp: timestamp.map(|t| t.timestamp()),
+            timestamp_micros: timestamp.map(|t| t.timestamp_micros()),
             time: time.map(|t| t.as_secs_f64()),
             message: message.map(|m| m.to_string()),
             ty: ty.map(|t| t.to_string()),
@@ -569,7 +597,8 @@ impl Into<TestRerun> for BindingsTestRerun {
     fn into(self) -> TestRerun {
         let Self {
             kind,
-            timestamp,
+            timestamp: _,
+            timestamp_micros,
             time,
             message,
             ty,
@@ -580,8 +609,13 @@ impl Into<TestRerun> for BindingsTestRerun {
         } = self;
         TestRerun {
             kind: kind.into(),
-            timestamp: timestamp
-                .and_then(|secs| DateTime::from_timestamp(secs, 0))
+            timestamp: timestamp_micros
+                .and_then(|micro_secs| {
+                    DateTime::from_timestamp(
+                        micro_secs / MICROSECONDS_PER_SECOND,
+                        (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                    )
+                })
                 .map(|dt| dt.fixed_offset()),
             time: time.map(|secs| Duration::from_secs_f64(secs)),
             message: message.map(|m| m.into()),


### PR DESCRIPTION
Part of [TRUNK-13579](https://linear.app/trunk/issue/TRUNK-13579/move-junit-parsing-out-of-glue-and-into-dagster)

Reconciles some things with respect to junit parsing encountered when using the bindings for python in the ETL.

Summary of changes:
 - Reports either the error returned by `JunitParser::parse()` or any of the errors collected in `JunitParser::errors()` as an error to the caller in the `junit_parse()` pyfunction. Previously would only report the error on `parse()` and ignore any errors collected in `errors()`
 - Exports some additional classes in the `context_py` module
 - Lots more `context_py` junit parsing tests
 - Adds a `timestamp_micros` field to the `BindingsX` classes for timestamps w/ microseconds
 - Fixes an issue in `JunitDateParser::parse_date()` where the cached `self.date_type` was set incorrectly, causing a panic when alternating between parsing datetimes and parsing naive dates. Probably an unlikely scenario? but encountered it in unit testing
 - Modifies the junit parser to ignore nested `<testsuite>`s. Verified that this is what the current [python junit parser](https://github.com/weiwei/junitparser) does
 - Modifies the junit parser to only set `<testcase>` status once. There's a comment in the parser code stating we expect a test case to only have one [status](https://github.com/trunk-io/analytics-cli/blob/25ce229d1e2d8247a6fe93b48740b3e12cf8f93b/context/src/junit/parser.rs#L178), but there's an example junit in the monorepo that has a test case with [two](https://github.com/trunk-io/trunk/blob/c57c36a91c23656328856bee350ce6812b803d73/trunk/py/metrics_data_pipeline/trunk_etl_junit_parser/test_data/basic_junit.xml#L5-L13) 
 - Modifies the junit parser to not treat missing report name as a parsing error. This is parity with the python parser. Doesn't look like we're using report name anywhere downstream in the ETL? And we'd be throwing away a lot of junits if we required it