### PR TITLE
(Feat): Upload streamlined BEP file

### DIFF
--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -86,6 +86,8 @@ impl BundlerUtil {
                     log::error!("Failed to write BEP event: {}", e);
                 }
             });
+            bep_events_file.flush()?;
+            bep_events_file.seek(std::io::SeekFrom::Start(0))?;
             tar.append_file("bazel_bep.json", &mut bep_events_file)?;
             total_bytes_in += bep_events_file.seek(std::io::SeekFrom::End(0))?;
         }

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -1,7 +1,7 @@
 use async_compression::futures::bufread::ZstdDecoder;
 use async_std::{io::ReadExt, stream::StreamExt};
 use async_tar_wasm::Archive;
-use context::bazel_bep::parser::BazelBepParser;
+use context::bazel_bep::parser::BepParseResult;
 use futures_io::AsyncBufRead;
 use std::path::PathBuf;
 use std::{
@@ -22,7 +22,7 @@ use crate::bundle_meta::{BundleMeta, VersionedBundle};
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct BundlerUtil {
     pub meta: BundleMeta,
-    pub bep_parser: Option<BazelBepParser>,
+    pub bep_result: Option<BepParseResult>,
 }
 
 const META_FILENAME: &'static str = "meta.json";
@@ -30,12 +30,8 @@ const META_FILENAME: &'static str = "meta.json";
 impl BundlerUtil {
     const ZSTD_COMPRESSION_LEVEL: i32 = 15; // This gives roughly 10x compression for text, 22 gives 11x.
 
-    pub fn new(meta: BundleMeta, bep_parser: Option<BazelBepParser>) -> Self {
-        Self { meta, bep_parser }
-    }
-
-    pub fn set_bep_parser(&mut self, bep_parser: BazelBepParser) {
-        self.bep_parser = Some(bep_parser);
+    pub fn new(meta: BundleMeta, bep_result: Option<BepParseResult>) -> Self {
+        Self { meta, bep_result }
     }
 
     /// Writes compressed tarball to disk.
@@ -79,9 +75,9 @@ impl BundlerUtil {
             total_bytes_in += std::fs::metadata(path)?.len();
         }
 
-        if let Some(bep_parser) = self.bep_parser.as_ref() {
+        if let Some(bep_result) = self.bep_result.as_ref() {
             let mut bep_events_file = tempfile::tempfile()?;
-            bep_parser.bep_test_events().iter().for_each(|event| {
+            bep_result.bep_test_events.iter().for_each(|event| {
                 if let Err(e) = serde_json::to_writer(&bep_events_file, event) {
                     log::error!("Failed to write BEP event: {}", e);
                 }

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -233,12 +233,7 @@ async fn upload_bundle_using_bep() {
     assert!(junit_parser.parse(junit_reader).is_ok());
     assert!(junit_parser.errors().is_empty());
 
-    let mut bazel_bep_parser = BazelBepParser::new(
-        tar_extract_directory
-            .join("bazel_bep.json")
-            .to_string_lossy()
-            .to_string(),
-    );
+    let mut bazel_bep_parser = BazelBepParser::new(tar_extract_directory.join("bazel_bep.json"));
     let parse_result = bazel_bep_parser.parse().ok().unwrap();
     assert!(parse_result.errors.is_empty());
     assert_eq!(parse_result.xml_file_counts(), (1, 0));

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -239,9 +239,9 @@ async fn upload_bundle_using_bep() {
             .to_string_lossy()
             .to_string(),
     );
-    assert!(bazel_bep_parser.parse().is_ok());
-    assert!(bazel_bep_parser.errors().is_empty());
-    assert_eq!(bazel_bep_parser.test_counts(), (1, 0));
+    let parse_result = bazel_bep_parser.parse().ok().unwrap();
+    assert!(parse_result.errors.is_empty());
+    assert_eq!(parse_result.xml_file_counts(), (1, 0));
 
     // HINT: View CLI output with `cargo test -- --nocapture`
     println!("{assert}");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -230,9 +230,9 @@ async fn run(cli: Cli) -> anyhow::Result<i32> {
             let junit_file_paths = match bazel_bep_path {
                 Some(bazel_bep_path) => {
                     let mut parser = BazelBepParser::new(bazel_bep_path);
-                    parser.parse()?;
-                    print_bep_results(&parser);
-                    parser.uncached_xml_files()
+                    let bep_result = parser.parse()?;
+                    print_bep_results(&bep_result);
+                    bep_result.uncached_xml_files()
                 }
                 None => junit_paths,
             };

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,14 +1,14 @@
-use context::bazel_bep::parser::BazelBepParser;
+use context::bazel_bep::parser::BepParseResult;
 
-pub fn print_bep_results(parser: &BazelBepParser) {
-    if !parser.errors().is_empty() {
-        log::warn!("Errors parsing BEP file: {:?}", &parser.errors());
+pub fn print_bep_results(bep_result: &BepParseResult) {
+    if !bep_result.errors.is_empty() {
+        log::warn!("Errors parsing BEP file: {:?}", &bep_result.errors);
     }
 
-    let (test_count, cached_count) = parser.test_counts();
+    let (xml_count, cached_xml_count) = bep_result.xml_file_counts();
     log::info!(
         "Parsed {} ({} cached) test results from BEP file",
-        test_count,
-        cached_count
+        xml_count,
+        cached_xml_count
     );
 }

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -35,9 +35,9 @@ pub async fn run_test_command(
         JunitSpec::Paths(paths) => paths,
         JunitSpec::BazelBep(bep_path) => {
             let mut parser = BazelBepParser::new(bep_path);
-            parser.parse()?;
-            print_bep_results(&parser);
-            parser.uncached_xml_files()
+            let bep_result = parser.parse()?;
+            print_bep_results(&bep_result);
+            bep_result.uncached_xml_files()
         }
     };
 

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -309,7 +309,7 @@ pub async fn run_upload(
 
     let bundle_temp_dir = tempfile::tempdir()?;
     let bundle_time_file = bundle_temp_dir.path().join("bundle.tar.zstd");
-    let mut bundle = BundlerUtil::new(meta, bep_parser);
+    let bundle = BundlerUtil::new(meta, bep_parser);
     bundle.make_tarball(&bundle_time_file)?;
     log::info!("Flushed temporary tarball to {:?}", bundle_time_file);
 

--- a/context/src/bazel_bep/parser.rs
+++ b/context/src/bazel_bep/parser.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Ok;
 use bazel_bep::types::build_event_stream::{build_event::Payload, file::File::Uri, BuildEvent};
 use serde_json::Deserializer;
@@ -51,13 +53,13 @@ impl BepParseResult {
 /// https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
 #[derive(Debug, Clone, Default)]
 pub struct BazelBepParser {
-    bazel_bep_path: String,
+    bazel_bep_path: PathBuf,
 }
 
 impl BazelBepParser {
-    pub fn new(bazel_bep_path: String) -> Self {
+    pub fn new<T: Into<PathBuf>>(bazel_bep_path: T) -> Self {
         Self {
-            bazel_bep_path,
+            bazel_bep_path: bazel_bep_path.into(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Include a subset of the BEP file in the bundle tar. This strips it to just `testResult` events, which removes sensitive information that may be in other events

This is mainly for our debugging purposes and for evaluating the success of this feature