### PR TITLE
[TRUNK-13580] JUnit validator changes for ETL usage

### DIFF
--- a/context-js/src/lib.rs
+++ b/context-js/src/lib.rs
@@ -76,8 +76,10 @@ pub fn junit_parse(xml: Vec<u8>) -> Result<Vec<junit::bindings::BindingsReport>,
 #[wasm_bindgen]
 pub fn junit_validate(
     report: &junit::bindings::BindingsReport,
-) -> junit::validator::JunitReportValidation {
-    junit::validator::validate(&report.clone().into())
+) -> junit::bindings::BindingsJunitReportValidation {
+    junit::bindings::BindingsJunitReportValidation::from(junit::validator::validate(
+        &report.clone().into(),
+    ))
 }
 
 #[wasm_bindgen]

--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -97,7 +97,7 @@ describe("context-js", () => {
     expect(junitReportValidation.num_suboptimal_issues()).toBe(1);
     expect(
       junitReportValidation
-        .all_issues()
+        .all_issues_owned()
         .filter((issue) => issue.error_type === JunitValidationType.Report),
     ).toHaveLength(1);
   });

--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -97,7 +97,7 @@ describe("context-js", () => {
     expect(junitReportValidation.num_suboptimal_issues()).toBe(1);
     expect(
       junitReportValidation
-        .all_issues_flat()
+        .all_issues()
         .filter((issue) => issue.error_type === JunitValidationType.Report),
     ).toHaveLength(1);
   });

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -70,8 +70,32 @@ fn junit_parse(xml: Vec<u8>) -> PyResult<Vec<junit::bindings::BindingsReport>> {
 #[pyfunction]
 fn junit_validate(
     report: junit::bindings::BindingsReport,
-) -> junit::validator::JunitReportValidation {
-    junit::validator::validate(&report.into())
+) -> junit::bindings::BindingsJunitReportValidation {
+    junit::bindings::BindingsJunitReportValidation::from(junit::validator::validate(&report.into()))
+}
+
+#[gen_stub_pyfunction]
+#[pyfunction]
+fn junit_validation_level_to_string(
+    junit_validation_level: junit::validator::JunitValidationLevel,
+) -> String {
+    match junit_validation_level {
+        junit::validator::JunitValidationLevel::Valid => "VALID".to_string(),
+        junit::validator::JunitValidationLevel::SubOptimal => "SUBOPTIMAL".to_string(),
+        junit::validator::JunitValidationLevel::Invalid => "INVALID".to_string(),
+    }
+}
+
+#[gen_stub_pyfunction]
+#[pyfunction]
+fn junit_validation_type_to_string(
+    junit_validation_type: junit::validator::JunitValidationType,
+) -> String {
+    match junit_validation_type {
+        junit::validator::JunitValidationType::Report => "Report".to_string(),
+        junit::validator::JunitValidationType::TestSuite => "TestSuite".to_string(),
+        junit::validator::JunitValidationType::TestCase => "TestCase".to_string(),
+    }
 }
 
 #[gen_stub_pyfunction]
@@ -109,10 +133,14 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<junit::bindings::BindingsTestCase>()?;
     m.add_class::<junit::bindings::BindingsTestCaseStatusStatus>()?;
     m.add_class::<junit::bindings::BindingsNonSuccessKind>()?;
+    m.add_class::<junit::bindings::BindingsJunitReportValidation>()?;
+    m.add_class::<junit::validator::JunitReportValidationFlatIssue>()?;
     m.add_class::<junit::validator::JunitValidationLevel>()?;
     m.add_class::<junit::validator::JunitValidationType>()?;
     m.add_function(wrap_pyfunction!(junit_parse, m)?)?;
     m.add_function(wrap_pyfunction!(junit_validate, m)?)?;
+    m.add_function(wrap_pyfunction!(junit_validation_level_to_string, m)?)?;
+    m.add_function(wrap_pyfunction!(junit_validation_type_to_string, m)?)?;
 
     m.add_class::<repo::BundleRepo>()?;
     m.add_class::<repo::RepoUrlParts>()?;

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -244,7 +244,7 @@ def test_junit_validate_suboptimal():
     assert junit_report_validation.num_suboptimal_issues() == 1
     report_level_issues = [
         x
-        for x in junit_report_validation.all_issues()
+        for x in junit_report_validation.all_issues
         if x.error_type == JunitValidationType.Report
     ]
     assert len(report_level_issues) == 1

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -244,7 +244,7 @@ def test_junit_validate_suboptimal():
     assert junit_report_validation.num_suboptimal_issues() == 1
     report_level_issues = [
         x
-        for x in junit_report_validation.all_issues
+        for x in junit_report_validation.all_issues()
         if x.error_type == JunitValidationType.Report
     ]
     assert len(report_level_issues) == 1

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -189,11 +189,12 @@ def test_junit_validate_valid():
     ), "\n" + "\n".join(
         [
             issue.error_message
-            for test_suite in junit_report_validation.test_suites_owned()
+            for test_suite in junit_report_validation.test_suites
             for test_case in test_suite.test_cases_owned()
             for issue in test_case.issues_flat()
         ]
     )
