### PR TITLE
[TRUNK-13672] validate timestamps as report-level issues

### DIFF
--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -307,6 +307,21 @@ impl JunitReportValidation {
                             JunitReportValidationIssueSubOptimal::TestCasesFileOrFilepathMissing,
                         )),
                         JunitValidationIssue::SubOptimal(
+                            JunitTestCaseValidationIssueSubOptimal::TestCaseNoTimestamp,
+                        ) => Some(JunitValidationIssue::SubOptimal(
+                            JunitReportValidationIssueSubOptimal::MissingTimestamps,
+                        )),
+                        JunitValidationIssue::SubOptimal(
+                            JunitTestCaseValidationIssueSubOptimal::TestCaseFutureTimestamp(..),
+                        ) => Some(JunitValidationIssue::SubOptimal(
+                            JunitReportValidationIssueSubOptimal::FutureTimestamps,
+                        )),
+                        JunitValidationIssue::SubOptimal(
+                            JunitTestCaseValidationIssueSubOptimal::TestCaseOldTimestamp(..),
+                        ) => Some(JunitValidationIssue::SubOptimal(
+                            JunitReportValidationIssueSubOptimal::OldTimestamps,
+                        )),
+                        JunitValidationIssue::SubOptimal(
                             JunitTestCaseValidationIssueSubOptimal::TestCaseStaleTimestamp(..),
                         ) => Some(JunitValidationIssue::SubOptimal(
                             JunitReportValidationIssueSubOptimal::StaleTimestamps,
@@ -368,6 +383,12 @@ impl ToString for JunitReportValidationIssue {
 pub enum JunitReportValidationIssueSubOptimal {
     #[error("report has test cases with missing file or filepath")]
     TestCasesFileOrFilepathMissing,
+    #[error("report has test cases with missing timestamp")]
+    MissingTimestamps,
+    #[error("report has test cases with future timestamp")]
+    FutureTimestamps,
+    #[error("report has old (> {} day(s)) timestamps", TIMESTAMP_OLD_DAYS)]
+    OldTimestamps,
     #[error("report has stale (> {} hour(s)) timestamps", TIMESTAMP_STALE_HOURS)]
     StaleTimestamps,
 }


### PR DESCRIPTION
[TRUNK-13672](https://linear.app/trunk/issue/TRUNK-13672/qa-bug-the-cli-is-too-verbose-in-validate)

Treat validation issues w/r/t timestamps on test cases as report-level issues to reduce verbosity, since those can be resolved with one action (e.g. configure test runner to output timestamps, re-run tests to get fresher timestamps, etc.)

```
max@max-cloudtop:~/src/flake-factory$ ./trunk-analytics-cli validate --junit-paths go/src/**/*.xml,rust/**/nextest/ci/*junit.xml,**/jest_*.xml
2024-11-25T20:07:58 [INFO] - Starting trunk flakytests 0.0.0 (git=0a74e0eee006ad84e23888f9a8513bf257050369) rustc=1.80.0-nightly

Validating the following 3 files:
  File set matching go/src/**/*.xml:
    go/src/gotestsum_test.xml
  File set matching rust/**/nextest/ci/*junit.xml:
    rust/target/nextest/ci/junit.xml
  File set matching **/jest_*.xml:
    tests/jest/jest_junit_test.xml

go/src/gotestsum_test.xml - 1 test suites, 3 test cases, 0 validation errors, 2 validation warnings
  OPTIONAL - report has test cases with missing file or filepath
  OPTIONAL - report has test cases with missing timestamp
rust/target/nextest/ci/junit.xml - 1 test suites, 2 test cases, 0 validation errors, 2 validation warnings
  OPTIONAL - report has old (> 30 day(s)) timestamps
  OPTIONAL - report has test cases with missing file or filepath
tests/jest/jest_junit_test.xml - 1 test suites, 3 test cases, 0 validation errors, 1 validation warnings
  OPTIONAL - report has stale (> 1 hour(s)) timestamps

All 3 files are valid! (3 files with validation warnings) ✅
```