### PR TITLE
Speed up clippy

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -103,6 +103,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust & Cargo
+        uses: ./.github/actions/setup_rust_cargo
+
+      - name: Build workspace
+        run: cargo build --all
+
       - name: Setup and build pyo3
         uses: ./.github/actions/setup_build_pyo3
 


### PR DESCRIPTION
I thought that we build "enough" of the workspace before calling Clippy, but it seems that wasn't the case. Clippy seems to be able to use artifacts from `cargo build` and for whatever reason `cargo build` is way, way, wayyyyyyy faster than having Clippy do the build.