### PR TITLE
Lock nextest

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Nextest
         shell: bash
         run: |
-          cargo install --version 0.9.85 cargo-nextest
+          cargo install --version 0.9.85 cargo-nextest --locked
 
       - name: Install cmake
         shell: bash


### PR DESCRIPTION
Locking nextest installs to a pinned version so we don't have false alarms from breaking dependencies.