### PR TITLE
Create repo before signaling bundle upload intent

### DIFF
--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -60,6 +60,21 @@ async fn upload_bundle() {
         })
     );
 
+    assert_eq!(
+        requests_iter.next().unwrap(),
+        RequestPayload::CreateRepo(CreateRepoRequest {
+            repo: Repo {
+                host: String::from("github.com"),
+                owner: String::from("trunk-io"),
+                name: String::from("analytics-cli"),
+            },
+            org_url_slug: String::from("test-org"),
+            remote_urls: Vec::from(&[String::from(
+                "https://github.com/trunk-io/analytics-cli.git"
+            )]),
+        })
+    );
+
     let upload_request = assert_matches!(requests_iter.next().unwrap(), RequestPayload::CreateBundleUpload(ur) => ur);
     assert_eq!(
         upload_request.repo,
@@ -159,21 +174,6 @@ async fn upload_bundle() {
             id: "test-bundle-upload-id".to_string(),
             upload_status: BundleUploadStatus::UploadComplete
         }),
-    );
-
-    assert_eq!(
-        requests_iter.next().unwrap(),
-        RequestPayload::CreateRepo(CreateRepoRequest {
-            repo: Repo {
-                host: String::from("github.com"),
-                owner: String::from("trunk-io"),
-                name: String::from("analytics-cli"),
-            },
-            org_url_slug: String::from("test-org"),
-            remote_urls: Vec::from(&[String::from(
-                "https://github.com/trunk-io/analytics-cli.git"
-            )]),
-        })
     );
 
     // HINT: View CLI output with `cargo test -- --nocapture`

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -209,7 +209,7 @@ pub async fn run_upload(
     api_client
         .create_trunk_repo(&api::CreateRepoRequest {
             repo: repo.repo,
-            org_url_slug.clone(),
+            org_url_slug,
             remote_urls: vec![repo.repo_url.clone()],
         })
         .await?;

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -206,6 +206,14 @@ pub async fn run_upload(
     let envs = EnvScanner::scan_env();
     let os_info: String = env::consts::OS.to_string();
 
+    api_client
+        .create_trunk_repo(&api::CreateRepoRequest {
+            repo: repo.repo,
+            org_url_slug.clone(),
+            remote_urls: vec![repo.repo_url.clone()],
+        })
+        .await?;
+
     let cli_version = format!(
         "cargo={} git={} rustc={}",
         env!("CARGO_PKG_VERSION"),
@@ -304,14 +312,6 @@ pub async fn run_upload(
             BundleUploadStatus::UploadComplete
         )
     }
-
-    api_client
-        .create_trunk_repo(&api::CreateRepoRequest {
-            repo: repo.repo,
-            org_url_slug,
-            remote_urls: vec![repo.repo_url.clone()],
-        })
-        .await?;
 
     if exit_code == EXIT_SUCCESS {
         log::info!("Done");

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -208,8 +208,8 @@ pub async fn run_upload(
 
     api_client
         .create_trunk_repo(&api::CreateRepoRequest {
-            repo: repo.repo,
-            org_url_slug,
+            repo: repo.repo.clone(),
+            org_url_slug: org_url_slug.clone(),
             remote_urls: vec![repo.repo_url.clone()],
         })
         .await?;
@@ -223,8 +223,8 @@ pub async fn run_upload(
     let client_version = format!("trunk-analytics-cli {}", cli_version);
     let upload = api_client
         .create_bundle_upload_intent(&api::CreateBundleUploadRequest {
-            repo: repo.repo.clone(),
-            org_url_slug: org_url_slug.clone(),
+            repo: repo.repo,
+            org_url_slug,
             client_version,
         })
         .await?;

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -223,8 +223,8 @@ pub async fn run_upload(
     let client_version = format!("trunk-analytics-cli {}", cli_version);
     let upload = api_client
         .create_bundle_upload_intent(&api::CreateBundleUploadRequest {
-            repo: repo.repo,
-            org_url_slug,
+            repo: repo.repo.clone(),
+            org_url_slug: org_url_slug.clone(),
             client_version,
         })
         .await?;
@@ -232,8 +232,8 @@ pub async fn run_upload(
     let meta = BundleMeta {
         base_props: BundleMetaBaseProps {
             version: META_VERSION.to_string(),
-            org: org_url_slug.clone(),
-            repo: repo.clone(),
+            org: org_url_slug,
+            repo,
             cli_version,
             bundle_upload_id: upload.id.clone(),
             tags,


### PR DESCRIPTION
Adds a guarantee that repo_id is queryable when uploading a bundle.

We want to start partitioning the hypertables based on repoID instead of ORG, and we can't do that unless we know that the repo exists.