+    assert len(junit_report_validation.valid_test_suites) == 1
 
 
 def test_junit_validate_suboptimal():
@@ -206,6 +207,8 @@ def test_junit_validate_suboptimal():
         JunitValidationType,
         junit_parse,
         junit_validate,
+        junit_validation_level_to_string,
+        junit_validation_type_to_string,
     )
 
     stale_timestamp = (
@@ -233,21 +236,23 @@ def test_junit_validate_suboptimal():
     ), "\n" + "\n".join(
         [
             issue.error_message
-            for test_suite in junit_report_validation.test_suites_owned()
+            for test_suite in junit_report_validation.test_suites
             for test_case in test_suite.test_cases_owned()
             for issue in test_case.issues_flat()
         ]
     )
     assert junit_report_validation.num_suboptimal_issues() == 1
+    report_level_issues = [
+        x
+        for x in junit_report_validation.all_issues
+        if x.error_type == JunitValidationType.Report
+    ]
+    assert len(report_level_issues) == 1
     assert (
-        len(
-            [
-                x
-                for x in junit_report_validation.all_issues_flat()
-                if x.error_type == JunitValidationType.Report
-            ]
-        )
-        == 1
+        junit_validation_type_to_string(report_level_issues[0].error_type) == "Report"
+    )
+    assert (
+        junit_validation_level_to_string(report_level_issues[0].level) == "SUBOPTIMAL"
     )
 
 

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -84,7 +84,7 @@ impl Into<Report> for BindingsReport {
                     let micros_delta = TimeDelta::microseconds(micro_secs);
                     DateTime::from_timestamp(
                         micros_delta.num_seconds(),
-                        micros_delta.num_nanoseconds().unwrap_or_default() as u32,
+                        micros_delta.subsec_nanos() as u32,
                     )
                 })
                 .map(|dt| dt.fixed_offset()),
@@ -215,7 +215,7 @@ impl Into<TestSuite> for BindingsTestSuite {
                 let micros_delta = TimeDelta::microseconds(micro_secs);
                 DateTime::from_timestamp(
                     micros_delta.num_seconds(),
-                    micros_delta.num_nanoseconds().unwrap_or_default() as u32,
+                    micros_delta.subsec_nanos() as u32,
                 )
             })
             .map(|dt| dt.fixed_offset());
@@ -373,7 +373,7 @@ impl TryInto<TestCase> for BindingsTestCase {
                 let micros_delta = TimeDelta::microseconds(micro_secs);
                 DateTime::from_timestamp(
                     micros_delta.num_seconds(),
-                    micros_delta.num_nanoseconds().unwrap_or_default() as u32,
+                    micros_delta.subsec_nanos() as u32,
                 )
             })
             .map(|dt| dt.fixed_offset());
@@ -622,7 +622,7 @@ impl Into<TestRerun> for BindingsTestRerun {
                     let micros_delta = TimeDelta::microseconds(micro_secs);
                     DateTime::from_timestamp(
                         micros_delta.num_seconds(),
-                        micros_delta.num_nanoseconds().unwrap_or_default() as u32,
+                        micros_delta.subsec_nanos() as u32,
                     )
                 })
                 .map(|dt| dt.fixed_offset()),

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -17,6 +17,7 @@ use super::validator::{
 };
 
 const MICROSECONDS_PER_SECOND: i64 = 1_000_000;
