### PR TITLE
(Chore): Build protoc from source

### DIFF
--- a/.github/actions/setup_proto/action.yaml
+++ b/.github/actions/setup_proto/action.yaml
@@ -7,5 +7,6 @@ runs:
     - name: Install cmake
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
         sudo apt-get install cmake -y
       shell: bash

--- a/.github/actions/setup_rust_cargo/action.yaml
+++ b/.github/actions/setup_rust_cargo/action.yaml
@@ -18,3 +18,6 @@ runs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Setup Proto
+      uses: ./.github/actions/setup_proto

--- a/.github/actions/setup_rust_cargo/action.yaml
+++ b/.github/actions/setup_rust_cargo/action.yaml
@@ -9,16 +9,6 @@ runs:
       with:
         targets: wasm32-unknown-unknown
 
-    - name: Install protoc
-      shell: bash
-      run: |
-        if [ -f /opt/homebrew/bin/brew ]; then
-          /opt/homebrew/bin/brew install protobuf
-        elif [ -f /usr/bin/apt ]; then
-          sudo /usr/bin/apt update
-          sudo /usr/bin/apt install -y protobuf-compiler
-        fi
-
     - uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,9 +109,6 @@ jobs:
       - name: Setup Ruby
         uses: ./.github/actions/setup_ruby
 
-      - name: Setup proto
-        uses: ./.github/actions/setup_proto
-
       - name: Build workspace
         run: cargo build --all
 

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -53,22 +53,12 @@ jobs:
             if [ -f /usr/bin/yum ]; then
               # quay.io/pypa/manylinux2014_x86_64:latest
               /usr/bin/yum -y upgrade
-              /usr/bin/yum -y install perl-IPC-Cmd perl-List-MoreUtils openssl-devel python3-pip unzip
+              /usr/bin/yum -y install perl-IPC-Cmd perl-List-MoreUtils openssl-devel python3-pip cmake
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
             elif [ -f /usr/bin/apt ]; then
               # ghcr.io/rust-cross/manylinux2014-cross:aarch64
               /usr/bin/apt update
-              /usr/bin/apt install -y pkg-config libssl-dev unzip
-            fi
-
-            if [ "$(uname -m)" == "aarch64" ]; then
-              curl -L https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-aarch_64.zip -o protoc.zip
-              unzip protoc.zip
-              export PROTOC=$(pwd)/bin/protoc
-            else
-              curl -L https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip -o protoc.zip
-              unzip protoc.zip
-              export PROTOC=$(pwd)/bin/protoc
+              /usr/bin/apt install -y pkg-config libssl-dev cmake
             fi
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -62,37 +62,10 @@ actions:
     - trunk-check-pre-push
     - trunk-fmt-pre-commit
     - trunk-upgrade-available
-downloads:
-  - name: protoc
-    downloads:
-      - os:
-          linux: linux
-          macos: osx
-        cpu:
-          x86_64: x86_64
-          arm_64: aarch_64
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-${os}-${cpu}.zip
-      - os:
-          windows: windows
-        cpu:
-          x86_64: x86_64
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-win64.zip
 tools:
-  definitions:
-    - name: protoc
-      download: protoc
-      known_good_version: 29.1
-      shims: [protoc]
-      environment:
-        - name: PATH
-          list: ["${tool}/bin"]
-      health_checks:
-        - command: protoc --version
-          parse_regex: libprotoc (\d+\.\d+)
   runtimes:
     - ruby
     - node
   enabled:
     - gh@2.62.0
     - pnpm@9.14.2
-    - protoc@29.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "prost 0.13.4",
  "prost-build 0.13.4",
  "prost-types 0.13.4",
+ "protobuf-src",
  "serde",
  "serde_json",
  "tonic",

--- a/bazel-bep/Cargo.toml
+++ b/bazel-bep/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.133"
 [build-dependencies]
 tonic-build = "0.10"
 prost-build = "0.13.3"
+protobuf-src = "2.1.0"
 pbjson-build = "0.7.0"
 
 [features]

--- a/bazel-bep/build.rs
+++ b/bazel-bep/build.rs
@@ -1,6 +1,7 @@
 use std::{env, io, path::PathBuf};
 
 fn main() -> io::Result<()> {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
     let protos = std::fs::read_dir("proto")?
         .filter(|a| {
             if let Ok(a) = a {


### PR DESCRIPTION
Rather than installing protoc in CI, install from source using cmake. This changes https://github.com/trunk-io/analytics-cli/pull/197 to behave more like https://github.com/trunk-io/analytics-cli/pull/203