### PR TITLE
Remove parsing errors from empty tags and testsuite names

### DIFF
--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -72,13 +72,6 @@ describe("context-js", () => {
             <system-err/>
           </testcase>
         </testsuite>
-        <testsuite name="" tests="1" disabled="0" errors="0" failures="1" timestamp="${validTimestamp}">
-          <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="${validTimestamp}" time="1">
-            <failure/>
-            <system-out/>
-            <system-err/>
-          </testcase>
-        </testsuite>
       </testsuites>
     `;
 
@@ -110,6 +103,23 @@ describe("context-js", () => {
         .all_issues_owned()
         .filter((issue) => issue.error_type === JunitValidationType.Report),
     ).toHaveLength(1);
+
+    const nestedJunitXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <testsuites>
+          <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" timestamp="${validTimestamp}" time="0.001161">
+              <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="${validTimestamp}">
+                  <testsuite name="" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="${validTimestamp}">
+                      <testcase name="testCanBeCreatedFromValidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="6" class="EmailTest" classname="EmailTest" assertions="1" time="0.000860" timestamp="${validTimestamp}"/>
+                      <testcase name="testCannotBeCreatedFromInvalidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="15" class="EmailTest" classname="EmailTest" assertions="1" time="0.000301" timestamp="${validTimestamp}"/>
+                  </testsuite>
+              </testsuite>
+          </testsuite>
+      </testsuites>`;
+
+    report = junit_parse(Buffer.from(nestedJunitXml, "utf-8"));
+    junitReportValidation = junit_validate(report[0]);
+
+    expect(junitReportValidation.max_level()).toBe(JunitValidationLevel.Valid);
   });
 
   it("validates repos", () => {

--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -68,6 +68,15 @@ describe("context-js", () => {
         <testsuite name="my-test-suite" tests="1" disabled="0" errors="0" failures="1" timestamp="${validTimestamp}">
           <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="${validTimestamp}" time="1">
             <failure/>
+            <system-out/>
+            <system-err/>
+          </testcase>
+        </testsuite>
+        <testsuite name="" tests="1" disabled="0" errors="0" failures="1" timestamp="${validTimestamp}">
+          <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="${validTimestamp}" time="1">
+            <failure/>
+            <system-out/>
+            <system-err/>
           </testcase>
         </testsuite>
       </testsuites>

--- a/context-py/tests/test_junit_parse.py
+++ b/context-py/tests/test_junit_parse.py
@@ -95,9 +95,9 @@ def test_junit_parse_nested_testsuites():
 
     nested_testsuites_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
-      <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
-          <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
-              <testsuite name="" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
+      <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}">
+          <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}">
+              <testsuite name="" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}">
                   <testcase name="testCanBeCreatedFromValidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="6" class="EmailTest" classname="EmailTest" assertions="1" time="0.000860"/>
                   <testcase name="testCannotBeCreatedFromInvalidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="15" class="EmailTest" classname="EmailTest" assertions="1" time="0.000301"/>
               </testsuite>

--- a/context-py/tests/test_junit_parse.py
+++ b/context-py/tests/test_junit_parse.py
@@ -26,18 +26,6 @@ def test_junit_parse_valid():
           </error>
         </testcase>
       </testsuite>
-      <testsuite name="" tests="1" disabled="0" errors="0" failures="1" timestamp="{valid_timestamp}">
-        <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="{valid_timestamp}" time="1">
-          <failure message="AssertionError: assert 'testdata' in '# estdata'">
-            FAILURE BODY
-          </failure>
-          <system-out/>
-          <system-err/>
-          <error message="       " type="">
-            <!-- Example of a test case with empty error text. -->
-          </error>
-        </testcase>
-      </testsuite>
     </testsuites>
    """
 
@@ -99,14 +87,17 @@ def test_junit_parse_broken_xml():
 
 def test_junit_parse_nested_testsuites():
     import typing as PT
+    from datetime import datetime, timezone
 
     from context_py import BindingsReport, BindingsTestCaseStatusStatus, junit_parse
 
-    nested_testsuites_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    valid_timestamp = datetime.now().astimezone(timezone.utc).isoformat()
+
+    nested_testsuites_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
-        <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
-            <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
-                <testsuite name="EmailTest" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161">
+        <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
+            <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
+                <testsuite name="" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
                     <testcase name="testCanBeCreatedFromValidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="6" class="EmailTest" classname="EmailTest" assertions="1" time="0.000860"/>
                     <testcase name="testCannotBeCreatedFromInvalidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="15" class="EmailTest" classname="EmailTest" assertions="1" time="0.000301"/>
                 </testsuite>

--- a/context-py/tests/test_junit_parse.py
+++ b/context-py/tests/test_junit_parse.py
@@ -93,8 +93,7 @@ def test_junit_parse_nested_testsuites():
 
     valid_timestamp = datetime.now().astimezone(timezone.utc).isoformat()
 
-    nested_testsuites_xml = f"""
-    <?xml version="1.0" encoding="UTF-8"?>
+    nested_testsuites_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
       <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
           <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>

--- a/context-py/tests/test_junit_parse.py
+++ b/context-py/tests/test_junit_parse.py
@@ -93,19 +93,21 @@ def test_junit_parse_nested_testsuites():
 
     valid_timestamp = datetime.now().astimezone(timezone.utc).isoformat()
 
-    nested_testsuites_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+    nested_testsuites_xml = f"""
+    <?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
-        <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
-            <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
-                <testsuite name="" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
-                    <testcase name="testCanBeCreatedFromValidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="6" class="EmailTest" classname="EmailTest" assertions="1" time="0.000860"/>
-                    <testcase name="testCannotBeCreatedFromInvalidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="15" class="EmailTest" classname="EmailTest" assertions="1" time="0.000301"/>
-                </testsuite>
-            </testsuite>
-        </testsuite>
-    </testsuites>"""
+      <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
+          <testsuite name="Project Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
+              <testsuite name="" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.001161" timestamp="{valid_timestamp}>
+                  <testcase name="testCanBeCreatedFromValidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="6" class="EmailTest" classname="EmailTest" assertions="1" time="0.000860"/>
+                  <testcase name="testCannotBeCreatedFromInvalidEmail" file="/home/runner/work/flake-farm/flake-farm/php/phpunit/tests/EmailTest.php" line="15" class="EmailTest" classname="EmailTest" assertions="1" time="0.000301"/>
+              </testsuite>
+          </testsuite>
+      </testsuite>
+    </testsuites>
+    """
 
-    reports: PT.List[BindingsReport] = junit_parse(nested_testsuites_xml)
+    reports: PT.List[BindingsReport] = junit_parse(str.encode(nested_testsuites_xml))
 
     assert len(reports) == 1
     report = reports[0]

--- a/context-py/tests/test_junit_parse.py
+++ b/context-py/tests/test_junit_parse.py
@@ -19,7 +19,20 @@ def test_junit_parse_valid():
           <failure message="AssertionError: assert 'testdata' in '# estdata'">
             FAILURE BODY
           </failure>
-
+          <system-out/>
+          <system-err/>
+          <error message="       " type="">
+            <!-- Example of a test case with empty error text. -->
+          </error>
+        </testcase>
+      </testsuite>
+      <testsuite name="" tests="1" disabled="0" errors="0" failures="1" timestamp="{valid_timestamp}">
+        <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="{valid_timestamp}" time="1">
+          <failure message="AssertionError: assert 'testdata' in '# estdata'">
+            FAILURE BODY
+          </failure>
+          <system-out/>
+          <system-err/>
           <error message="       " type="">
             <!-- Example of a test case with empty error text. -->
           </error>

--- a/context/src/junit/parser.rs
+++ b/context/src/junit/parser.rs
@@ -38,8 +38,6 @@ pub enum JunitParseError {
     ReportMultipleFound,
     #[error("report end tag found without start tag")]
     ReportStartTagNotFound,
-    #[error("could not parse test suite name")]
-    TestSuiteName,
     #[error("test suite end tag found without start tag")]
     TestSuiteStartTagNotFound,
     #[error("could not parse test case name")]
@@ -54,12 +52,6 @@ pub enum JunitParseError {
     TestRerunStartTagNotFound,
     #[error("test rerun end tag found without start tag")]
     TestRerunTestCaseNotFound,
-    #[error("system out is empty")]
-    SystemOutEmpty,
-    #[error("system err is empty")]
-    SystemErrEmpty,
-    #[error("stack trace is empty")]
-    StackTraceEmpty,
 }
 
 #[derive(Debug, Clone)]
@@ -213,9 +205,6 @@ impl JunitParser {
                     self.open_test_rerun(&e);
                     self.close_test_rerun();
                 }
-                TAG_TEST_RERUN_STACK_TRACE => self.errors.push(JunitParseError::StackTraceEmpty),
-                TAG_SYSTEM_OUT => self.errors.push(JunitParseError::SystemOutEmpty),
-                TAG_SYSTEM_ERR => self.errors.push(JunitParseError::SystemErrEmpty),
                 _ => (),
             },
             Event::CData(e) => {
@@ -295,9 +284,6 @@ impl JunitParser {
         }
 
         let test_suite_name = parse_attr::name(e).unwrap_or_default();
-        if test_suite_name.is_empty() {
-            self.errors.push(JunitParseError::TestSuiteName);
-        };
         let mut test_suite = TestSuite::new(test_suite_name);
 
         if let Some(timestamp) = parse_attr::timestamp(e, &mut self.date_parser) {


### PR DESCRIPTION
Baby's first rust PR plz be gentle

## Context
See [here](https://trunk-io.slack.com/archives/C044VBASZ0D/p1734365895854939) for the reasoning behind this. TL:DR is that we were reporting parsing errors for files that don't actually have errors that make them unparsable. These errors were:
1. `StackTraceEmpty` - empty stack trace tag
2. `SystemErrEmpty` empty `<system-err/>`
3. `SystemOutEmpty` empty `system-out/>`
4. `TestSuiteName` empty `testsuite name`

StackAV was getting a ton of errors from this that we were reporting

## Fix
Remove throwing errors relating to these. I left the logic for parsing the tags in there, but just made it so we aren't going to throw an error anymore

## Tests
Update tests in order to addresss