+const NANOSECONDS_PER_MICROSECOND: i64 = 1_000;
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
@@ -85,7 +86,8 @@ impl Into<Report> for BindingsReport {
                 .and_then(|micro_secs| {
                     DateTime::from_timestamp(
                         micro_secs / MICROSECONDS_PER_SECOND,
-                        (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                        ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND)
+                            as u32,
                     )
                 })
                 .map(|dt| dt.fixed_offset()),
@@ -215,7 +217,7 @@ impl Into<TestSuite> for BindingsTestSuite {
             .and_then(|micro_secs| {
                 DateTime::from_timestamp(
                     micro_secs / MICROSECONDS_PER_SECOND,
-                    (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                    ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND) as u32,
                 )
             })
             .map(|dt| dt.fixed_offset());
@@ -372,7 +374,7 @@ impl TryInto<TestCase> for BindingsTestCase {
             .and_then(|micro_secs| {
                 DateTime::from_timestamp(
                     micro_secs / MICROSECONDS_PER_SECOND,
-                    (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                    ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND) as u32,
                 )
             })
             .map(|dt| dt.fixed_offset());
@@ -620,7 +622,8 @@ impl Into<TestRerun> for BindingsTestRerun {
                 .and_then(|micro_secs| {
                     DateTime::from_timestamp(
                         micro_secs / MICROSECONDS_PER_SECOND,
-                        (micro_secs % MICROSECONDS_PER_SECOND) as u32,
+                        ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND)
+                            as u32,
                     )
                 })
                 .map(|dt| dt.fixed_offset()),

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -702,6 +702,10 @@ impl From<JunitReportValidation> for BindingsJunitReportValidation {
 #[cfg_attr(feature = "pyo3", gen_stub_pymethods, pymethods)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl BindingsJunitReportValidation {
+    pub fn all_issues(&self) -> Vec<JunitReportValidationFlatIssue> {
+        self.all_issues.clone()
+    }
+
     pub fn max_level(&self) -> JunitValidationLevel {
         self.test_suites
             .iter()

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -702,7 +702,7 @@ impl From<JunitReportValidation> for BindingsJunitReportValidation {
 #[cfg_attr(feature = "pyo3", gen_stub_pymethods, pymethods)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl BindingsJunitReportValidation {
-    pub fn all_issues(&self) -> Vec<JunitReportValidationFlatIssue> {
+    pub fn all_issues_owned(&self) -> Vec<JunitReportValidationFlatIssue> {
         self.all_issues.clone()
     }
 

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::Duration};
 
-use chrono::DateTime;
+use chrono::{DateTime, TimeDelta};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
@@ -15,9 +15,6 @@ use super::validator::{
     JunitReportValidation, JunitReportValidationFlatIssue, JunitTestSuiteValidation,
     JunitValidationLevel, JunitValidationType,
 };
-
-const MICROSECONDS_PER_SECOND: i64 = 1_000_000;
-const NANOSECONDS_PER_MICROSECOND: i64 = 1_000;
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
@@ -84,10 +81,10 @@ impl Into<Report> for BindingsReport {
             uuid: None,
             timestamp: timestamp_micros
                 .and_then(|micro_secs| {
+                    let micros_delta = TimeDelta::microseconds(micro_secs);
                     DateTime::from_timestamp(
-                        micro_secs / MICROSECONDS_PER_SECOND,
-                        ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND)
-                            as u32,
+                        micros_delta.num_seconds(),
+                        micros_delta.num_nanoseconds().unwrap_or_default() as u32,
                     )
                 })
                 .map(|dt| dt.fixed_offset()),
@@ -215,9 +212,10 @@ impl Into<TestSuite> for BindingsTestSuite {
         test_suite.failures = failures;
         test_suite.timestamp = timestamp_micros
             .and_then(|micro_secs| {
+                let micros_delta = TimeDelta::microseconds(micro_secs);
                 DateTime::from_timestamp(
-                    micro_secs / MICROSECONDS_PER_SECOND,
-                    ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND) as u32,
+                    micros_delta.num_seconds(),
+                    micros_delta.num_nanoseconds().unwrap_or_default() as u32,
                 )
             })
             .map(|dt| dt.fixed_offset());
@@ -372,9 +370,10 @@ impl TryInto<TestCase> for BindingsTestCase {
         test_case.assertions = assertions;
         test_case.timestamp = timestamp_micros
             .and_then(|micro_secs| {
+                let micros_delta = TimeDelta::microseconds(micro_secs);
                 DateTime::from_timestamp(
-                    micro_secs / MICROSECONDS_PER_SECOND,
-                    ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND) as u32,
+                    micros_delta.num_seconds(),
+                    micros_delta.num_nanoseconds().unwrap_or_default() as u32,
                 )
             })
             .map(|dt| dt.fixed_offset());
@@ -620,10 +619,10 @@ impl Into<TestRerun> for BindingsTestRerun {
             kind: kind.into(),
             timestamp: timestamp_micros
                 .and_then(|micro_secs| {
+                    let micros_delta = TimeDelta::microseconds(micro_secs);
                     DateTime::from_timestamp(
-                        micro_secs / MICROSECONDS_PER_SECOND,
-                        ((micro_secs % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND)
-                            as u32,
+                        micros_delta.num_seconds(),
+                        micros_delta.num_nanoseconds().unwrap_or_default() as u32,
                     )
                 })
                 .map(|dt| dt.fixed_offset()),

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pymethods};
-use quick_junit::Report;
+use quick_junit::{Report, TestCase, TestSuite};
 use std::{cmp::Ordering, collections::HashSet};
 use thiserror::Error;
 #[cfg(feature = "wasm")]
@@ -94,6 +94,7 @@ pub fn validate(report: &Report) -> JunitReportValidation {
             }
         }
 
+        let mut valid_test_cases: Vec<TestCase> = Vec::new();
         for test_case in test_suite.test_cases.iter() {
             let mut test_case_validation = JunitTestCaseValidation::default();
 
@@ -197,7 +198,17 @@ pub fn validate(report: &Report) -> JunitReportValidation {
                 ));
             }
 
+            if test_case_validation.level != JunitValidationLevel::Invalid {
+                valid_test_cases.push(test_case.clone());
+            }
+
             test_suite_validation.test_cases.push(test_case_validation);
+        }
+
+        if test_suite_validation.level != JunitValidationLevel::Invalid {
+            let mut valid_test_suite = test_suite.clone();
+            valid_test_suite.test_cases = valid_test_cases;
+            report_validation.valid_test_suites.push(valid_test_suite);
         }
 
         report_validation.test_suites.push(test_suite_validation);
@@ -208,13 +219,12 @@ pub fn validate(report: &Report) -> JunitReportValidation {
     report_validation
 }
 
-#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
-#[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct JunitReportValidation {
-    all_issues: Vec<JunitValidationIssueType>,
-    level: JunitValidationLevel,
-    test_suites: Vec<JunitTestSuiteValidation>,
+    pub all_issues: Vec<JunitValidationIssueType>,
+    pub level: JunitValidationLevel,
+    pub test_suites: Vec<JunitTestSuiteValidation>,
+    pub valid_test_suites: Vec<TestSuite>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -263,9 +273,11 @@ pub struct JunitReportValidationFlatIssue {
     pub error_message: String,
 }
 
-#[cfg_attr(feature = "pyo3", gen_stub_pymethods, pymethods)]
-#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl JunitReportValidation {
+    pub fn all_issues(&self) -> &[JunitValidationIssueType] {
+        &self.all_issues
+    }
+
     pub fn all_issues_flat(&self) -> Vec<JunitReportValidationFlatIssue> {
         self.all_issues
             .iter()
@@ -277,8 +289,15 @@ impl JunitReportValidation {
             .collect()
     }
 
-    pub fn test_suites_owned(&self) -> Vec<JunitTestSuiteValidation> {
-        self.test_suites.clone()
+    pub fn test_suites(&self) -> &[JunitTestSuiteValidation] {
+        &self.test_suites
+    }
+
+    pub fn test_cases(&self) -> Vec<&JunitTestCaseValidation> {
+        self.test_suites
+            .iter()
+            .flat_map(|test_suite| test_suite.test_cases())
+            .collect()
     }
 
     pub fn max_level(&self) -> JunitValidationLevel {
@@ -308,23 +327,6 @@ impl JunitReportValidation {
             .iter()
             .filter(|issue| JunitValidationLevel::from(*issue) == JunitValidationLevel::SubOptimal)
             .count()
-    }
-}
-
-impl JunitReportValidation {
-    pub fn all_issues(&self) -> &[JunitValidationIssueType] {
-        &self.all_issues
-    }
-
-    pub fn test_suites(&self) -> &[JunitTestSuiteValidation] {
-        &self.test_suites
-    }
-
-    pub fn test_cases(&self) -> Vec<&JunitTestCaseValidation> {
-        self.test_suites
-            .iter()
-            .flat_map(|test_suite| test_suite.test_cases())
-            .collect()
     }
 
     fn derive_all_issues(&mut self) {
@@ -381,6 +383,10 @@ impl JunitReportValidation {
             .map(|report_level_issue| JunitValidationLevel::from(report_level_issue))
             .max()
             .map_or(self.level, |l| l.max(self.level));
+
+        if self.level == JunitValidationLevel::Invalid {
+            self.valid_test_suites.clear();
+        }
 
         other_issues.extend(
             report_level_issues

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -86,8 +86,8 @@ pub fn validate(report: &Report) -> JunitReportValidation {
         if let Some(raw_test_suite_id) = test_suite.extra.get("id") {
             let test_case_id = uuid::Uuid::parse_str(raw_test_suite_id).unwrap_or_default();
             if test_case_id.get_version() != Some(uuid::Version::Sha1) {
-                test_suite_validation.add_issue(JunitValidationIssue::Invalid(
-                    JunitTestSuiteValidationIssueInvalid::TestSuiteInvalidId(
+                test_suite_validation.add_issue(JunitValidationIssue::SubOptimal(
+                    JunitTestSuiteValidationIssueSubOptimal::TestSuiteInvalidId(
                         raw_test_suite_id.to_string().clone(),
                     ),
                 ));
@@ -515,6 +515,8 @@ impl JunitTestSuiteValidation {
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum JunitTestSuiteValidationIssueSubOptimal {
+    #[error("test suite id is not a valid uuidv5")]
+    TestSuiteInvalidId(String),
     #[error("test suite name too long, truncated to {}", MAX_FIELD_LEN)]
     TestSuiteNameTooLong(String),
 }
@@ -523,8 +525,6 @@ pub enum JunitTestSuiteValidationIssueSubOptimal {
 pub enum JunitTestSuiteValidationIssueInvalid {
     #[error("test suite name too short")]
     TestSuiteNameTooShort(String),
-    #[error("test suite id is not a valid uuidv5")]
-    TestSuiteInvalidId(String),
 }
 
 pub type JunitTestCaseValidationIssue = JunitValidationIssue<

--- a/context/tests/junit.rs
+++ b/context/tests/junit.rs
@@ -98,6 +98,8 @@ fn validate_test_suite_name_too_short() {
         seed,
     );
 
+    assert_eq!(report_validation.valid_test_suites.len(), 0);
+
     pretty_assertions::assert_eq!(
         report_validation
             .test_suites()
@@ -152,6 +154,7 @@ fn validate_test_invalid_test_suite_id() {
             .insert(extra_attrs::ID.into(), id.to_string().into());
     }
     let report_validation = junit::validator::validate(&generated_report);
+    assert_eq!(report_validation.valid_test_suites.len(), 1);
     pretty_assertions::assert_eq!(
         report_validation
             .test_suites()

--- a/context/tests/junit.rs
+++ b/context/tests/junit.rs
@@ -125,10 +125,10 @@ fn validate_test_invalid_test_suite_id() {
     }
 
     let report_validation = junit::validator::validate(&generated_report);
-
+    assert_eq!(report_validation.valid_test_suites.len(), 1);
     assert_eq!(
         report_validation.max_level(),
-        JunitValidationLevel::Invalid,
+        JunitValidationLevel::SubOptimal,
         "failed to validate with seed `{}`",
         seed,
     );
@@ -139,8 +139,8 @@ fn validate_test_invalid_test_suite_id() {
             .iter()
             .flat_map(|test_suite| Vec::from(test_suite.issues()))
             .collect::<Vec<JunitTestSuiteValidationIssue>>(),
-        vec![JunitValidationIssue::Invalid(
-            JunitTestSuiteValidationIssueInvalid::TestSuiteInvalidId(id.into()),
+        vec![JunitValidationIssue::SubOptimal(
+            JunitTestSuiteValidationIssueSubOptimal::TestSuiteInvalidId(id.into()),
         )],
         "failed to validate with seed `{}`",
         seed,


### PR DESCRIPTION
Part of [TRUNK-13580](https://linear.app/trunk/issue/TRUNK-13580/move-junit-validation-out-of-glue-and-into-dagster)

Tweaks to the junit validator to prepare for usage in the ETL

Summary of changes:
 - Extends `validate()` to collect all of the 'valid' (suboptimal issues are ok) test suites & test cases in its resulting `JunitReportValidation`. This allows the ETL to get a quick list of the successfully-parsed test suites & test cases it's allowed to process
 - Introduces a new `BindingsJunitReportValidation` type. Since `JunitReportValidation` now includes a vector of `quick_junit::TestSuite` as the 'valid' test suites, pyo3 can no longer directly create a class from it
 - Changes the `junit_validate` pyfunction to return the new `BindingsJunitReportValidation` type
 - Fixes an issue where converting from `BindingsJunitReport` to `quick_junit::Report` would result in test cases with an incorrect number of microseconds in their timestamps