### PR TITLE
bundle version downgrading

### DIFF
--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -46,6 +46,14 @@ pub struct BundleMetaV0_5_29 {
     pub base_props: BundleMetaBaseProps,
 }
 
+impl From<BundleMetaV0_5_34> for BundleMetaV0_5_29 {
+    fn from(bundle_meta: BundleMetaV0_5_34) -> Self {
+        BundleMetaV0_5_29 {
+            base_props: bundle_meta.base_props,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
@@ -62,6 +70,15 @@ pub struct BundleMetaV0_5_34 {
     pub base_props: BundleMetaBaseProps,
     #[serde(flatten)]
     pub junit_props: BundleMetaJunitProps,
+}
+
+impl From<BundleMetaV0_6_2> for BundleMetaV0_5_34 {
+    fn from(bundle_meta: BundleMetaV0_6_2) -> Self {
+        BundleMetaV0_5_34 {
+            base_props: bundle_meta.base_props,
+            junit_props: bundle_meta.junit_props,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -105,12 +122,20 @@ pub struct BindingsVersionedBundle(pub VersionedBundle);
 impl BindingsVersionedBundle {
     pub fn get_v0_5_29(&self) -> Option<BundleMetaV0_5_29> {
         match &self.0 {
+            VersionedBundle::V0_6_2(bundle_meta) => Some(BundleMetaV0_5_29::from(
+                BundleMetaV0_5_34::from(bundle_meta.clone()),
+            )),
+            VersionedBundle::V0_5_34(bundle_meta) => {
+                Some(BundleMetaV0_5_29::from(bundle_meta.clone()))
+            }
             VersionedBundle::V0_5_29(bundle_meta) => Some(bundle_meta.clone()),
-            _ => None,
         }
     }
     pub fn get_v0_5_34(&self) -> Option<BundleMetaV0_5_34> {
         match &self.0 {
+            VersionedBundle::V0_6_2(bundle_meta) => {
+                Some(BundleMetaV0_5_34::from(bundle_meta.clone()))
+            }
             VersionedBundle::V0_5_34(bundle_meta) => Some(bundle_meta.clone()),
             _ => None,
         }

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -120,15 +120,13 @@ pub struct BindingsVersionedBundle(pub VersionedBundle);
 #[gen_stub_pymethods]
 #[pymethods]
 impl BindingsVersionedBundle {
-    pub fn get_v0_5_29(&self) -> Option<BundleMetaV0_5_29> {
+    pub fn get_v0_5_29(&self) -> BundleMetaV0_5_29 {
         match &self.0 {
-            VersionedBundle::V0_6_2(bundle_meta) => Some(BundleMetaV0_5_29::from(
-                BundleMetaV0_5_34::from(bundle_meta.clone()),
-            )),
-            VersionedBundle::V0_5_34(bundle_meta) => {
-                Some(BundleMetaV0_5_29::from(bundle_meta.clone()))
+            VersionedBundle::V0_6_2(bundle_meta) => {
+                BundleMetaV0_5_29::from(BundleMetaV0_5_34::from(bundle_meta.clone()))
             }
-            VersionedBundle::V0_5_29(bundle_meta) => Some(bundle_meta.clone()),
+            VersionedBundle::V0_5_34(bundle_meta) => BundleMetaV0_5_29::from(bundle_meta.clone()),
+            VersionedBundle::V0_5_29(bundle_meta) => bundle_meta.clone(),
         }
     }
     pub fn get_v0_5_34(&self) -> Option<BundleMetaV0_5_34> {

--- a/context-py/tests/test_parse_compressed_bundle.py
+++ b/context-py/tests/test_parse_compressed_bundle.py
@@ -104,5 +104,4 @@ def test_parse_meta_from_tarball():
     assert versioned_bundle.get_v0_6_2() is None
 
     bundle_meta = versioned_bundle.get_v0_5_29()
-    assert bundle_meta is not None
     assert bundle_meta.base_props.bundle_upload_id == expected_meta["bundle_upload_id"]


### PR DESCRIPTION
Allows for easily getting the lowest denominator of a bundle version