### PR TITLE
Tenest/trunk 13755 codeowners parse from bytestream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ name = "context-py"
 version = "0.1.0"
 dependencies = [
  "bundle",
+ "codeowners",
  "context",
  "futures-io",
  "pyo3",

--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -1,7 +1,6 @@
 use std::{
     ffi::OsStr,
     fs::File,
-    io::BufRead,
     path::{Path, PathBuf},
 };
 
@@ -71,13 +70,12 @@ impl CodeOwners {
         })
     }
 
-    pub fn parse<R: BufRead>(&mut self, codeowners: R) -> Self
-    where
-        R: Read,
-    {
-        let owners_result = GitHubOwners::from_reader(&codeowners)
+    pub fn parse(codeowners: Vec<u8>) -> Self {
+        let owners_result = GitHubOwners::from_reader(codeowners.as_slice())
             .map(Owners::GitHubOwners)
-            .or_else(|_| GitLabOwners::from_reader(&codeowners).map(Owners::GitLabOwners));
+            .or_else(|_| {
+                GitLabOwners::from_reader(codeowners.as_slice()).map(Owners::GitLabOwners)
+            });
 
         if let Err(ref err) = owners_result {
             log::error!(

--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -1,5 +1,4 @@
 use std::{
-    ffi::OsStr,
     fs::File,
     path::{Path, PathBuf},
 };
@@ -77,17 +76,9 @@ impl CodeOwners {
                 GitLabOwners::from_reader(codeowners.as_slice()).map(Owners::GitLabOwners)
             });
 
-        if let Err(ref err) = owners_result {
-            log::error!(
-                "Found CODEOWNERS file `{}` in bundle, but couldn't parse it",
-                err
-            );
-        }
-
-        let owners = Result::ok(owners_result);
         Self {
-            path: PathBuf::from(OsStr::new("")),
-            owners,
+            path: PathBuf::new(),
+            owners: owners_result.ok(),
         }
     }
 }

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -14,6 +14,7 @@ path = "bin/stub_gen.rs"
 
 [dependencies]
 bundle = { path = "../bundle", default-features = false, features = ["pyo3"] }
+codeowners = { path = "../codeowners" }
 context = { path = "../context", features = ["git-access", "pyo3"] }
 pyo3-stub-gen = "0.6.0"
 futures-io = "0.3.31"

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -96,6 +96,22 @@ pub fn parse_meta_from_tarball(
     Ok(BindingsVersionedBundle(versioned_bundle))
 }
 
+#[gen_stub_pyfunction]
+#[pyfunction]
+fn codeowners_parse(codeowners: Vec<u8>) -> PyResult<Vec<junit::bindings::BindingsReport>> {
+    let mut codeowners_parser = codeowners::CodeOwners::new();
+    if let Err(e) = codeowners_parser.parse(BufReader::new(&codeowners[..])) {
+        return Err(PyTypeError::new_err(e.to_string()));
+    }
+
+    // turn this copy pasta into codeowners things
+    Ok(junit_parser
+        .into_reports()
+        .into_iter()
+        .map(junit::bindings::BindingsReport::from)
+        .collect())
+}
+
 #[pymodule]
 fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<env::parser::CIPlatform>()?;

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -99,10 +99,8 @@ pub fn parse_meta_from_tarball(
 
 #[gen_stub_pyfunction]
 #[pyfunction]
-fn codeowners_parse(codeowners_bytes: Vec<u8>) -> PyResult<CodeOwners> {
-    let codeowners = CodeOwners::parse(codeowners_bytes);
-
-    Ok(codeowners)
+fn codeowners_parse(codeowners_bytes: Vec<u8>) -> CodeOwners {
+    CodeOwners::parse(codeowners_bytes)
 }
 
 #[pymodule]

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -89,8 +89,9 @@ def test_junit_parse_valid():
 
 
 def test_junit_parse_non_xml():
-    from context_py import junit_parse
     from pytest import raises
+
+    from context_py import junit_parse
 
     simple_string = "no reports here!"
 
@@ -101,13 +102,14 @@ def test_junit_parse_non_xml():
 
 
 def test_junit_parse_broken_xml():
-    from context_py import junit_parse
     from pytest import raises
 
-    broken_xml = "<testsuites"
+    from context_py import junit_parse
+
+    broken_xml = b"<testsuites"
 
     with raises(Exception) as excinfo:
-        _ = junit_parse(str.encode(broken_xml))
+        _ = junit_parse(broken_xml)
 
     assert (
         str(excinfo.value)
@@ -120,7 +122,7 @@ def test_junit_parse_nested_testsuites():
 
     from context_py import BindingsReport, BindingsTestCaseStatusStatus, junit_parse
 
-    nested_testsuites_xml = """<?xml version="1.0" encoding="UTF-8"?>
+    nested_testsuites_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
         <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
             <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
@@ -132,7 +134,7 @@ def test_junit_parse_nested_testsuites():
         </testsuite>
     </testsuites>"""
 
-    reports: PT.List[BindingsReport] = junit_parse(str.encode(nested_testsuites_xml))
+    reports: PT.List[BindingsReport] = junit_parse(nested_testsuites_xml)
 
     assert len(reports) == 1
     report = reports[0]

--- a/context-py/tests/test_parse_and_validate.py
+++ b/context-py/tests/test_parse_and_validate.py
@@ -89,9 +89,8 @@ def test_junit_parse_valid():
 
 
 def test_junit_parse_non_xml():
-    from pytest import raises
-
     from context_py import junit_parse
+    from pytest import raises
 
     simple_string = "no reports here!"
 
@@ -102,9 +101,8 @@ def test_junit_parse_non_xml():
 
 
 def test_junit_parse_broken_xml():
-    from pytest import raises
-
     from context_py import junit_parse
+    from pytest import raises
 
     broken_xml = b"<testsuites"
 

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -4,4 +4,4 @@ def test_parse_meta_from_tarball():
     codeowners_text = """* @trunk/test"""
     codeowners = codeowners_parse(str.encode(codeowners_text))
 
-    assert codeowners != None
+    assert codeowners is not None

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -1,12 +1,4 @@
 def test_parse_meta_from_tarball():
-    import io
-    import json
-    import tarfile
-    import tempfile
-
-    import zstandard as zstd
-    from botocore.response import StreamingBody
-
     from context_py import codeowners_parse
 
     codeowners_text = """* @trunk/test"""

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -10,6 +10,6 @@ def test_parse_meta_from_tarball():
     from context_py import codeowners_parse
 
     codeowners_text = """* @trunk/test"""
-    owners = codeowners_parse(str.encode(codeowners_text))
+    codeowners = codeowners_parse(str.encode(codeowners_text))
 
-    assert owners != None
+    assert codeowners != None

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -1,7 +1,7 @@
 def test_parse_meta_from_tarball():
     from context_py import codeowners_parse
 
-    codeowners_text = """* @trunk/test"""
-    codeowners = codeowners_parse(str.encode(codeowners_text))
+    codeowners_text = b"""* @trunk/test"""
+    codeowners = codeowners_parse(codeowners_text)
 
     assert codeowners is not None

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -1,0 +1,15 @@
+def test_parse_meta_from_tarball():
+    import io
+    import json
+    import tarfile
+    import tempfile
+
+    import zstandard as zstd
+    from botocore.response import StreamingBody
+
+    from context_py import codeowners_parse
+
+    codeowners_text = """* @trunk/test"""
+    owners = codeowners_parse(str.encode(codeowners_text))
+
+    assert owners != None


### PR DESCRIPTION
Add function to parse codeowners from a byte vector. Add a basic py test. Will expand on test after more work on py bindings.