### PR TITLE
Tenest/trunk 13719 codeowners py bindings

### DIFF
--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -1,5 +1,4 @@
 use std::{
-    ffi::OsStr,
     fs::File,
     path::{Path, PathBuf},
 };
@@ -8,15 +7,18 @@ use constants::CODEOWNERS_LOCATIONS;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
-use pyo3_stub_gen::derive::gen_stub_pymethods;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::{github::GitHubOwners, gitlab::GitLabOwners, traits::FromReader};
+use crate::{
+    github::{BindingsGitHubOwners, GitHubOwners},
+    gitlab::{BindingsGitLabOwners, GitLabOwners},
+    traits::FromReader,
+};
 
 // TODO(TRUNK-13628): Implement serializing and deserializing for CodeOwners
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -85,13 +87,13 @@ impl CodeOwners {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Owners {
     GitHubOwners(GitHubOwners),
     GitLabOwners(GitLabOwners),
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass)]
 pub struct BindingsOwners(pub Owners);
 
@@ -99,15 +101,19 @@ pub struct BindingsOwners(pub Owners);
 #[gen_stub_pymethods]
 #[pymethods]
 impl BindingsOwners {
-    pub fn get_github_owners(&self) -> Option<GitHubOwners> {
+    pub fn get_github_owners(&self) -> Option<BindingsGitHubOwners> {
         match &self.0 {
-            Owners::GitHubOwners(owners) => Some(GitHubOwners::from(owners.clone())),
+            Owners::GitHubOwners(owners) => {
+                Some(BindingsGitHubOwners(GitHubOwners::from(owners.clone())))
+            }
             _ => None,
         }
     }
-    pub fn get_gitlab_owners(&self) -> Option<GitLabOwners> {
+    pub fn get_gitlab_owners(&self) -> Option<BindingsGitLabOwners> {
         match &self.0 {
-            Owners::GitLabOwners(owners) => Some(GitLabOwners::from(owners.clone())),
+            Owners::GitLabOwners(owners) => {
+                Some(BindingsGitLabOwners(GitLabOwners::from(owners.clone())))
+            }
             _ => None,
         }
     }

--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -73,6 +73,8 @@ impl CodeOwners {
         })
     }
 
+    // TODO: take in origin path and parse CODEOWNERS based on location
+    // which informs which parser to use (GitHub or GitLab)
     pub fn parse(codeowners: Vec<u8>) -> Self {
         let owners_result = GitHubOwners::from_reader(codeowners.as_slice())
             .map(Owners::GitHubOwners)
@@ -93,6 +95,8 @@ pub enum Owners {
     GitLabOwners(GitLabOwners),
 }
 
+// TODO: Make this smarter and return only an object with a .of method
+// instead of forcing the ETL to try GitHub or GitLab
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass)]
 pub struct BindingsOwners(pub Owners);

--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -14,11 +14,10 @@ use tsify_next::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::{
-    github::{BindingsGitHubOwners, GitHubOwners},
-    gitlab::{BindingsGitLabOwners, GitLabOwners},
-    traits::FromReader,
-};
+#[cfg(feature = "pyo3")]
+use crate::{github::BindingsGitHubOwners, gitlab::BindingsGitLabOwners};
+
+use crate::{github::GitHubOwners, gitlab::GitLabOwners, traits::FromReader};
 
 // TODO(TRUNK-13628): Implement serializing and deserializing for CodeOwners
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -16,7 +16,6 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "pyo3")]
 use crate::{github::BindingsGitHubOwners, gitlab::BindingsGitLabOwners};
-
 use crate::{github::GitHubOwners, gitlab::GitLabOwners, traits::FromReader};
 
 // TODO(TRUNK-13628): Implement serializing and deserializing for CodeOwners
@@ -72,7 +71,7 @@ impl CodeOwners {
         })
     }
 
