### PR TITLE
Part 3 - organize cli commands and imports

### DIFF
--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -40,13 +40,13 @@ pub struct Test {
 }
 
 impl Test {
-    pub fn new(
+    pub fn new<T: AsRef<str>>(
         name: String,
         parent_name: String,
         class_name: Option<String>,
         file: Option<String>,
         id: Option<String>,
-        org_slug: &str,
+        org_slug: T,
         repo: &RepoUrlParts,
         timestamp_millis: Option<i64>,
     ) -> Self {
@@ -61,7 +61,7 @@ impl Test {
             };
         }
         let info_id_input = [
-            org_slug,
+            org_slug.as_ref(),
             repo.repo_full_name().as_str(),
             file.as_deref().unwrap_or(""),
             class_name.as_deref().unwrap_or(""),

--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -45,41 +45,37 @@ impl Test {
         parent_name: String,
         class_name: Option<String>,
         file: Option<String>,
-        id: Option<String>,
         org_slug: T,
         repo: &RepoUrlParts,
         timestamp_millis: Option<i64>,
     ) -> Self {
-        if let Some(id) = id {
-            return Test {
-                parent_name,
-                name,
-                class_name,
-                file,
-                id,
-                timestamp_millis,
-            };
-        }
-        let info_id_input = [
-            org_slug.as_ref(),
-            repo.repo_full_name().as_str(),
-            file.as_deref().unwrap_or(""),
-            class_name.as_deref().unwrap_or(""),
-            &parent_name,
-            &name,
-            "JUNIT_TESTCASE",
-        ]
-        .join("#");
-        let id =
-            uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, info_id_input.as_bytes()).to_string();
-        Test {
+        let mut test = Self {
             parent_name,
             name,
             class_name,
             file,
-            id,
+            id: String::with_capacity(0),
             timestamp_millis,
-        }
+        };
+
+        test.set_id(org_slug, repo);
+
+        test
+    }
+
+    pub fn set_id<T: AsRef<str>>(&mut self, org_slug: T, repo: &RepoUrlParts) {
+        let info_id_input = [
+            org_slug.as_ref(),
+            repo.repo_full_name().as_str(),
+            self.file.as_deref().unwrap_or(""),
+            self.class_name.as_deref().unwrap_or(""),
+            &self.parent_name,
+            &self.name,
+            "JUNIT_TESTCASE",
+        ]
+        .join("#");
+        self.id =
+            uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, info_id_input.as_bytes()).to_string()
     }
 }
 
