### PR TITLE
(Fix): Output message correctly for empty BEP

### DIFF
--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -301,7 +301,10 @@ pub async fn run_upload(
     if file_counter.get_count() == 0 {
         log::warn!(
             "No JUnit files found to pack and upload using globs: {:?}",
-            junit_path_wrappers.iter().map(|j| &j.junit_path)
+            junit_path_wrappers
+                .iter()
+                .map(|j| &j.junit_path)
+                .collect::<Vec<&String>>()
         );
     }
 

--- a/context/src/junit/junit_path.rs
+++ b/context/src/junit/junit_path.rs
@@ -1,3 +1,4 @@
+use bazel_bep::types::build_event_stream::TestStatus;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
@@ -7,8 +8,6 @@ use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
-
-use bazel_bep::types::build_event_stream::TestStatus;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]


### PR DESCRIPTION
When the BEP doesn't contain any uncached test results, we were outputting:
```bash
No JUnit files found to pack and upload using globs: Map { iter: Iter([]) }
```

Fixed this to be just a proper `[]`. No need to add a test imo because this is a very corner case and not impacting any significant functionality