### PR TITLE
Do not embed Magnus

### DIFF
--- a/context-ruby/ext/context_ruby/Cargo.toml
+++ b/context-ruby/ext/context_ruby/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.93"
 context = { path = "../../../context", features = ["git-access", "ruby"] }
-magnus = { version = "0.7", features = ["embed"] }
+magnus = { version = "0.7" }


### PR DESCRIPTION
Related thread https://trunk-io.slack.com/archives/C044VBASZ0D/p1733515756917399

We don't actually need this as it allows us to call ruby from rust. We'll just test the rust bindings for ruby directly using ruby code.