-    // TODO: take in origin path and parse CODEOWNERS based on location
+    // TODO(TRUNK-13783): take in origin path and parse CODEOWNERS based on location
     // which informs which parser to use (GitHub or GitLab)
     pub fn parse(codeowners: Vec<u8>) -> Self {
         let owners_result = GitHubOwners::from_reader(codeowners.as_slice())
@@ -94,7 +93,7 @@ pub enum Owners {
     GitLabOwners(GitLabOwners),
 }
 
-// TODO: Make this smarter and return only an object with a .of method
+// TODO(TRUNK-13784): Make this smarter and return only an object with a .of method
 // instead of forcing the ETL to try GitHub or GitLab
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass)]

--- a/codeowners/src/github.rs
+++ b/codeowners/src/github.rs
@@ -12,7 +12,7 @@ use std::{
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 use crate::{FromPath, FromReader, OwnersOfPath};
 
@@ -170,14 +170,11 @@ impl FromReader for GitHubOwners {
 pub struct BindingsGitHubOwners(pub GitHubOwners);
 
 #[cfg(feature = "pyo3")]
-impl OwnersOfPath for BindingsGitHubOwners {
-    type Owner = String;
-
-    fn of<P>(&self, path: P) -> Option<Vec<String>>
-    where
-        P: AsRef<Path>,
-    {
-        let owners = self.0.of(path);
+#[gen_stub_pymethods]
+#[pymethods]
+impl BindingsGitHubOwners {
+    fn of(&self, path: String) -> Option<Vec<String>> {
+        let owners = self.0.of(Path::new(&path));
         match owners {
             Some(owners) => Some(owners.iter().map(|owner| owner.to_string()).collect()),
             None => None,

--- a/codeowners/src/github.rs
+++ b/codeowners/src/github.rs
@@ -9,6 +9,17 @@ use std::{
     str::FromStr,
 };
 
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+#[cfg(feature = "pyo3")]
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
 use crate::{FromPath, FromReader, OwnersOfPath};
 
 /// Various types of owners
@@ -24,7 +35,7 @@ use crate::{FromPath, FromReader, OwnersOfPath};
 ///   raw
 /// );
 /// ```
-#[derive(Debug, PartialEq, Clone, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Eq)]
 pub enum GitHubOwner {
     /// Owner in the form @username
     Username(String),
@@ -68,6 +79,8 @@ impl FromStr for GitHubOwner {
 
 /// Mappings of GitHub owners to path patterns
 #[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct GitHubOwners {
     paths: Vec<(Pattern, Vec<GitHubOwner>)>,
 }

--- a/codeowners/src/github.rs
+++ b/codeowners/src/github.rs
@@ -175,10 +175,7 @@ pub struct BindingsGitHubOwners(pub GitHubOwners);
 impl BindingsGitHubOwners {
     fn of(&self, path: String) -> Option<Vec<String>> {
         let owners = self.0.of(Path::new(&path));
-        match owners {
-            Some(owners) => Some(owners.iter().map(|owner| owner.to_string()).collect()),
-            None => None,
-        }
+        owners.map(|owners| owners.iter().map(ToString::to_string).collect())
     }
 }
 

--- a/codeowners/src/gitlab/mod.rs
+++ b/codeowners/src/gitlab/mod.rs
@@ -12,6 +12,17 @@ use std::{
     path::Path,
 };
 
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+#[cfg(feature = "pyo3")]
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
 use crate::{FromPath, FromReader, OwnersOfPath};
 
 pub use entry::*;
@@ -38,7 +49,9 @@ impl fmt::Display for GitLabOwner {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct GitLabOwners {
     file: File,
 }

--- a/codeowners/src/gitlab/mod.rs
+++ b/codeowners/src/gitlab/mod.rs
@@ -15,13 +15,7 @@ use std::{
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-#[cfg(feature = "wasm")]
-use tsify_next::Tsify;
-#[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::*;
+use pyo3_stub_gen::derive::gen_stub_pyclass;
 
 use crate::{FromPath, FromReader, OwnersOfPath};
 
@@ -49,9 +43,7 @@ impl fmt::Display for GitLabOwner {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
-#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GitLabOwners {
     file: File,
 }
@@ -114,6 +106,26 @@ impl FromReader for GitLabOwners {
         }
 
         Ok(GitLabOwners { file })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass)]
+pub struct BindingsGitLabOwners(pub GitLabOwners);
+
+#[cfg(feature = "pyo3")]
+impl OwnersOfPath for BindingsGitLabOwners {
+    type Owner = String;
+
+    fn of<P>(&self, path: P) -> Option<Vec<String>>
+    where
+        P: AsRef<Path>,
+    {
+        let owners = self.0.of(path);
+        match owners {
+            Some(owners) => Some(owners.iter().map(|owner| owner.to_string()).collect()),
+            None => None,
+        }
     }
 }
 

--- a/codeowners/src/gitlab/mod.rs
+++ b/codeowners/src/gitlab/mod.rs
@@ -119,10 +119,7 @@ pub struct BindingsGitLabOwners(pub GitLabOwners);
 impl BindingsGitLabOwners {
     fn of(&self, path: String) -> Option<Vec<String>> {
         let owners = self.0.of(Path::new(&path));
-        match owners {
-            Some(owners) => Some(owners.iter().map(|owner| owner.to_string()).collect()),
-            None => None,
-        }
+        owners.map(|owners| owners.iter().map(ToString::to_string).collect())
     }
 }
 

--- a/codeowners/src/gitlab/mod.rs
+++ b/codeowners/src/gitlab/mod.rs
@@ -15,7 +15,7 @@ use std::{
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
-use pyo3_stub_gen::derive::gen_stub_pyclass;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 use crate::{FromPath, FromReader, OwnersOfPath};
 
@@ -114,14 +114,11 @@ impl FromReader for GitLabOwners {
 pub struct BindingsGitLabOwners(pub GitLabOwners);
 
 #[cfg(feature = "pyo3")]
-impl OwnersOfPath for BindingsGitLabOwners {
-    type Owner = String;
-
-    fn of<P>(&self, path: P) -> Option<Vec<String>>
-    where
-        P: AsRef<Path>,
-    {
-        let owners = self.0.of(path);
+#[gen_stub_pymethods]
+#[pymethods]
+impl BindingsGitLabOwners {
+    fn of(&self, path: String) -> Option<Vec<String>> {
+        let owners = self.0.of(Path::new(&path));
         match owners {
             Some(owners) => Some(owners.iter().map(|owner| owner.to_string()).collect()),
             None => None,

--- a/codeowners/src/lib.rs
+++ b/codeowners/src/lib.rs
@@ -3,7 +3,7 @@ mod github;
 mod gitlab;
 mod traits;
 
-pub use codeowners::{CodeOwners, Owners};
-pub use github::{GitHubOwner, GitHubOwners};
-pub use gitlab::{GitLabOwner, GitLabOwners};
+pub use codeowners::{BindingsOwners, CodeOwners, Owners};
+pub use github::{BindingsGitHubOwners, GitHubOwner, GitHubOwners};
+pub use gitlab::{BindingsGitLabOwners, GitLabOwner, GitLabOwners};
 pub use traits::{FromPath, FromReader, OwnersOfPath};

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, io::BufReader};
 
 use bundle::{parse_meta_from_tarball as parse_tarball, BindingsVersionedBundle};
-use codeowners::CodeOwners;
+use codeowners::{BindingsOwners, CodeOwners};
 use context::{env, junit, repo};
 use pyo3::{exceptions::PyTypeError, prelude::*};
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyfunction};

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -159,6 +159,7 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(repo_validate, m)?)?;
 
     m.add_class::<codeowners::CodeOwners>()?;
+    m.add_class::<codeowners::BindingsOwners>()?;
     m.add_function(wrap_pyfunction!(codeowners_parse, m)?)?;
 
     m.add_function(wrap_pyfunction!(parse_meta_from_tarball, m)?)?;

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -158,7 +158,6 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<repo::validator::RepoValidationLevel>()?;
     m.add_function(wrap_pyfunction!(repo_validate, m)?)?;
 
-    m.add_class::<codeowners::CodeOwners>()?;
     m.add_class::<codeowners::BindingsOwners>()?;
     m.add_function(wrap_pyfunction!(codeowners_parse, m)?)?;
 

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -123,8 +123,8 @@ pub fn parse_meta_from_tarball(
 
 #[gen_stub_pyfunction]
 #[pyfunction]
-fn codeowners_parse(codeowners_bytes: Vec<u8>) -> CodeOwners {
-    CodeOwners::parse(codeowners_bytes)
+fn codeowners_parse(codeowners_bytes: Vec<u8>) -> PyResult<BindingsOwners> {
+    Ok(BindingsOwners(CodeOwners::parse(codeowners_bytes)))
 }
 
 #[pymodule]

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -124,7 +124,11 @@ pub fn parse_meta_from_tarball(
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn codeowners_parse(codeowners_bytes: Vec<u8>) -> PyResult<BindingsOwners> {
-    Ok(BindingsOwners(CodeOwners::parse(codeowners_bytes)))
+    let codeowners = CodeOwners::parse(codeowners_bytes);
+    match codeowners.owners {
+        Some(owners) => Ok(BindingsOwners(owners)),
+        None => Err(PyTypeError::new_err("Failed to parse CODEOWNERS file")),
+    }
 }
 
 #[pymodule]

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -11,5 +11,49 @@ def test_parse_codeowners_from_tarball_github():
     assert github_owners.of("*.py") == ["@trunk/test"]
 
 
-# TODO: Add tests for GITLAB
-# Currently I am unable to force the parser to interpret the input as a gitlab codeowners file
+def test_parse_codeowners_from_tarball_gitlab():
+    from context_py import codeowners_parse
+
+    codeowners_text = b"""
+        [Documentation]
+        ee/docs    @gl-docs
+        docs       @gl-docs
+
+        [Database]
+        README.md  @gl-database
+        model/db   @gl-database
+
+        [dOcUmEnTaTiOn]
+        README.md  @gl-docs
+
+        [Two Words]
+        README.md  @gl-database
+        model/db   @gl-database
+
+        [Double::Colon]
+        README.md  @gl-database
+        model/db   @gl-database
+
+        [DefaultOwners] @config-owner @gl-docs
+        README.md
+        model/db
+
+        [OverriddenOwners] @config-owner
+        README.md  @gl-docs
+        model/db   @gl-docs
+    """
+    codeowners = codeowners_parse(codeowners_text)
+
+    assert codeowners is not None
+
+    gitlab_owners = codeowners.get_gitlab_owners()
+    assert gitlab_owners is not None
+    assert gitlab_owners.of("README.md") == [
+        "@gl-docs",
+        "@gl-database",
+        "@gl-database",
+        "@gl-database",
+        "@config-owner",
+        "@gl-docs",
+        "@gl-docs",
+    ]

--- a/context-py/tests/test_parse_compressed_codeowners.py
+++ b/context-py/tests/test_parse_compressed_codeowners.py
@@ -1,7 +1,15 @@
-def test_parse_meta_from_tarball():
+def test_parse_codeowners_from_tarball_github():
     from context_py import codeowners_parse
 
     codeowners_text = b"""* @trunk/test"""
     codeowners = codeowners_parse(codeowners_text)
 
     assert codeowners is not None
+
+    github_owners = codeowners.get_github_owners()
+    assert github_owners is not None
+    assert github_owners.of("*.py") == ["@trunk/test"]
+
+
+# TODO: Add tests for GITLAB
+# Currently I am unable to force the parser to interpret the input as a gitlab codeowners file


### PR DESCRIPTION
First pass, with TODOs for future work. Add bindings for python to be able to pass in a bytestream and get out a BindingsOwners object, which can be unpacked into either a BindingsGitHubOwners or BindingsGitLabOwners object. From there, the ETL can invoke owners.of('some/path') to calculate ownership.

Future work: make the BindingsOwners generic so that the ETL doesn't have to unpack it into a specific flavor of owners, and can just invoke .of() directly.