@@ -214,7 +210,6 @@ mod tests {
             parent_name.clone(),
             class_name.clone(),
             file.clone(),
-            None,
             org_slug,
             &repo,
             Some(0),
@@ -224,16 +219,14 @@ mod tests {
         assert_eq!(result.class_name, class_name);
         assert_eq!(result.file, file);
         assert_eq!(result.id, "aad1f138-09ab-5ea9-9c21-af48a03d6edd");
-        let result = Test::new(
-            name.clone(),
-            parent_name.clone(),
-            class_name.clone(),
-            file.clone(),
-            Some(String::from("da5b8893-d6ca-5c1c-9a9c-91f40a2a3649")),
-            org_slug,
-            &repo,
-            Some(0),
-        );
+        let result = Test {
+            name: name.clone(),
+            parent_name: parent_name.clone(),
+            class_name: class_name.clone(),
+            file: file.clone(),
+            id: String::from("da5b8893-d6ca-5c1c-9a9c-91f40a2a3649"),
+            timestamp_millis: Some(0),
+        };
         assert_eq!(result.name, name);
         assert_eq!(result.parent_name, parent_name);
         assert_eq!(result.class_name, class_name);

--- a/cli/src/api_client/mod.rs
+++ b/cli/src/api_client/mod.rs
@@ -1,12 +1,12 @@
-use anyhow::Context;
-use http::{header::HeaderMap, HeaderValue};
-use reqwest::{header, Client, Response, StatusCode};
 use std::path::Path;
-use tokio::fs;
 
+use anyhow::Context;
 use api;
 use call_api::CallApi;
 use constants::{DEFAULT_ORIGIN, TRUNK_PUBLIC_API_ADDRESS_ENV};
+use http::{header::HeaderMap, HeaderValue};
+use reqwest::{header, Client, Response, StatusCode};
+use tokio::fs;
 
 mod call_api;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api_client;
 pub mod print;
-pub mod runner;
+pub mod quarantine;
 pub mod scanner;
+pub mod test;
 pub mod upload;
 pub mod validate;

--- a/cli/src/quarantine.rs
+++ b/cli/src/quarantine.rs
@@ -21,21 +21,24 @@ fn convert_case_to_test<T: AsRef<str>>(
     let xml_string_to_string = |s: &quick_junit::XmlString| String::from(s.as_str());
     let class_name = case.classname.as_ref().map(xml_string_to_string);
     let file = case.extra.get("file").map(xml_string_to_string);
-    let id: Option<String> = case.extra.get("id").map(xml_string_to_string);
-    let timestamp = case
+    let timestamp_millis = case
         .timestamp
         .or(suite.timestamp)
         .map(|t| t.timestamp_millis());
-    Test::new(
+    let mut test = Test {
         name,
         parent_name,
         class_name,
         file,
-        id,
-        org_slug,
-        repo,
-        timestamp,
-    )
+        id: String::with_capacity(0),
+        timestamp_millis,
+    };
+    if let Some(id) = case.extra.get("id").map(xml_string_to_string) {
+        test.id = id;
+    } else {
+        test.set_id(org_slug, repo);
+    }
+    test
 }
 
 #[derive(Debug, Default, Clone)]

--- a/cli/src/quarantine.rs
+++ b/cli/src/quarantine.rs
@@ -1,96 +1,19 @@
-use context::repo::RepoUrlParts;
-use quick_junit::TestCaseStatus;
 use std::collections::HashMap;
-use std::process::{Command, Stdio};
-use std::time::SystemTime;
 
-use api;
-use bundle::{
-    FileSet, FileSetBuilder, QuarantineBulkTestStatus, QuarantineRunResult, RunResult, Test,
-};
-use codeowners::CodeOwners;
+use bundle::{FileSet, FileSetBuilder, QuarantineBulkTestStatus, QuarantineRunResult, Test};
 use constants::{EXIT_FAILURE, EXIT_SUCCESS};
 use context::{
-    bazel_bep::parser::BazelBepParser,
-    junit::{
-        junit_path::{JunitReportFileWithStatus, JunitReportStatus},
-        parser::JunitParser,
-    },
-    repo::BundleRepo,
+    junit::{junit_path::JunitReportStatus, parser::JunitParser},
+    repo::RepoUrlParts,
 };
+use quick_junit::TestCaseStatus;
 
-use crate::{api_client::ApiClient, print::print_bep_results};
+use crate::api_client::ApiClient;
 
-pub enum JunitSpec {
-    Paths(Vec<String>),
-    BazelBep(String),
-}
-
-pub async fn run_test_command(
-    repo: &BundleRepo,
-    command: &String,
-    args: Vec<&String>,
-    junit_spec: JunitSpec,
-    team: Option<String>,
-    codeowners: &Option<CodeOwners>,
-) -> anyhow::Result<RunResult> {
-    let start = SystemTime::now();
-    let exit_code = run_test_and_get_exit_code(command, args)?;
-    log::info!("Command exit code: {}", exit_code);
-
-    let output_paths = match junit_spec {
-        JunitSpec::Paths(paths) => paths
-            .into_iter()
-            .map(JunitReportFileWithStatus::from)
-            .collect(),
-        JunitSpec::BazelBep(bep_path) => {
-            let mut parser = BazelBepParser::new(bep_path);
-            let bep_result = parser.parse()?;
-            print_bep_results(&bep_result);
-            bep_result.uncached_xml_files()
-        }
-    };
-
-    let file_set_builder = FileSetBuilder::build_file_sets(
-        &repo.repo_root,
-        &output_paths,
-        team,
-        codeowners,
-        Some(start),
-    )?;
-
-    Ok(RunResult {
-        exit_code,
-        file_set_builder,
-        exec_start: Some(start),
-    })
-}
-
-fn run_test_and_get_exit_code(command: &String, args: Vec<&String>) -> anyhow::Result<i32> {
-    let mut child = Command::new(command)
-        .args(args)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-
-    let result = child
-        .wait()
-        .map_or_else(
-            |e| {
-                log::error!("Error waiting for execution: {}", e);
-                None
-            },
-            |exit_status| exit_status.code(),
-        )
-        .unwrap_or(EXIT_FAILURE);
-
-    Ok(result)
-}
-
-fn convert_case_to_test(
+fn convert_case_to_test<T: AsRef<str>>(
     repo: &RepoUrlParts,
-    org_slug: &str,
-    parent_name: &String,
+    org_slug: T,
+    parent_name: String,
     case: &quick_junit::TestCase,
     suite: &quick_junit::TestSuite,
 ) -> Test {
@@ -105,7 +28,7 @@ fn convert_case_to_test(
         .map(|t| t.timestamp_millis());
     Test::new(
         name,
-        parent_name.clone(),
+        parent_name,
         class_name,
         file,
         id,
@@ -156,7 +79,7 @@ impl FailedTestsExtractor {
                             let test = convert_case_to_test(
                                 repo,
                                 org_slug.as_ref(),
-                                &parent_name,
+                                parent_name.clone(),
                                 case,
                                 suite,
                             );

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -1,0 +1,206 @@
+use std::{
+    process::{Command, Stdio},
+    time::SystemTime,
+};
+
+use bundle::{FileSetBuilder, RunResult};
+use clap::Args;
+use codeowners::CodeOwners;
+use constants::EXIT_FAILURE;
+use context::{
+    bazel_bep::parser::BazelBepParser, junit::junit_path::JunitReportFileWithStatus,
+    repo::BundleRepo,
+};
+
+use crate::{
+    api_client::ApiClient,
+    print::print_bep_results,
+    quarantine::{run_quarantine, FailedTestsExtractor},
+    upload::{run_upload, UploadArgs},
+};
+
+#[derive(Args, Clone, Debug)]
+pub struct TestArgs {
+    #[command(flatten)]
+    upload_args: UploadArgs,
+    #[arg(
+        required = true,
+        allow_hyphen_values = true,
+        trailing_var_arg = true,
+        help = "Test command to invoke."
+    )]
+    command: Vec<String>,
+}
+
+pub async fn run_test(test_args: TestArgs) -> anyhow::Result<i32> {
+    let TestArgs {
+        command,
+        upload_args,
+    } = test_args;
+    let UploadArgs {
+        junit_paths,
+        bazel_bep_path,
+        org_url_slug,
+        token,
+        repo_root,
+        repo_url,
+        repo_head_sha,
+        repo_head_branch,
+        repo_head_commit_epoch,
+        use_quarantining,
+        team,
+        codeowners_path,
+        ..
+    } = &upload_args;
+
+    let repo = BundleRepo::new(
+        repo_root.clone(),
+        repo_url.clone(),
+        repo_head_sha.clone(),
+        repo_head_branch.clone(),
+        repo_head_commit_epoch.clone(),
+    )?;
+
+    if junit_paths.is_empty() && bazel_bep_path.is_none() {
+        return Err(anyhow::anyhow!("No junit paths provided."));
+    }
+
+    let api_client = ApiClient::new(String::from(token))?;
+
+    let codeowners = CodeOwners::find_file(&repo.repo_root, codeowners_path);
+    let junit_spec = if !junit_paths.is_empty() {
+        JunitSpec::Paths(junit_paths.clone())
+    } else {
+        JunitSpec::BazelBep(bazel_bep_path.as_deref().unwrap_or_default().to_string())
+    };
+
+    log::info!("running command: {:?}", command);
+    let run_result = run_test_command(
+        &repo,
+        command.first().unwrap(),
+        command.iter().skip(1).collect(),
+        junit_spec,
+        team.clone(),
+        &codeowners,
+    )
+    .await
+    .unwrap_or_else(|e| {
+        log::error!("Test command failed to run: {}", e);
+        RunResult {
+            exit_code: EXIT_FAILURE,
+            ..Default::default()
+        }
+    });
+
+    let run_exit_code = run_result.exit_code;
+    let failed_tests_extractor = FailedTestsExtractor::new(
+        &repo.repo,
+        org_url_slug,
+        run_result.file_set_builder.file_sets(),
+    );
+
+    let quarantine_run_result = if *use_quarantining {
+        Some(
+            run_quarantine(
+                &api_client,
+                &api::GetQuarantineBulkTestStatusRequest {
+                    repo: repo.repo,
+                    org_url_slug: org_url_slug.clone(),
+                    test_identifiers: failed_tests_extractor.failed_tests().to_vec(),
+                },
+                &run_result.file_set_builder,
+                Some(failed_tests_extractor),
+                Some(run_exit_code),
+            )
+            .await,
+        )
+    } else {
+        None
+    };
+
+    let exit_code = quarantine_run_result
+        .as_ref()
+        .map(|r| r.exit_code)
+        .unwrap_or(run_exit_code);
+
+    let exec_start = run_result.exec_start;
+    if let Err(e) = run_upload(
+        upload_args,
+        Some(command.join(" ")),
+        None, // don't re-run quarantine checks
+        codeowners,
+        exec_start,
+    )
+    .await
+    {
+        log::error!("Error uploading test results: {:?}", e)
+    };
+
+    Ok(exit_code)
+}
+
+pub enum JunitSpec {
+    Paths(Vec<String>),
+    BazelBep(String),
+}
+
+pub async fn run_test_command(
+    repo: &BundleRepo,
+    command: &String,
+    args: Vec<&String>,
+    junit_spec: JunitSpec,
+    team: Option<String>,
+    codeowners: &Option<CodeOwners>,
+) -> anyhow::Result<RunResult> {
+    let start = SystemTime::now();
+    let exit_code = run_test_and_get_exit_code(command, args)?;
+    log::info!("Command exit code: {}", exit_code);
+
+    let output_paths = match junit_spec {
+        JunitSpec::Paths(paths) => paths
+            .into_iter()
+            .map(JunitReportFileWithStatus::from)
+            .collect(),
+        JunitSpec::BazelBep(bep_path) => {
+            let mut parser = BazelBepParser::new(bep_path);
+            let bep_result = parser.parse()?;
+            print_bep_results(&bep_result);
+            bep_result.uncached_xml_files()
+        }
+    };
+
+    let file_set_builder = FileSetBuilder::build_file_sets(
+        &repo.repo_root,
+        &output_paths,
+        team,
+        codeowners,
+        Some(start),
+    )?;
+
+    Ok(RunResult {
+        exit_code,
+        file_set_builder,
+        exec_start: Some(start),
+    })
+}
+
+fn run_test_and_get_exit_code(command: &String, args: Vec<&String>) -> anyhow::Result<i32> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let result = child
+        .wait()
+        .map_or_else(
+            |e| {
+                log::error!("Error waiting for execution: {}", e);
+                None
+            },
+            |exit_status| exit_status.code(),
+        )
+        .unwrap_or(EXIT_FAILURE);
+
+    Ok(result)
+}

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -1,4 +1,3 @@
-use clap::{ArgAction, Args};
 #[cfg(target_os = "macos")]
 use std::io::Write;
 use std::{
@@ -6,14 +5,13 @@ use std::{
     io::BufReader,
     time::{SystemTime, UNIX_EPOCH},
 };
-#[cfg(target_os = "macos")]
-use xcresult::XCResult;
 
 use api::BundleUploadStatus;
 use bundle::{
     parse_custom_tags, BundleMeta, BundleMetaBaseProps, BundleMetaDebugProps, BundleMetaJunitProps,
     BundlerUtil, FileSet, FileSetBuilder, QuarantineRunResult, META_VERSION,
 };
+use clap::{ArgAction, Args};
 use codeowners::CodeOwners;
 use constants::EXIT_SUCCESS;
 #[cfg(target_os = "macos")]
@@ -23,11 +21,13 @@ use context::{
     junit::{junit_path::JunitReportFileWithStatus, parser::JunitParser},
     repo::BundleRepo,
 };
+#[cfg(target_os = "macos")]
+use xcresult::XCResult;
 
 use crate::{
     api_client::ApiClient,
     print::print_bep_results,
-    runner::{run_quarantine, FailedTestsExtractor},
+    quarantine::{run_quarantine, FailedTestsExtractor},
     scanner::EnvScanner,
 };
 


### PR DESCRIPTION
* Moved `test` and `validate` to their own files
* Moved around imports so that `std`, other crates, and then `crate` imports are grouped and in that order