### PR TITLE
no cmake, no protoc, no problems

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -17,4 +17,4 @@ use_trunk.io() {
 use trunk.io
 
 # Needed by `rust-analyzer`. Hash should be the same for all platforms.
-export RUST_SRC_PATH="$HOME/.cache/trunk/tools/rust/2024-11-15-41630b9ccc37d4c3f29f3f2c80409ef9/rust-src-nightly/rust-src/lib/rustlib/src/rust/library"
+export RUST_SRC_PATH="$HOME/.cache/trunk/tools/rust/2024-05-01-d4daa7f4db5f9d74e00218df573de113/rust-src-nightly/rust-src/lib/rustlib/src/rust/library"

--- a/.envrc
+++ b/.envrc
@@ -15,3 +15,6 @@ use_trunk.io() {
 }
 
 use trunk.io
+
+# Needed by `rust-analyzer`. Hash should be the same for all platforms.
+export RUST_SRC_PATH="$HOME/.cache/trunk/tools/rust/2024-11-15-41630b9ccc37d4c3f29f3f2c80409ef9/rust-src-nightly/rust-src/lib/rustlib/src/rust/library"

--- a/.envrc
+++ b/.envrc
@@ -17,4 +17,4 @@ use_trunk.io() {
 use trunk.io
 
 # Needed by `rust-analyzer`. Hash should be the same for all platforms.
-export RUST_SRC_PATH="$HOME/.cache/trunk/tools/rust/2024-05-01-d4daa7f4db5f9d74e00218df573de113/rust-src-nightly/rust-src/lib/rustlib/src/rust/library"
+export RUST_SRC_PATH="$HOME/.cache/trunk/tools/rust-src/2024-05-01-d4daa7f4db5f9d74e00218df573de113/rust-src-nightly/rust-src/lib/rustlib/src/rust/library"

--- a/.github/actions/setup_rust_cargo/action.yaml
+++ b/.github/actions/setup_rust_cargo/action.yaml
@@ -9,16 +9,6 @@ runs:
       with:
         targets: wasm32-unknown-unknown
 
-    - name: Install protoc
-      shell: bash
-      run: |
-        if [ -f /opt/homebrew/bin/brew ]; then
-          /opt/homebrew/bin/brew install protobuf
-        elif [ -f /usr/bin/apt ]; then
-          sudo /usr/bin/apt update
-          sudo /usr/bin/apt install -y protobuf-compiler
-        fi
-
     - uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -60,16 +60,6 @@ jobs:
               /usr/bin/apt update
               /usr/bin/apt install -y pkg-config libssl-dev unzip
             fi
-
-            if [ "$(uname -m)" == "aarch64" ]; then
-              curl -L https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-aarch_64.zip -o protoc.zip
-              unzip protoc.zip
-              export PROTOC=$(pwd)/bin/protoc
-            else
-              curl -L https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-linux-x86_64.zip -o protoc.zip
-              unzip protoc.zip
-              export PROTOC=$(pwd)/bin/protoc
-            fi
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -97,20 +97,6 @@ actions:
     - trunk-fmt-pre-commit
     - trunk-upgrade-available
 downloads:
-  - name: protoc
-    downloads:
-      - os:
-          linux: linux
-          macos: osx
-        cpu:
-          x86_64: x86_64
-          arm_64: aarch_64
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-${os}-${cpu}.zip
-      - os:
-          windows: windows
-        cpu:
-          x86_64: x86_64
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-win64.zip
   - name: rust
     downloads:
       - os:
@@ -126,16 +112,6 @@ downloads:
       - url: https://static.rust-lang.org/dist/${version}/rust-src-nightly.tar.xz
 tools:
   definitions:
-    - name: protoc
-      download: protoc
-      known_good_version: 29.1
-      shims: [protoc]
-      environment:
-        - name: PATH
-          list: ["${tool}/bin"]
-      health_checks:
-        - command: protoc --version
-          parse_regex: libprotoc (\d+\.\d+)
     - name: rust-src
       download: rust-src
       known_good_version: 2024-11-15
@@ -147,7 +123,6 @@ tools:
   enabled:
     - gh@2.62.0
     - pnpm@9.14.2
-    - protoc@29.1
     # Update `RUST_SRC_PATH` path to `rust-src` if this is updated
     # IfChange
     - rust-src@2024-11-15

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,7 +15,7 @@ runtimes:
     - node@18.12.1
     - python@3.10.8
     - ruby@3.1.0
-    - rust@2024-11-15
+    - rust@2024-05-01
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
@@ -24,7 +24,7 @@ lint:
     - bandit@1.7.10
     - black@24.10.0
     - checkov@3.2.296
-    - clippy@2024-11-15
+    - clippy@2024-05-01
     - eslint@9.14.0
     - git-diff-check
     - isort@5.13.2
@@ -32,7 +32,7 @@ lint:
     - osv-scanner@1.9.1
     - prettier@3.3.3
     - ruff@0.7.3
-    - rustfmt@2024-11-15
+    - rustfmt@2024-05-01
     - taplo@0.9.3
     - trufflehog@3.83.7
     - yamllint@1.35.1
@@ -114,7 +114,7 @@ tools:
   definitions:
     - name: rust-src
       download: rust-src
-      known_good_version: 2024-11-15
+      known_good_version: 2024-05-01
       shims: [rust-src]
   runtimes:
     - ruby
@@ -125,5 +125,5 @@ tools:
     - pnpm@9.14.2
     # Update `RUST_SRC_PATH` path to `rust-src` if this is updated
     # IfChange
-    - rust-src@2024-11-15
+    - rust-src@2024-05-01
     # ThenChange .envrc

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,8 +14,8 @@ runtimes:
   enabled:
     - node@18.12.1
     - python@3.10.8
-    - rust@1.81.0
     - ruby@3.1.0
+    - rust@2024-11-15
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
@@ -24,7 +24,7 @@ lint:
     - bandit@1.7.10
     - black@24.10.0
     - checkov@3.2.296
-    - clippy@1.81.0
+    - clippy@2024-11-15
     - eslint@9.14.0
     - git-diff-check
     - isort@5.13.2
@@ -32,7 +32,7 @@ lint:
     - osv-scanner@1.9.1
     - prettier@3.3.3
     - ruff@0.7.3
-    - rustfmt@1.81.0
+    - rustfmt@2024-11-15
     - taplo@0.9.3
     - trufflehog@3.83.7
     - yamllint@1.35.1
@@ -48,9 +48,43 @@ lint:
           run: pyright -p context-py --outputjson
           target: .
           batch: false
+    - name: clippy
+      runtime: rust
+      environment:
+        - name: PATH
+          list: ["${runtime}", "${env.PATH}"]
+      commands:
+        - name: lint
+          run:
+            cargo clippy --message-format json --locked --all-targets --all-features --
+            --cap-lints=warn --no-deps
+          output: clippy
+          target: ${parent_with(Cargo.toml)}
+          success_codes: [0, 101, 383]
+          run_from: ${target_directory}
+          disable_upstream: true
+    - name: rustfmt
+      runtime: rust
+      commands:
+        - name: format
+          output: rewrite
+          read_output_from: stdout
+          stdin: true
+          success_codes: [0]
+          cache_results: false # sometimes caches an empty file for some reason
+          in_place: false
+          batch: false
+          run: rustfmt --edition=2021
+  ignore:
+    - linters: [ALL]
+      paths:
+        # Ignore generated files
+        - target/**
+        - "**/target/**"
 actions:
   definitions:
     - id: generate-pyi
+      runtime: rust
       description: Generate Python stubs
       # Don't use hermetic runtime so we can use nightly cargo
       run: |
@@ -77,6 +111,19 @@ downloads:
         cpu:
           x86_64: x86_64
         url: https://github.com/protocolbuffers/protobuf/releases/download/v29.1/protoc-29.1-win64.zip
+  - name: rust
+    downloads:
+      - os:
+          macos: apple-darwin
+          linux: unknown-linux-gnu
+        cpu:
+          x86_64: x86_64
+          arm_64: aarch64
+        url: https://static.rust-lang.org/dist/${version}/rust-nightly-${cpu}-${os}.tar.gz
+        strip_components: 2
+  - name: rust-src
+    downloads:
+      - url: https://static.rust-lang.org/dist/${version}/rust-src-nightly.tar.xz
 tools:
   definitions:
     - name: protoc
@@ -89,10 +136,19 @@ tools:
       health_checks:
         - command: protoc --version
           parse_regex: libprotoc (\d+\.\d+)
+    - name: rust-src
+      download: rust-src
+      known_good_version: 2024-11-15
+      shims: [rust-src]
   runtimes:
     - ruby
     - node
+    - rust
   enabled:
     - gh@2.62.0
     - pnpm@9.14.2
     - protoc@29.1
+    # Update `RUST_SRC_PATH` path to `rust-src` if this is updated
+    # IfChange
+    - rust-src@2024-11-15
+    # ThenChange .envrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@ These are instructions for building, running, and testing the Rust CLI locally. 
 ## Prerequisites
 
 - Install a nightly version of Cargo using [rustup](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-- Install [protoc](https://grpc.io/docs/protoc-installation/)
 - Run `trunk tools install`
 
 ### Optional Prerequisites

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,47 +384,19 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "axum-macros",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -447,23 +419,6 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
@@ -471,8 +426,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -528,9 +483,9 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "protox",
  "serde",
  "serde_json",
@@ -965,7 +920,7 @@ dependencies = [
  "codeowners",
  "context",
  "futures-io",
- "prost 0.13.4",
+ "prost",
  "proto",
  "pyo3",
  "pyo3-stub-gen",
@@ -1931,16 +1886,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap 2.7.0",
  "slab",
  "tokio",
@@ -2006,17 +1961,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -2028,23 +1972,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -2055,8 +1988,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2080,30 +2013,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
@@ -2111,8 +2020,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2129,8 +2039,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.1",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -2142,14 +2052,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 0.14.31",
+ "hyper",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -2160,7 +2071,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2177,9 +2088,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.5.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3031,8 +2942,8 @@ checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
  "heck",
  "itertools 0.13.0",
- "prost 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -3045,8 +2956,8 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.13.4",
- "prost-build 0.13.4",
+ "prost",
+ "prost-build",
  "serde",
 ]
 
@@ -3233,43 +3144,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
- "prost-derive 0.13.4",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "regex",
- "syn 2.0.90",
- "tempfile",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3285,24 +3165,11 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.90",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -3327,17 +3194,8 @@ dependencies = [
  "logos",
  "miette",
  "once_cell",
- "prost 0.13.4",
- "prost-types 0.13.4",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -3346,7 +3204,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
- "prost 0.13.4",
+ "prost",
 ]
 
 [[package]]
@@ -3357,7 +3215,7 @@ checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
 dependencies = [
  "chrono",
  "inventory",
- "prost 0.13.4",
+ "prost",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3371,9 +3229,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
 dependencies = [
  "heck",
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "quote",
 ]
 
@@ -3384,9 +3242,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
 dependencies = [
  "chrono",
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "prost-wkt",
  "prost-wkt-build",
  "regex",
@@ -3399,9 +3257,9 @@ dependencies = [
 name = "proto"
 version = "0.0.0"
 dependencies = [
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "prost-wkt-types",
  "protox",
  "serde",
@@ -3415,9 +3273,9 @@ checksum = "873f359bdecdfe6e353752f97cb9ee69368df55b16363ed2216da85e03232a58"
 dependencies = [
  "bytes",
  "miette",
- "prost 0.13.4",
+ "prost",
  "prost-reflect",
- "prost-types 0.13.4",
+ "prost-types",
  "protox-parse",
  "thiserror 1.0.69",
 ]
@@ -3430,7 +3288,7 @@ checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
 dependencies = [
  "logos",
  "miette",
- "prost-types 0.13.4",
+ "prost-types",
  "thiserror 1.0.69",
 ]
 
@@ -3745,10 +3603,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -4397,7 +4255,7 @@ dependencies = [
  "js-sys",
  "magnus",
  "more-asserts",
- "prost 0.13.4",
+ "prost",
  "prost-wkt-types",
  "proto",
  "serde_json",
@@ -4414,7 +4272,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "api",
- "axum 0.7.9",
+ "axum",
  "git2",
  "junit-mock",
  "lazy_static",
@@ -4541,16 +4399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,23 +4500,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "axum",
+ "base64 0.22.1",
  "bytes",
  "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -4679,13 +4530,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.90",
 ]
@@ -4786,7 +4638,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "api",
- "axum 0.7.9",
+ "axum",
  "bundle",
  "chrono",
  "clap",
@@ -4798,7 +4650,7 @@ dependencies = [
  "env_logger",
  "exitcode",
  "glob",
- "http 1.2.0",
+ "http",
  "lazy_static",
  "log",
  "openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "prost 0.13.4",
  "prost-build 0.13.4",
  "prost-types 0.13.4",
+ "protox",
  "serde",
  "serde_json",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,19 +384,47 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "axum-macros",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -419,6 +447,23 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
@@ -426,8 +471,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -734,7 +779,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -1886,16 +1931,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "futures-util",
+ "http 0.2.12",
  "indexmap 2.7.0",
  "slab",
  "tokio",
@@ -1920,6 +1965,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1961,6 +2012,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -1972,12 +2034,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1988,8 +2061,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2013,6 +2086,30 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
@@ -2020,9 +2117,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2039,8 +2135,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.2.0",
+ "hyper 1.5.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -2052,15 +2148,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.5.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
- "hyper-util",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
- "tower-service",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2071,7 +2166,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.5.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2088,9 +2183,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.5.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2303,6 +2398,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2926,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "pbjson"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -2936,21 +3040,21 @@ dependencies = [
 
 [[package]]
 name = "pbjson-build"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
- "heck",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "prost",
  "prost-types",
 ]
 
 [[package]]
 name = "pbjson-types"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54e5e7bfb1652f95bc361d76f3c780d8e526b134b85417e774166ee941f0887"
+checksum = "18f596653ba4ac51bdecbb4ef6773bc7f56042dc13927910de1684ad3d32aa12"
 dependencies = [
  "bytes",
  "chrono",
@@ -3144,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3154,12 +3258,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
- "heck",
- "itertools 0.13.0",
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3174,12 +3279,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -3187,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ae544fca2892fd4b7e9ff26cba1090cedf1d4d95c2aded1af15d2f93f270b8"
+checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
 dependencies = [
  "logos",
  "miette",
@@ -3200,18 +3305,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "prost-wkt"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
+checksum = "5fb7ec2850c138ebaa7ab682503b5d08c3cb330343e9c94776612928b6ddb53f"
 dependencies = [
  "chrono",
  "inventory",
@@ -3224,11 +3329,11 @@ dependencies = [
 
 [[package]]
 name = "prost-wkt-build"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
+checksum = "598b7365952c2ed4e32902de0533653aafbe5ae3da436e8e2335c7d375a1cef3"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "prost",
  "prost-build",
  "prost-types",
@@ -3237,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "prost-wkt-types"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
+checksum = "1a8eadc2381640a49c1fbfb9f4a857794b4e5bf5a2cbc2d858cfdb74f64dcd22"
 dependencies = [
  "chrono",
  "prost",
@@ -3247,6 +3352,7 @@ dependencies = [
  "prost-types",
  "prost-wkt",
  "prost-wkt-build",
+ "protox",
  "regex",
  "serde",
  "serde_derive",
@@ -3267,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "protox"
-version = "0.7.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873f359bdecdfe6e353752f97cb9ee69368df55b16363ed2216da85e03232a58"
+checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
 dependencies = [
  "bytes",
  "miette",
@@ -3282,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "protox-parse"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
 dependencies = [
  "logos",
  "miette",
@@ -3348,7 +3454,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -3603,10 +3709,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -4127,7 +4233,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4272,7 +4378,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "api",
- "axum",
+ "axum 0.7.9",
  "git2",
  "junit-mock",
  "lazy_static",
@@ -4399,6 +4505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,26 +4616,23 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
- "base64 0.22.1",
+ "axum 0.6.20",
+ "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-timeout",
- "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -4530,14 +4643,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types",
  "quote",
  "syn 2.0.90",
 ]
@@ -4638,7 +4750,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "api",
- "axum",
+ "axum 0.7.9",
  "bundle",
  "chrono",
  "clap",
@@ -4650,7 +4762,7 @@ dependencies = [
  "env_logger",
  "exitcode",
  "glob",
- "http",
+ "http 1.2.0",
  "lazy_static",
  "log",
  "openssl",

--- a/bazel-bep/Cargo.toml
+++ b/bazel-bep/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/ChristianBelloni/bazel-bep"
 
 [dependencies]
-tonic = { version = "0.10", default-features = false, features = [
+tonic = { version = "0.12.3", default-features = false, features = [
   "codegen",
   "prost",
 ] }
@@ -19,7 +19,7 @@ serde = { version = "1.0.215", default-features = false, features = ["derive"] }
 serde_json = "1.0.133"
 
 [build-dependencies]
-tonic-build = "0.10"
+tonic-build = "0.12.3"
 prost-build = "0.13.3"
 pbjson-build = "0.7.0"
 protox = "0.7.1"

--- a/bazel-bep/Cargo.toml
+++ b/bazel-bep/Cargo.toml
@@ -7,22 +7,22 @@ license = "MIT"
 repository = "https://github.com/ChristianBelloni/bazel-bep"
 
 [dependencies]
-tonic = { version = "0.12.3", default-features = false, features = [
+tonic = { version = "0.11.0", default-features = false, features = [
   "codegen",
   "prost",
 ] }
-prost = "0.13.3"
-prost-types = "0.13.3"
-pbjson = "0.7.0"
-pbjson-types = "0.7.0"
+prost = "0.12.6"
+prost-types = "0.12.6"
+pbjson = "0.6.0"
+pbjson-types = "0.6.0"
 serde = { version = "1.0.215", default-features = false, features = ["derive"] }
 serde_json = "1.0.133"
 
 [build-dependencies]
-tonic-build = "0.12.3"
-prost-build = "0.13.3"
-pbjson-build = "0.7.0"
-protox = "0.7.1"
+tonic-build = "0.11.0"
+prost-build = "0.12.6"
+pbjson-build = "0.6.2"
+protox = "0.6.1"
 
 [features]
 default = []

--- a/bazel-bep/Cargo.toml
+++ b/bazel-bep/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.133"
 tonic-build = "0.10"
 prost-build = "0.13.3"
 pbjson-build = "0.7.0"
+protox = "0.7.1"
 
 [features]
 default = []

--- a/bazel-bep/build.rs
+++ b/bazel-bep/build.rs
@@ -33,7 +33,7 @@ fn main() -> io::Result<()> {
         .compile_well_known_types(true)
         // Override prost-types with pbjson-types
         .extern_path(".google.protobuf", "::pbjson_types")
-        .compile(&protos, &["proto/"])?;
+        .compile_protos(&protos, &["proto/"])?;
 
     pbjson_build::Builder::new()
         .register_descriptors(&file_descriptors_bytes)?

--- a/bazel-bep/build.rs
+++ b/bazel-bep/build.rs
@@ -33,7 +33,7 @@ fn main() -> io::Result<()> {
         .compile_well_known_types(true)
         // Override prost-types with pbjson-types
         .extern_path(".google.protobuf", "::pbjson_types")
-        .compile_protos(&protos, &["proto/"])?;
+        .compile(&protos, &["proto/"])?;
 
     pbjson_build::Builder::new()
         .register_descriptors(&file_descriptors_bytes)?

--- a/bazel-bep/src/lib.rs
+++ b/bazel-bep/src/lib.rs
@@ -45,6 +45,8 @@ pub mod types {
     }
 }
 
+// NOTE: `build_event_stream(.serde).rs` has some failing clippy lints
+#[allow(clippy::all)]
 pub(crate) mod build_event_stream {
     include!(concat!(env!("OUT_DIR"), "/build_event_stream.rs"));
     include!(concat!(env!("OUT_DIR"), "/build_event_stream.serde.rs"));

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -17,8 +17,6 @@ use bundle::{
 use codeowners::CodeOwners;
 use constants::{EXIT_FAILURE, EXIT_SUCCESS};
 #[cfg(target_os = "macos")]
-use context::junit::junit_path::JunitReportStatus;
-#[cfg(target_os = "macos")]
 use context::repo::RepoUrlParts;
 use context::{
     bazel_bep::parser::{BazelBepParser, BepParseResult},

--- a/context-py/Cargo.toml
+++ b/context-py/Cargo.toml
@@ -20,7 +20,7 @@ pyo3-stub-gen = "0.6.0"
 futures-io = "0.3.31"
 tokio = { version = "*", default-features = false, features = ["rt"] }
 proto = { path = "../proto" }
-prost = "0.13.4"
+prost = "0.12.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pyo3 = { version = "0.22.5", features = ["abi3-py39", "extension-module"] }

--- a/context-ruby/ext/context_ruby/Cargo.lock
+++ b/context-ruby/ext/context_ruby/Cargo.lock
@@ -603,7 +603,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -1576,6 +1576,12 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1614,6 +1620,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -1625,12 +1642,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1641,8 +1669,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1667,8 +1695,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1684,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6884a48c6826ec44f524c7456b163cebe9e55a18d7b5e307cb4f100371cc767"
 dependencies = [
  "futures-util",
- "http",
+ "http 1.2.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1720,8 +1748,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "hyper",
  "pin-project-lite",
  "socket2",
@@ -1922,18 +1950,18 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2379,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "pbjson"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -2389,21 +2417,21 @@ dependencies = [
 
 [[package]]
 name = "pbjson-build"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
- "heck",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "prost",
  "prost-types",
 ]
 
 [[package]]
 name = "pbjson-types"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54e5e7bfb1652f95bc361d76f3c780d8e526b134b85417e774166ee941f0887"
+checksum = "18f596653ba4ac51bdecbb4ef6773bc7f56042dc13927910de1684ad3d32aa12"
 dependencies = [
  "bytes",
  "chrono",
@@ -2540,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2550,12 +2578,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
- "heck",
- "itertools 0.13.0",
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -2570,12 +2599,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -2583,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ae544fca2892fd4b7e9ff26cba1090cedf1d4d95c2aded1af15d2f93f270b8"
+checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
 dependencies = [
  "logos",
  "miette",
@@ -2596,18 +2625,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "prost-wkt"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
+checksum = "5fb7ec2850c138ebaa7ab682503b5d08c3cb330343e9c94776612928b6ddb53f"
 dependencies = [
  "chrono",
  "inventory",
@@ -2620,11 +2649,11 @@ dependencies = [
 
 [[package]]
 name = "prost-wkt-build"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
+checksum = "598b7365952c2ed4e32902de0533653aafbe5ae3da436e8e2335c7d375a1cef3"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "prost",
  "prost-build",
  "prost-types",
@@ -2633,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "prost-wkt-types"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
+checksum = "1a8eadc2381640a49c1fbfb9f4a857794b4e5bf5a2cbc2d858cfdb74f64dcd22"
 dependencies = [
  "chrono",
  "prost",
@@ -2643,6 +2672,7 @@ dependencies = [
  "prost-types",
  "prost-wkt",
  "prost-wkt-build",
+ "protox",
  "regex",
  "serde",
  "serde_derive",
@@ -2663,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "protox"
-version = "0.7.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873f359bdecdfe6e353752f97cb9ee69368df55b16363ed2216da85e03232a58"
+checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
 dependencies = [
  "bytes",
  "miette",
@@ -2678,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "protox-parse"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
 dependencies = [
  "logos",
  "miette",
@@ -2900,8 +2930,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3390,7 +3420,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3680,19 +3710,19 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bytes",
- "http",
- "http-body",
- "http-body-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "percent-encoding",
  "pin-project",
  "prost",
+ "tokio",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -3701,14 +3731,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types",
  "quote",
  "syn 2.0.90",
 ]
@@ -3783,7 +3812,7 @@ dependencies = [
  "env_logger",
  "exitcode",
  "glob",
- "http",
+ "http 1.2.0",
  "log",
  "openssl",
  "openssl-src",

--- a/context-ruby/ext/context_ruby/Cargo.lock
+++ b/context-ruby/ext/context_ruby/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "protox",
  "serde",
  "serde_json",
@@ -1614,17 +1614,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -1636,23 +1625,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -1663,8 +1641,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1689,8 +1667,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1706,7 +1684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6884a48c6826ec44f524c7456b163cebe9e55a18d7b5e307cb4f100371cc767"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1742,8 +1720,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "hyper",
  "pin-project-lite",
  "socket2",
@@ -2417,8 +2395,8 @@ checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
  "heck",
  "itertools 0.13.0",
- "prost 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -2431,8 +2409,8 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.13.4",
- "prost-build 0.13.4",
+ "prost",
+ "prost-build",
  "serde",
 ]
 
@@ -2562,43 +2540,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
- "prost-derive 0.13.4",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "regex",
- "syn 2.0.90",
- "tempfile",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2614,24 +2561,11 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.90",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -2656,17 +2590,8 @@ dependencies = [
  "logos",
  "miette",
  "once_cell",
- "prost 0.13.4",
- "prost-types 0.13.4",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -2675,7 +2600,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
- "prost 0.13.4",
+ "prost",
 ]
 
 [[package]]
@@ -2686,7 +2611,7 @@ checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
 dependencies = [
  "chrono",
  "inventory",
- "prost 0.13.4",
+ "prost",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2700,9 +2625,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
 dependencies = [
  "heck",
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "quote",
 ]
 
@@ -2713,9 +2638,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
 dependencies = [
  "chrono",
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "prost-wkt",
  "prost-wkt-build",
  "regex",
@@ -2728,9 +2653,9 @@ dependencies = [
 name = "proto"
 version = "0.0.0"
 dependencies = [
- "prost 0.13.4",
- "prost-build 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-build",
+ "prost-types",
  "prost-wkt-types",
  "protox",
  "serde",
@@ -2744,9 +2669,9 @@ checksum = "873f359bdecdfe6e353752f97cb9ee69368df55b16363ed2216da85e03232a58"
 dependencies = [
  "bytes",
  "miette",
- "prost 0.13.4",
+ "prost",
  "prost-reflect",
- "prost-types 0.13.4",
+ "prost-types",
  "protox-parse",
  "thiserror 1.0.69",
 ]
@@ -2759,7 +2684,7 @@ checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
 dependencies = [
  "logos",
  "miette",
- "prost-types 0.13.4",
+ "prost-types",
  "thiserror 1.0.69",
 ]
 
@@ -2975,8 +2900,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3564,7 +3489,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "magnus",
- "prost 0.13.4",
+ "prost",
  "prost-wkt-types",
  "proto",
  "serde_json",
@@ -3755,19 +3680,19 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
- "tokio",
+ "prost",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -3776,13 +3701,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.90",
 ]
@@ -3857,7 +3783,7 @@ dependencies = [
  "env_logger",
  "exitcode",
  "glob",
- "http 1.2.0",
+ "http",
  "log",
  "openssl",
  "openssl-src",

--- a/context-ruby/ext/context_ruby/Cargo.lock
+++ b/context-ruby/ext/context_ruby/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "prost 0.13.4",
  "prost-build 0.13.4",
  "prost-types 0.13.4",
+ "protox",
  "serde",
  "serde_json",
  "tonic",

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -8,7 +8,6 @@ pretty_assertions = "0.6"
 junit-mock = { path = "../junit-mock" }
 test_utils = { path = "../test_utils" }
 tempfile = "3.2.0"
-prost-wkt-types = "0.6.0"
 
 [dependencies]
 anyhow = "1.0.44"
@@ -34,7 +33,7 @@ uuid = { version = "1.10.0", features = ["v5"] }
 wasm-bindgen = { version = "0.2.95", optional = true }
 magnus = { version = "0.7.1", optional = true, default-features = false }
 proto = { path = "../proto" }
-prost-wkt-types = "0.6.0"
+prost-wkt-types = { version = "0.5.1", features = ["vendored-protox"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pyo3 = { version = "0.22.5", optional = true, features = [

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -107,15 +107,18 @@ impl From<TestResult> for BindingsReport {
                 )
             });
         let (name, timestamp, timestamp_micros) = match uploader_metadata {
-            Some(t) => (
-                t.origin,
-                Some(t.upload_time.unwrap_or_default().seconds),
-                Some(
-                    chrono::Duration::nanoseconds(t.upload_time.unwrap_or_default().nanos as i64)
-                        .num_microseconds()
-                        .unwrap_or_default(),
-                ),
-            ),
+            Some(t) => {
+                let upload_time = t.upload_time.clone().unwrap_or_default();
+                (
+                    t.origin,
+                    Some(upload_time.seconds),
+                    Some(
+                        chrono::Duration::nanoseconds(upload_time.nanos as i64)
+                            .num_microseconds()
+                            .unwrap_or_default(),
+                    ),
+                )
+            }
             None => ("Unknown".to_string(), None, None),
         };
         BindingsReport {
@@ -148,9 +151,9 @@ impl From<TestCaseRun> for BindingsTestCase {
             attempt_number,
         }: TestCaseRun,
     ) -> Self {
-        let timestamp = chrono::DateTime::from(started_at.unwrap_or_default());
-        let timestamp_micros =
-            chrono::DateTime::from(started_at.unwrap_or_default()).timestamp_subsec_micros() as i64;
+        let started_at = started_at.unwrap_or_default();
+        let timestamp = chrono::DateTime::from(started_at.clone());
+        let timestamp_micros = chrono::DateTime::from(started_at).timestamp_subsec_micros() as i64;
         let time = (chrono::DateTime::from(finished_at.unwrap_or_default()) - timestamp)
             .to_std()
             .unwrap_or_default();
@@ -933,8 +936,8 @@ fn parse_test_report_to_bindings() {
         line: 1,
         status: TestCaseRunStatus::Success.into(),
         attempt_number: 1,
-        started_at: Some(test_started_at),
-        finished_at: Some(test_finished_at),
+        started_at: Some(test_started_at.clone()),
+        finished_at: Some(test_finished_at.clone()),
         status_output_message: "test_status_output_message".into(),
         ..Default::default()
     };
@@ -948,7 +951,7 @@ fn parse_test_report_to_bindings() {
         line: 1,
         status: TestCaseRunStatus::Failure.into(),
         attempt_number: 1,
-        started_at: Some(test_started_at),
+        started_at: Some(test_started_at.clone()),
         finished_at: Some(test_finished_at),
         status_output_message: "test_status_output_message".into(),
         ..Default::default()
@@ -978,7 +981,7 @@ fn parse_test_report_to_bindings() {
     assert_eq!(test_case1.assertions, None);
     assert_eq!(
         test_case1.timestamp,
-        Some(test1.started_at.unwrap().seconds)
+        Some(test1.started_at.clone().unwrap().seconds)
     );
     assert_eq!(
         test_case1.timestamp_micros,
@@ -1003,7 +1006,7 @@ fn parse_test_report_to_bindings() {
     assert_eq!(test_case2.assertions, None);
     assert_eq!(
         test_case2.timestamp,
-        Some(test2.started_at.unwrap().seconds)
+        Some(test2.started_at.clone().unwrap().seconds)
     );
     assert_eq!(
         test_case2.timestamp_micros,

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -1,5 +1,3 @@
-// NOTE: This lint isn't applicable since we compile with nightly
-/* trunk-ignore(clippy/E0554) */
 #![feature(round_char_boundary)]
 
 pub mod bazel_bep;

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -9,11 +9,11 @@ name = "proto"
 path = "src/lib.rs"
 
 [dependencies]
-prost = "0.13.4"
-prost-types = "0.13.4"
-prost-wkt-types = "0.6.0"
+prost = "0.12.6"
+prost-types = "0.12.6"
+prost-wkt-types = { version = "0.5.1", features = ["vendored-protox"] }
 serde = "1.0.215"
 
 [build-dependencies]
-prost-build = "0.13.4"
-protox = "0.7.1"
+prost-build = "0.12.6"
+protox = "0.6.1"

--- a/proto/src/build.rs
+++ b/proto/src/build.rs
@@ -1,10 +1,8 @@
-use std::io::Result;
-
-fn main() -> Result<()> {
-    let mut prost_build = prost_build::Config::new();
-    prost_build
+fn main() {
+    let file_descriptors = protox::compile(["proto/test_context.proto"], ["proto/"]).unwrap();
+    prost_build::Config::new()
         .type_attribute(".", "#[derive(serde::Serialize,serde::Deserialize)]")
         .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
-        .compile_protos(&["proto/test_context.proto"], &["proto/"])?;
-    Ok(())
+        .compile_fds(file_descriptors)
+        .unwrap();
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly-2024-05-01" # Output tests in JSON for Junit reports requires nightly
+channel = "nightly-2024-11-15"
+components = ["clippy", "rustfmt", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-11-15"
+channel = "nightly-2024-05-01"
 components = ["clippy", "rustfmt", "rust-src"]

--- a/test_report/Cargo.toml
+++ b/test_report/Cargo.toml
@@ -8,8 +8,8 @@ wasm-bindgen = { version = "0.2.95", optional = true }
 magnus = { version = "0.7.1", optional = true, default-features = false }
 proto = { path = "../proto" }
 trunk-analytics-cli = { path = "../cli" }
-prost-wkt-types = "0.6.0"
-prost = "0.13.4"
+prost-wkt-types = { version = "0.5.1", features = ["vendored-protox"] }
+prost = "0.12.6"
 tempfile = "3.2.0"
 chrono = "0.4.33"
 serde_json = "1.0.133"


### PR DESCRIPTION
* Simplify setup and build by removing reliance on `cmake` and `protoc`
* [Fixes `Cargo.lock` issue](https://trunk-io.slack.com/archives/C02CMS4TFUJ/p1734464030801369) seen in `context-ruby`
* Fix running Clippy
* Fix running `rust-analyzer`
* Fix `cargo check` lints
* Fix imports of dependencies with inconsistent versions
