### PR TITLE
chore: add end to end test to exercise missing filepath + codeowners present

### DIFF
--- a/cli-tests/src/utils.rs
+++ b/cli-tests/src/utils.rs
@@ -60,6 +60,21 @@ pub fn generate_mock_suboptimal_junit_xmls<T: AsRef<Path>>(directory: T) {
         .unwrap();
 }
 
+pub fn generate_mock_missing_filepath_suboptimal_junit_xmls<T: AsRef<Path>>(directory: T) {
+    let jm_options = junit_mock::Options::default();
+    let mut jm = JunitMock::new(jm_options);
+    let mut reports = jm.generate_reports();
+    for report in reports.iter_mut() {
+        for testsuite in report.test_suites.iter_mut() {
+            for test_case in testsuite.test_cases.iter_mut() {
+                test_case.extra.swap_remove("file");
+            }
+        }
+    }
+    jm.write_reports_to_file(directory.as_ref(), reports)
+        .unwrap();
+}
+
 pub fn generate_mock_codeowners<T: AsRef<Path>>(directory: T) {
     const CODEOWNERS: &str = r#"
         [Owners of Everything]

--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     generate_mock_codeowners, generate_mock_invalid_junit_xmls,
-    generate_mock_suboptimal_junit_xmls, generate_mock_valid_junit_xmls, write_junit_xml_to_dir,
-    CARGO_RUN,
+    generate_mock_missing_filepath_suboptimal_junit_xmls, generate_mock_suboptimal_junit_xmls,
+    generate_mock_valid_junit_xmls, write_junit_xml_to_dir, CARGO_RUN,
 };
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -112,6 +112,30 @@ fn validate_suboptimal_junits() {
         ))
         .stdout(predicate::str::contains(
             "OPTIONAL - report has stale (> 1 hour(s)) timestamps",
+        ));
+
+    println!("{assert}");
+}
+
+#[test]
+fn validate_missing_filepath_suboptimal_junits() {
+    let temp_dir = tempdir().unwrap();
+    generate_mock_missing_filepath_suboptimal_junit_xmls(&temp_dir);
+    generate_mock_codeowners(&temp_dir);
+
+    let assert = Command::new(CARGO_RUN.path())
+        .current_dir(&temp_dir)
+        .args(&["validate", "--junit-paths", "./*"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "0 validation errors, 2 validation warning",
+        ))
+        .stdout(predicate::str::contains(
+            "OPTIONAL - report has test cases with missing file or filepath",
+        ))
+        .stdout(predicate::str::contains(
+            "OPTIONAL - CODEOWNERS found but test cases are missing filepaths. We will not be able to correlate flaky tests with owners.",
         ));
 
     println!("{assert}");


### PR DESCRIPTION
Add end to end test to exercise the case when junit tests are missing filepaths but there is a codeowners file present.