### PR TITLE
(Fix): Calculate failed tests accounting for retries

### DIFF
--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -31,6 +31,7 @@ pub struct Test {
     pub class_name: Option<String>,
     pub file: Option<String>,
     pub id: String,
+    pub timestamp_millis: Option<i64>,
 }
 
 impl Test {
@@ -42,6 +43,7 @@ impl Test {
         id: Option<String>,
         org_slug: &str,
         repo: &BundleRepo,
+        timestamp_millis: Option<i64>,
     ) -> Self {
         if let Some(id) = id {
             return Test {
@@ -50,6 +52,7 @@ impl Test {
                 class_name,
                 file,
                 id,
+                timestamp_millis,
             };
         }
         // generate a unique id if not provided
@@ -72,6 +75,7 @@ impl Test {
             class_name,
             file,
             id,
+            timestamp_millis,
         }
     }
 }
@@ -267,6 +271,7 @@ mod tests {
             None,
             org_slug,
             &repo,
+            Some(0),
         );
         assert_eq!(result.name, name);
         assert_eq!(result.parent_name, parent_name);
@@ -281,6 +286,7 @@ mod tests {
             Some(String::from("da5b8893-d6ca-5c1c-9a9c-91f40a2a3649")),
             org_slug,
             &repo,
+            Some(0),
         );
         assert_eq!(result.name, name);
         assert_eq!(result.parent_name, parent_name);

--- a/cli-tests/test_fixtures/bep_retries
+++ b/cli-tests/test_fixtures/bep_retries
@@ -1,0 +1,81 @@
+{
+  "id": {
+    "testResult": {
+      "label": "//trunk/hello_world/cc:hello_test",
+      "run": 1,
+      "shard": 1,
+      "attempt": 1,
+      "configuration": {
+        "id": "2136e65c67d9ba6b2652accfbf6533486c16692a484f4dc7ea7756de0edc13a6"
+      }
+    }
+  },
+  "children": [
+    {
+      "testResult": {
+        "label": "//trunk/hello_world/cc:hello_test",
+        "run": 1,
+        "shard": 1,
+        "attempt": 2,
+        "configuration": {
+          "id": "2136e65c67d9ba6b2652accfbf6533486c16692a484f4dc7ea7756de0edc13a6"
+        }
+      }
+    }
+  ],
+  "testResult": {
+    "testActionOutput": [
+      {
+        "name": "test.xml",
+        "uri": "${URI_FAIL}"
+      }
+    ],
+    "testAttemptDurationMillis": "43",
+    "status": "FAILED",
+    "testAttemptStartMillisEpoch": "1733811443963",
+    "executionInfo": {
+      "strategy": "linux-sandbox",
+      "timingBreakdown": {
+        "child": [],
+        "name": "totalTime",
+        "time": "0.043s"
+      }
+    },
+    "testAttemptStart": "2024-12-10T06:17:23.963Z",
+    "testAttemptDuration": "0.043s"
+  }
+}
+{
+  "id": {
+    "testResult": {
+      "label": "//trunk/hello_world/cc:hello_test",
+      "run": 1,
+      "shard": 1,
+      "attempt": 2,
+      "configuration": {
+        "id": "2136e65c67d9ba6b2652accfbf6533486c16692a484f4dc7ea7756de0edc13a6"
+      }
+    }
+  },
+  "testResult": {
+    "testActionOutput": [
+      {
+        "name": "test.xml",
+        "uri": "${URI_PASS}"
+      }
+    ],
+    "testAttemptDurationMillis": "44",
+    "status": "PASSED",
+    "testAttemptStartMillisEpoch": "1733811444011",
+    "executionInfo": {
+      "strategy": "linux-sandbox",
+      "timingBreakdown": {
+        "child": [],
+        "name": "totalTime",
+        "time": "0.044s"
+      }
+    },
+    "testAttemptStart": "2024-12-10T06:17:24.011Z",
+    "testAttemptDuration": "0.044s"
+  }
+}

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -313,9 +313,13 @@ mod tests {
     use bundle::{BundledFile, FileSetType};
     use test_utils::inputs::get_test_file_path;
 
+    /// Contains 1 failure at 1:00
     const JUNIT0_FAIL: &str = "test_fixtures/junit0_fail.xml";
+    // Contains 1 pass at 2:00
     const JUNIT0_PASS: &str = "test_fixtures/junit0_pass.xml";
+    // Contains 1 failure at 3:00 and 1 failure at 5:00
     const JUNIT1_FAIL: &str = "test_fixtures/junit1_fail.xml";
+    // Contains 2 passes at 4:00
     const JUNIT1_PASS: &str = "test_fixtures/junit1_pass.xml";
 
     const ORG_SLUG: &str = "test-org";

--- a/cli/test_fixtures/junit0_fail.xml
+++ b/cli/test_fixtures/junit0_fail.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="1" disabled="0" errors="0" time="0.001" timestamp="2024-12-10T01:00:00.000" name="AllTests">
+  <testsuite name="HelloTest" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="0.001" timestamp="2024-12-10T01:00:00.000">
+    <testcase name="Hello" file="trunk/hello_world/cc/hello_test.cc" line="9" status="run" result="completed" time="0.001" timestamp="2024-12-10T01:00:00.000" classname="HelloTest">
+      <failure message="Failure at 1:00"/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/cli/test_fixtures/junit0_pass.xml
+++ b/cli/test_fixtures/junit0_pass.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="0" disabled="0" errors="0" time="0." timestamp="2024-12-10T02:00:00.000" name="AllTests">
+  <testsuite name="HelloTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="0." timestamp="2024-12-10T02:00:00.000">
+    <testcase name="Hello" file="trunk/hello_world/cc/hello_test.cc" line="9" status="run" result="completed" time="0." timestamp="2024-12-10T02:00:00.000" classname="HelloTest" />
+  </testsuite>
+</testsuites>

--- a/cli/test_fixtures/junit1_fail.xml
+++ b/cli/test_fixtures/junit1_fail.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="1" disabled="0" errors="0" time="0.001" timestamp="2024-12-10T03:00:00.000" name="AllTests">
+  <testsuite name="HelloTest" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="0.001" timestamp="2024-12-10T03:00:00.000">
+    <testcase name="Hello" file="trunk/hello_world/cc/hello_test.cc" line="9" status="run" result="completed" time="0.001" timestamp="2024-12-10T03:00:00.000" classname="HelloTest">
+      <failure message="Failure at 3:00"/>
+    </testcase>
+  </testsuite>
+  <testsuite name="GoodbyeTest" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="0.001" timestamp="2024-12-10T05:00:00.000">
+    <testcase name="Goodbye" file="trunk/hello_world/cc/hello_test.cc" line="9" status="run" result="completed" time="0.001" timestamp="2024-12-10T05:00:00.000" classname="HelloTest">
+      <failure message="Failure at 5:00"/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/cli/test_fixtures/junit1_pass.xml
+++ b/cli/test_fixtures/junit1_pass.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="0" disabled="0" errors="0" time="0." timestamp="2024-12-10T04:00:00.000" name="AllTests">
+  <testsuite name="HelloTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="0." timestamp="2024-12-10T04:00:00.000">
+    <testcase name="Hello" file="trunk/hello_world/cc/hello_test.cc" line="9" status="run" result="completed" time="0." timestamp="2024-12-10T04:00:00.000" classname="HelloTest" />
+  </testsuite>
+  <testsuite name="GoodbyeTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="0." timestamp="2024-12-10T04:00:00.000">
+    <testcase name="Goodbye" file="trunk/hello_world/cc/hello_test.cc" line="9" status="run" result="completed" time="0." timestamp="2024-12-10T04:00:00.000" classname="HelloTest" />
+  </testsuite>
+</testsuites>

--- a/context/src/bazel_bep/parser.rs
+++ b/context/src/bazel_bep/parser.rs
@@ -121,23 +121,15 @@ impl BazelBepParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use test_utils::inputs::get_test_file_path;
 
     const SIMPLE_EXAMPLE: &str = "test_fixtures/bep_example";
     const EMPTY_EXAMPLE: &str = "test_fixtures/bep_empty";
     const PARTIAL_EXAMPLE: &str = "test_fixtures/bep_partially_valid";
 
-    fn get_test_file(file: &str) -> String {
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
-            .join(file)
-            .to_str()
-            .unwrap()
-            .to_string()
-    }
-
     #[test]
     fn test_parse_simple_bep() {
-        let input_file = get_test_file(SIMPLE_EXAMPLE);
+        let input_file = get_test_file_path(SIMPLE_EXAMPLE);
         let mut parser = BazelBepParser::new(input_file);
         parser.parse().unwrap();
 
@@ -151,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_parse_empty_bep() {
-        let input_file = get_test_file(EMPTY_EXAMPLE);
+        let input_file = get_test_file_path(EMPTY_EXAMPLE);
         let mut parser = BazelBepParser::new(input_file);
         parser.parse().unwrap();
 
@@ -162,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_parse_partial_bep() {
-        let input_file = get_test_file(PARTIAL_EXAMPLE);
+        let input_file = get_test_file_path(PARTIAL_EXAMPLE);
         let mut parser = BazelBepParser::new(input_file);
         parser.parse().unwrap();
 

--- a/test_utils/src/inputs.rs
+++ b/test_utils/src/inputs.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+pub fn get_test_file_path(file: &str) -> String {
+    PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join(file)
+        .to_str()
+        .unwrap()
+        .to_string()
+}

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod inputs;
 pub mod mock_git_repo;
 mod mock_logger;
 mod mock_sentry;


### PR DESCRIPTION
Uses the last timestamp for a given test ID to determine whether or not it failed, for the sake of setting a local exit code.

This is primarily to support `--bazel-bep-path`, which if bazel retries are on for flaky tests, [will output multiple junit xmls for a single test](https://github.com/trunk-io/trunk/actions/runs/12245144578/job/34158530182?pr=19962). Adds unit and integration tests to cover the repro case.
- There were a couple different options for how to approach this (BEP introspection, passing junit rankings along, etc.), but using the timestamp seems to be the most generic/extensible, and we still defer to the services for any final parsing, since the only logic we're applying here is setting the exit code