### PR TITLE
[runner integration - 1] Add support for test report generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -490,17 +496,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -722,6 +728,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -1122,6 +1129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1408,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
@@ -2658,6 +2675,15 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -2813,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -3253,13 +3279,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-wkt"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
+dependencies = [
+ "chrono",
+ "inventory",
+ "prost 0.13.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "typetag",
+]
+
+[[package]]
+name = "prost-wkt-build"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
+dependencies = [
+ "heck",
+ "prost 0.13.4",
+ "prost-build 0.13.4",
+ "prost-types 0.13.4",
+ "quote",
+]
+
+[[package]]
+name = "prost-wkt-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
+dependencies = [
+ "chrono",
+ "prost 0.13.4",
+ "prost-build 0.13.4",
+ "prost-types 0.13.4",
+ "prost-wkt",
+ "prost-wkt-build",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "proto"
 version = "0.0.0"
 dependencies = [
  "prost 0.13.4",
  "prost-build 0.13.4",
  "prost-types 0.13.4",
+ "prost-wkt-types",
  "protobuf-src",
+ "serde",
 ]
 
 [[package]]
@@ -4224,6 +4298,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "test_report"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "js-sys",
+ "magnus",
+ "prost 0.13.4",
+ "prost-wkt-types",
+ "proto",
+ "serde_json",
+ "tempfile",
+ "test_utils",
+ "tokio",
+ "trunk-analytics-cli",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "test_utils"
 version = "0.1.0"
 dependencies = [
@@ -4658,6 +4751,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
+name = "typetag"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba3b6e86ffe0054b2c44f2d86407388b933b16cb0a70eea3929420db1d9bbe"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b20a22c42c8f1cd23ce5e34f165d4d37038f5b663ad20fb6adbdf029172483"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,9 +4302,12 @@ name = "test_report"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
+ "bundle",
  "chrono",
  "js-sys",
  "magnus",
+ "more-asserts",
  "prost 0.13.4",
  "prost-wkt-types",
  "proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "smoke-test",
   "test_utils",
   "xcresult",
+  "test_report",
 ]
 exclude = ["context-ruby/ext/context_ruby"]
 resolver = "2"

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -115,6 +115,37 @@ pub struct UploadArgs {
     pub allow_empty_test_results: bool,
 }
 
+impl UploadArgs {
+    pub fn new(
+        token: String,
+        org_url_slug: String,
+        junit_paths: Vec<String>,
+        repo_root: String,
+    ) -> Self {
+        Self {
+            junit_paths,
+            #[cfg(target_os = "macos")]
+            xcresult_path: None,
+            org_url_slug,
+            token,
+            bazel_bep_path: None,
+            repo_root: Some(repo_root),
+            repo_url: None,
+            repo_head_sha: None,
+            repo_head_branch: None,
+            repo_head_commit_epoch: None,
+            tags: Vec::new(),
+            print_files: false,
+            dry_run: false,
+            team: None,
+            // TODO - how are code owners handled?
+            codeowners_path: None,
+            use_quarantining: false,
+            allow_empty_test_results: true,
+        }
+    }
+}
+
 pub async fn run_upload(
     upload_args: UploadArgs,
     test_command: Option<String>,

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/lib.rs"
 [dependencies]
 prost = "0.13.4"
 prost-types = "0.13.4"
+prost-wkt-types = "0.6.0"
+serde = "1.0.215"
 
 [build-dependencies]
 prost-build = "0.13.4"

--- a/proto/proto/test_context.proto
+++ b/proto/proto/test_context.proto
@@ -16,7 +16,6 @@ message TestCaseRun {
   string name = 2;
   string classname = 3;
   string file = 4;
-  // need parent_id
   string parent_name = 5;
   int32 line = 6;
   TestCaseRunStatus status = 7;

--- a/proto/proto/test_context.proto
+++ b/proto/proto/test_context.proto
@@ -4,5 +4,35 @@ import "google/protobuf/timestamp.proto";
 
 package test_context.test_run;
 
+enum TestCaseRunStatus {
+  TEST_CASE_RUN_STATUS_UNSPECIFIED = 0;
+  TEST_CASE_RUN_STATUS_SUCCESS = 1;
+  TEST_CASE_RUN_STATUS_FAILURE = 2;
+  TEST_CASE_RUN_STATUS_SKIPPED = 3;
+}
+
 message TestCaseRun {
+  string id = 1;
+  string name = 2;
+  string classname = 3;
+  string file = 4;
+  // need parent_id
+  string parent_name = 5;
+  int32 line = 6;
+  TestCaseRunStatus status = 7;
+  int32 attempt_number = 8;
+  google.protobuf.Timestamp started_at = 9;
+  google.protobuf.Timestamp finished_at = 10;
+  string status_output_message = 11;
+}
+
+message UploaderMetadata {
+    string version = 1;
+    string origin = 2; // RSpec, jest, etc..
+    google.protobuf.Timestamp upload_time = 3;
+}
+
+message TestResult {
+  repeated TestCaseRun test_case_runs = 1;
+  UploaderMetadata uploader_metadata = 2;
 }

--- a/proto/src/build.rs
+++ b/proto/src/build.rs
@@ -2,6 +2,10 @@ use std::io::Result;
 
 fn main() -> Result<()> {
     std::env::set_var("PROTOC", protobuf_src::protoc());
-    prost_build::compile_protos(&["proto/test_context.proto"], &["proto/"])?;
+    let mut prost_build = prost_build::Config::new();
+    prost_build
+        .type_attribute(".", "#[derive(serde::Serialize,serde::Deserialize)]")
+        .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
+        .compile_protos(&["proto/test_context.proto"], &["proto/"])?;
     Ok(())
 }

--- a/test_report/Cargo.toml
+++ b/test_report/Cargo.toml
@@ -18,6 +18,9 @@ tokio = "1.42.0"
 anyhow = "1.0.94"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
+bundle = { path = "../bundle" }
+more-asserts = "0.3.1"
 test_utils = { path = "../test_utils" }
 
 

--- a/test_report/Cargo.toml
+++ b/test_report/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "test_report"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = { version = "0.2.95", optional = true }
+magnus = { version = "0.7.1", optional = true, default-features = false }
+proto = { path = "../proto" }
+trunk-analytics-cli = { path = "../cli" }
+prost-wkt-types = "0.6.0"
+prost = "0.13.4"
+tempfile = "3.2.0"
+chrono = "0.4.33"
+serde_json = "1.0.133"
+js-sys = { version = "0.3.70", optional = true }
+tokio = "1.42.0"
+anyhow = "1.0.94"
+
+[dev-dependencies]
+test_utils = { path = "../test_utils" }
+
+
+[features]
+bindings = []
+wasm = ["bindings", "dep:wasm-bindgen", "dep:js-sys"]
+ruby = ["bindings", "dep:magnus"]

--- a/test_report/src/lib.rs
+++ b/test_report/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod report;

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -1,0 +1,247 @@
+use chrono::prelude::*;
+#[cfg(feature = "ruby")]
+use magnus::{value::ReprValue, Module, Object};
+use prost_wkt_types::Timestamp;
+use proto::test_context::test_run::{TestCaseRun, TestCaseRunStatus, TestResult, UploaderMetadata};
+use std::cell::RefCell;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TestReport {
+    test_result: TestResult,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[cfg_attr(feature = "ruby", magnus::wrap(class = "TestExecution"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestExecution {
+    id: Option<String>,
+    name: String,
+    classname: String,
+    file: String,
+    parent_name: String,
+    line: Option<i32>,
+    status: Status,
+    attempt_number: i32,
+    started_at: i64,
+    finished_at: i64,
+    output: String,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[cfg_attr(feature = "ruby", magnus::wrap(class = "Status"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Success,
+    Failure,
+    Skipped,
+}
+
+#[cfg(feature = "ruby")]
+impl Status {
+    fn new(status: String) -> Self {
+        match status.as_str() {
+            "success" => Status::Success,
+            "failure" => Status::Failure,
+            "skipped" => Status::Skipped,
+            _ => Status::Success,
+        }
+    }
+}
+
+impl Into<&str> for Status {
+    fn into(self) -> &'static str {
+        match self {
+            Status::Success => "success",
+            Status::Failure => "failure",
+            Status::Skipped => "skipped",
+        }
+    }
+}
+
+impl ToString for Status {
+    fn to_string(&self) -> String {
+        String::from(Into::<&str>::into(*self))
+    }
+}
+
+#[cfg(feature = "ruby")]
+impl Status {
+    pub fn to_string(&self) -> &str {
+        (*self).into()
+    }
+}
+
+#[cfg(feature = "ruby")]
+impl magnus::TryConvert for Status {
+    fn try_convert(val: magnus::Value) -> Result<Self, magnus::Error> {
+        let sval: String = val.funcall("to_s", ())?;
+        Ok(Status::new(sval))
+    }
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
+#[cfg_attr(feature = "ruby", magnus::wrap(class = "TestReport"))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct MutTestReport(RefCell<TestReport>);
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl MutTestReport {
+    pub fn new(origin: String) -> Self {
+        let mut test_result = TestResult::default();
+        test_result.uploader_metadata = Some(UploaderMetadata {
+            origin,
+            version: std::env!("CARGO_PKG_VERSION").to_string(),
+            upload_time: None,
+        });
+        Self(RefCell::new(TestReport {
+            test_result: TestResult::default(),
+        }))
+    }
+
+    fn serialize_test_result(&self) -> Vec<u8> {
+        let test_result = self.0.borrow().test_result.clone();
+        let buf: Vec<u8> = prost::Message::encode_to_vec(&test_result);
+        buf
+    }
+
+    // sends out to the trunk api
+    pub fn publish(&self, repo_root: String) -> bool {
+        let path = self.save();
+        if path.is_err() {
+            return false;
+        }
+        let resolved_path = path.unwrap_or_default();
+        let token = std::env::var("TRUNK_API_TOKEN").unwrap_or_default();
+        let org_url_slug = std::env::var("TRUNK_ORG_URL_SLUG").unwrap_or_default();
+        if token.is_empty() || org_url_slug.is_empty() {
+            println!("Token or org url slug not set");
+            return false;
+        }
+        if let Some(uploader_metadata) = &mut self.0.borrow_mut().test_result.uploader_metadata {
+            uploader_metadata.upload_time = Some(Timestamp {
+                seconds: Utc::now().timestamp(),
+                nanos: Utc::now().timestamp_subsec_nanos() as i32,
+            });
+        }
+        // TODO - handle finding the repo root automatically
+        let upload_args = trunk_analytics_cli::upload::UploadArgs::new(
+            token,
+            org_url_slug,
+            vec![resolved_path],
+            repo_root,
+        );
+        match tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(trunk_analytics_cli::upload::run_upload(
+                upload_args,
+                None,
+                None,
+                None,
+                None,
+            )) {
+            Ok(_) => return true,
+            Err(e) => {
+                println!("Error uploading: {:?}", e);
+                return false;
+            }
+        }
+    }
+
+    // saves to local fs and returns the path
+    pub fn save(&self) -> Result<String, anyhow::Error> {
+        let buf = self.serialize_test_result();
+        if let Ok(named_temp_file) = tempfile::Builder::new().suffix(".bin").tempfile() {
+            std::fs::write(&named_temp_file, buf).unwrap_or_default();
+            let (_, path) = named_temp_file.keep().unwrap();
+            let path_str = path.to_str().unwrap_or_default();
+            return Ok(path_str.to_string());
+        }
+        Err(anyhow::anyhow!("Error saving test report"))
+    }
+
+    // adds a test to the test report
+    pub fn add_test(
+        &self,
+        id: Option<String>,
+        name: String,
+        classname: String,
+        file: String,
+        parent_name: String,
+        line: Option<i32>,
+        status: Status,
+        attempt_number: i32,
+        started_at: i64,
+        finished_at: i64,
+        output: String,
+    ) {
+        let mut test = TestCaseRun::default();
+        if let Some(id) = id {
+            test.id = id;
+        }
+        test.name = name;
+        test.classname = classname;
+        test.file = file;
+        test.parent_name = parent_name;
+        if let Some(line) = line {
+            test.line = line;
+        }
+        match status {
+            Status::Success => test.status = TestCaseRunStatus::Success.into(),
+            Status::Failure => test.status = TestCaseRunStatus::Failure.into(),
+            Status::Skipped => test.status = TestCaseRunStatus::Skipped.into(),
+        }
+        // test.status = status;
+        test.attempt_number = attempt_number;
+        let started_at_date_time = DateTime::from_timestamp(started_at, 0).unwrap_or_default();
+        let test_started_at = Timestamp {
+            seconds: started_at_date_time.timestamp(),
+            nanos: started_at_date_time.timestamp_subsec_nanos() as i32,
+        };
+        test.started_at = Some(test_started_at);
+        let finished_at_date_time = DateTime::from_timestamp(finished_at, 0).unwrap_or_default();
+        let test_finished_at = Timestamp {
+            seconds: finished_at_date_time.timestamp(),
+            nanos: finished_at_date_time.timestamp_subsec_nanos() as i32,
+        };
+        test.finished_at = Some(test_finished_at);
+        test.status_output_message = output;
+        self.0
+            .borrow_mut()
+            .test_result
+            .test_case_runs
+            .push(test.clone());
+    }
+
+    pub fn to_string(&self) -> String {
+        self.clone().into()
+    }
+}
+
+impl Into<String> for MutTestReport {
+    fn into(self) -> String {
+        serde_json::to_string(&self.0.borrow().test_result).unwrap_or_default()
+    }
+}
+
+#[cfg(feature = "ruby")]
+pub fn ruby_init(ruby: &magnus::Ruby) -> Result<(), magnus::Error> {
+    let status = ruby.define_class("Status", ruby.class_object())?;
+    status.define_singleton_method("new", magnus::function!(Status::new, 1))?;
+    status.define_method("to_s", magnus::method!(Status::to_string, 0))?;
+    let test_report = ruby.define_class("TestReport", ruby.class_object())?;
+    test_report.define_singleton_method("new", magnus::function!(MutTestReport::new, 1))?;
+    test_report.define_method("to_s", magnus::method!(MutTestReport::to_string, 0))?;
+    test_report.define_method("publish", magnus::method!(MutTestReport::publish, 0))?;
+    test_report.define_method("add_test", magnus::method!(MutTestReport::add_test, 11))?;
+    test_report.define_method(
+        "list_quarantined_tests",
+        magnus::method!(MutTestReport::list_quarantined_tests, 0),
+    )?;
+    test_report.define_method("valid_env", magnus::method!(MutTestReport::valid_env, 0))?;
+    test_report.define_method("valid_git", magnus::method!(MutTestReport::valid_git, 0))?;
+    Ok(())
+}

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -1,26 +1,27 @@
-use prost::Message;
-use prost_wkt_types::Timestamp;
-use proto::test_context::test_run::TestCaseRunStatus;
+use std::{env, fs, io::BufReader, thread};
+
+use assert_matches::assert_matches;
+use bundle::{BundleMeta, FileSetType};
 use tempfile::tempdir;
 use test_report::report::{MutTestReport, Status};
 use test_utils::mock_git_repo::setup_repo_with_commit;
-use test_utils::mock_server::MockServerBuilder;
+use test_utils::mock_server::{MockServerBuilder, RequestPayload};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_test_report() {
     let temp_dir = tempdir().unwrap();
     let repo_setup_res = setup_repo_with_commit(&temp_dir);
     assert!(repo_setup_res.is_ok());
-    let set_current_dir_res = std::env::set_current_dir(&temp_dir);
+    let set_current_dir_res = env::set_current_dir(&temp_dir);
     assert!(set_current_dir_res.is_ok());
     let state = MockServerBuilder::new().spawn_mock_server().await;
-    std::env::set_var("TRUNK_PUBLIC_API_ADDRESS", &state.host);
-    std::env::set_var("CI", "1");
-    std::env::set_var("GITHUB_JOB", "test-job");
-    std::env::set_var("TRUNK_API_TOKEN", "test-token");
-    std::env::set_var("TRUNK_ORG_URL_SLUG", "test-org");
+    env::set_var("TRUNK_PUBLIC_API_ADDRESS", &state.host);
+    env::set_var("CI", "1");
+    env::set_var("GITHUB_JOB", "test-job");
+    env::set_var("TRUNK_API_TOKEN", "test-token");
+    env::set_var("TRUNK_ORG_URL_SLUG", "test-org");
 
-    let thread_join_handle = std::thread::spawn(|| {
+    let thread_join_handle = thread::spawn(|| {
         let test_report = MutTestReport::new("test".into());
         test_report.add_test(
             Some("1".into()),
@@ -31,67 +32,56 @@ async fn publish_test_report() {
             None,
             Status::Success,
             0,
-            0,
-            0,
+            1000,
+            1001,
             "test-message".into(),
         );
         let result = test_report.publish(".".into());
         assert_eq!(result, true);
     });
-    let thread_res = thread_join_handle.join();
-    assert!(thread_res.is_ok());
-}
+    thread_join_handle.join().unwrap();
 
-#[test]
-fn save_test_report() {
-    let temp_dir = tempdir().unwrap();
-    setup_repo_with_commit(&temp_dir).unwrap();
-    let _ = std::env::set_current_dir(&temp_dir);
-    let test_report = MutTestReport::new("test".into());
-    test_report.add_test(
-        Some("1".into()),
-        "test-name".into(),
-        "test-classname".into(),
-        "test-file".into(),
-        "test-parent-name".into(),
-        None,
-        Status::Success,
-        0,
-        1000,
-        1001,
-        "test-message".into(),
-    );
-    let result = test_report.save();
-    assert!(result.is_ok());
-
-    // read the file result
-    let file = std::fs::read(result.unwrap());
-    let report = proto::test_context::test_run::TestResult::decode(&*file.unwrap()).unwrap();
-
-    let test_started_at = Timestamp {
-        seconds: 1000,
-        nanos: 0,
-    };
-    let test_finished_at = Timestamp {
-        seconds: 1001,
-        nanos: 0,
-    };
-    assert_eq!(report.test_case_runs.len(), 1);
-    assert_eq!(report.test_case_runs[0].id, "1");
-    assert_eq!(report.test_case_runs[0].name, "test-name");
-    assert_eq!(report.test_case_runs[0].classname, "test-classname");
-    assert_eq!(report.test_case_runs[0].file, "test-file");
-    assert_eq!(report.test_case_runs[0].parent_name, "test-parent-name");
+    let requests = state.requests.lock().unwrap().clone();
+    assert!(requests.len() == 4);
+    let tar_extract_directory = assert_matches!(&requests[2], RequestPayload::S3Upload(d) => d);
+    let file = fs::File::open(tar_extract_directory.join("meta.json")).unwrap();
+    let reader = BufReader::new(file);
+    let bundle_meta: BundleMeta = serde_json::from_reader(reader).unwrap();
+    let base_props = bundle_meta.base_props;
+    assert_eq!(base_props.org, "test-org");
     assert_eq!(
-        report.test_case_runs[0].status,
-        TestCaseRunStatus::Success as i32
+        base_props.repo.repo_url,
+        "https://github.com/trunk-io/analytics-cli.git"
     );
-    assert_eq!(report.test_case_runs[0].line, 0);
-    assert_eq!(report.test_case_runs[0].attempt_number, 0);
-    assert_eq!(report.test_case_runs[0].started_at, Some(test_started_at));
-    assert_eq!(report.test_case_runs[0].finished_at, Some(test_finished_at));
+    assert!(!base_props.repo.repo_head_sha.is_empty());
+    let repo_head_sha_short = base_props.repo.repo_head_sha_short.unwrap();
+    assert!(!repo_head_sha_short.is_empty());
+    assert!(&repo_head_sha_short.len() < &base_props.repo.repo_head_sha.len());
+    assert!(base_props
+        .repo
+        .repo_head_sha
+        .starts_with(&repo_head_sha_short));
+    assert_eq!(base_props.repo.repo_head_branch, "refs/heads/trunk/test");
+    assert_eq!(base_props.repo.repo_head_author_name, "Your Name");
     assert_eq!(
-        report.test_case_runs[0].status_output_message,
-        "test-message"
+        base_props.repo.repo_head_author_email,
+        "your.email@example.com"
     );
+    assert_eq!(base_props.bundle_upload_id, "test-bundle-upload-id");
+    assert_eq!(base_props.tags, &[]);
+    assert_eq!(base_props.file_sets.len(), 1);
+    assert_eq!(base_props.envs.get("CI"), Some(&String::from("1")));
+    assert_eq!(
+        base_props.envs.get("GITHUB_JOB"),
+        Some(&String::from("test-job"))
+    );
+    let time_since_upload = chrono::Utc::now()
+        - chrono::DateTime::from_timestamp(base_props.upload_time_epoch as i64, 0).unwrap();
+    more_asserts::assert_lt!(time_since_upload.num_minutes(), 5);
+    assert_eq!(base_props.test_command, None);
+    assert!(base_props.os_info.is_some());
+    assert!(base_props.quarantined_tests.is_empty());
+
+    let file_set = base_props.file_sets.get(0).unwrap();
+    assert_eq!(file_set.file_set_type, FileSetType::Junit);
 }

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -1,0 +1,97 @@
+use prost::Message;
+use prost_wkt_types::Timestamp;
+use proto::test_context::test_run::TestCaseRunStatus;
+use tempfile::tempdir;
+use test_report::report::{MutTestReport, Status};
+use test_utils::mock_git_repo::setup_repo_with_commit;
+use test_utils::mock_server::MockServerBuilder;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_test_report() {
+    let temp_dir = tempdir().unwrap();
+    let repo_setup_res = setup_repo_with_commit(&temp_dir);
+    assert!(repo_setup_res.is_ok());
+    let set_current_dir_res = std::env::set_current_dir(&temp_dir);
+    assert!(set_current_dir_res.is_ok());
+    let state = MockServerBuilder::new().spawn_mock_server().await;
+    std::env::set_var("TRUNK_PUBLIC_API_ADDRESS", &state.host);
+    std::env::set_var("CI", "1");
+    std::env::set_var("GITHUB_JOB", "test-job");
+    std::env::set_var("TRUNK_API_TOKEN", "test-token");
+    std::env::set_var("TRUNK_ORG_URL_SLUG", "test-org");
+
+    let thread_join_handle = std::thread::spawn(|| {
+        let test_report = MutTestReport::new("test".into());
+        test_report.add_test(
+            Some("1".into()),
+            "test-name".into(),
+            "test-classname".into(),
+            "test-file".into(),
+            "test-parent-name".into(),
+            None,
+            Status::Success,
+            0,
+            0,
+            0,
+            "test-message".into(),
+        );
+        let result = test_report.publish(".".into());
+        assert_eq!(result, true);
+    });
+    let thread_res = thread_join_handle.join();
+    assert!(thread_res.is_ok());
+}
+
+#[test]
+fn save_test_report() {
+    let temp_dir = tempdir().unwrap();
+    setup_repo_with_commit(&temp_dir).unwrap();
+    let _ = std::env::set_current_dir(&temp_dir);
+    let test_report = MutTestReport::new("test".into());
+    test_report.add_test(
+        Some("1".into()),
+        "test-name".into(),
+        "test-classname".into(),
+        "test-file".into(),
+        "test-parent-name".into(),
+        None,
+        Status::Success,
+        0,
+        1000,
+        1001,
+        "test-message".into(),
+    );
+    let result = test_report.save();
+    assert!(result.is_ok());
+
+    // read the file result
+    let file = std::fs::read(result.unwrap());
+    let report = proto::test_context::test_run::TestResult::decode(&*file.unwrap()).unwrap();
+
+    let test_started_at = Timestamp {
+        seconds: 1000,
+        nanos: 0,
+    };
+    let test_finished_at = Timestamp {
+        seconds: 1001,
+        nanos: 0,
+    };
+    assert_eq!(report.test_case_runs.len(), 1);
+    assert_eq!(report.test_case_runs[0].id, "1");
+    assert_eq!(report.test_case_runs[0].name, "test-name");
+    assert_eq!(report.test_case_runs[0].classname, "test-classname");
+    assert_eq!(report.test_case_runs[0].file, "test-file");
+    assert_eq!(report.test_case_runs[0].parent_name, "test-parent-name");
+    assert_eq!(
+        report.test_case_runs[0].status,
+        TestCaseRunStatus::Success as i32
+    );
+    assert_eq!(report.test_case_runs[0].line, 0);
+    assert_eq!(report.test_case_runs[0].attempt_number, 0);
+    assert_eq!(report.test_case_runs[0].started_at, Some(test_started_at));
+    assert_eq!(report.test_case_runs[0].finished_at, Some(test_finished_at));
+    assert_eq!(
+        report.test_case_runs[0].status_output_message,
+        "test-message"
+    );
+}


### PR DESCRIPTION
Adds the initial format and integration point for direct test runner integration.

See
* https://github.com/trunk-io/analytics-cli/pull/254
* https://github.com/trunk-io/analytics-cli/pull/255