### PR TITLE
Check if cli exists before executing

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -39,6 +39,7 @@ jobs:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         shell: bash
         run: |
+          ls -lh ./trunk-analytics-cli && \
           ./trunk-analytics-cli test \
           --org-url-slug trunk-staging-org \
           --junit-paths ${{ github.workspace }}/target/**/*junit.xml \


### PR DESCRIPTION
Check if CLI exists before executing.

We have seen some sporadic exit code 127.

https://trunk-io.slack.com/archives/C044VBASZ0D/p1734148787307919?thread_ts=1734148787.307919&cid=C044VBASZ0D