### PR TITLE
Tenest/parse and validate codeowners in validate cmd

### DIFF
--- a/cli/src/api_client/mod.rs
+++ b/cli/src/api_client/mod.rs
@@ -19,7 +19,7 @@ pub struct ApiClient {
 
 impl ApiClient {
     const TRUNK_API_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-    const TRUNK_API_TOKEN_HEADER: &str = "x-api-token";
+    const TRUNK_API_TOKEN_HEADER: &'static str = "x-api-token";
 
     pub fn new(api_token: String) -> anyhow::Result<Self> {
         let trimmed_token = api_token.trim();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,6 +50,8 @@ struct ValidateArgs {
     junit_paths: Vec<String>,
     #[arg(long, help = "Show warning-level log messages in output.")]
     show_warnings: bool,
+    #[arg(long, help = "Value to override CODEOWNERS file or directory path.")]
+    pub codeowners_path: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -199,9 +201,10 @@ async fn run(cli: Cli) -> anyhow::Result<i32> {
             let ValidateArgs {
                 junit_paths,
                 show_warnings,
+                codeowners_path,
             } = validate_args;
             print_cli_start_info();
-            validate(junit_paths, show_warnings).await
+            validate(junit_paths, show_warnings, codeowners_path).await
         }
     }
 }

--- a/cli/src/validate.rs
+++ b/cli/src/validate.rs
@@ -2,6 +2,7 @@ use quick_junit::Report;
 use std::{collections::BTreeMap, io::BufReader};
 
 use bundle::{FileSet, FileSetCounter};
+use codeowners::CodeOwners;
 use colored::{ColoredString, Colorize};
 use console::Emoji;
 use constants::{EXIT_FAILURE, EXIT_SUCCESS};
@@ -18,7 +19,11 @@ use crate::runner::build_filesets;
 type JunitFileToReportAndErrors = BTreeMap<String, (anyhow::Result<Report>, Vec<JunitParseError>)>;
 type JunitFileToValidation = BTreeMap<String, anyhow::Result<JunitReportValidation>>;
 
-pub async fn validate(junit_paths: Vec<String>, show_warnings: bool) -> anyhow::Result<i32> {
+pub async fn validate(
+    junit_paths: Vec<String>,
+    show_warnings: bool,
+    codeowners_path: Option<String>,
+) -> anyhow::Result<i32> {
     // scan files
     let current_dir = std::env::current_dir()
         .ok()
@@ -49,19 +54,25 @@ pub async fn validate(junit_paths: Vec<String>, show_warnings: bool) -> anyhow::
         .collect();
 
     // print results
+    let mut exit = EXIT_SUCCESS;
     let (num_invalid_reports, num_suboptimal_reports) =
         print_validation_errors(&report_validations);
     if num_invalid_reports == 0 {
         print_summary_success(report_validations.len(), num_suboptimal_reports);
-        Ok(EXIT_SUCCESS)
     } else {
         print_summary_failure(
             report_validations.len(),
             num_invalid_reports,
             num_suboptimal_reports,
         );
-        Ok(EXIT_FAILURE)
+        exit = EXIT_FAILURE
     }
+
+    let codeowners = CodeOwners::find_file(&current_dir, &codeowners_path);
+
+    print_codeowners(codeowners);
+
+    Ok(exit)
 }
 
 fn parse_file_sets(file_sets: Vec<FileSet>) -> JunitFileToReportAndErrors {
@@ -268,5 +279,22 @@ fn print_validation_level(level: JunitValidationLevel) -> ColoredString {
         JunitValidationLevel::SubOptimal => "OPTIONAL".yellow(),
         JunitValidationLevel::Invalid => "INVALID".red(),
         JunitValidationLevel::Valid => "VALID".green(),
+    }
+}
+
+fn print_codeowners(codeowners: Option<CodeOwners>) {
+    println!("\nChecking for codeowners file...");
+    match codeowners {
+        Some(owners) => {
+            println!(
+                "  {} - Found codeowners:",
+                print_validation_level(JunitValidationLevel::Valid)
+            );
+            println!("    Path: {:?}", owners.path);
+        }
+        None => println!(
+            "  {} - No codeowners file found.",
+            print_validation_level(JunitValidationLevel::SubOptimal)
+        ),
     }
 }


### PR DESCRIPTION
https://linear.app/trunk/issue/TRUNK-12586/parse-code-owners-in-cli-and-show-parse-errors

Add CODEOWNERS parsing to end of `validate` command. First pass - only check if it was parseable.

Future work: if CODEOWNERS was found and parsed successfully, check the owner paths against the junit test paths.

Sample output:

```hui@hui-cloudtop:~/dev/analytics-cli$ ./target/debug/trunk-analytics-cli validate --junit-paths test_junit.xml
2024-11-25T17:08:42 [INFO] - Starting trunk flakytests 0.0.0 (git=a5fda4d95caab18906ca10878d1511624e9985cd) rustc=1.80.0-nightly

Validating the following 1 files:
  File set matching test_junit.xml:
    test_junit.xml

test_junit.xml - 3 test suites, 4 test cases, 0 validation errors, 5 validation warnings
  OPTIONAL - report has test cases with missing file or filepath
  OPTIONAL - test case or parent has no timestamp
  OPTIONAL - test case or parent has no timestamp
  OPTIONAL - test case or parent has no timestamp
  OPTIONAL - test case or parent has old (> 30 day(s)) timestamp

All 1 files are valid! (1 files with validation warnings) ✅

Checking for codeowners file...
  VALID - Found codeowners:
    Path: "/home/hui/dev/analytics-cli/./CODEOWNERS"```

```hui@hui-cloudtop:~/dev/analytics-cli$ ./target/debug/trunk-analytics-cli validate --junit-paths test_junit.xml
2024-11-25T16:55:08 [INFO] - Starting trunk flakytests 0.0.0 (git=a5fda4d95caab18906ca10878d1511624e9985cd) rustc=1.80.0-nightly

Validating the following 1 files:
  File set matching test_junit.xml:
    test_junit.xml

test_junit.xml - 3 test suites, 4 test cases, 0 validation errors, 5 validation warnings
  OPTIONAL - report has test cases with missing file or filepath
  OPTIONAL - test case or parent has no timestamp
  OPTIONAL - test case or parent has no timestamp
  OPTIONAL - test case or parent has no timestamp
  OPTIONAL - test case or parent has old (> 30 day(s)) timestamp

All 1 files are valid! (1 files with validation warnings) ✅

Checking for codeowners file...
  OPTIONAL - No codeowners file found.```