### PR TITLE
Part 2 - use `xcrun xcresulttool get test-results tests` for parsing xcresults

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           lfs: "true"
 
+      - name: Setup Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16
+
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
         if: "!cancelled()"

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -121,6 +121,10 @@ jobs:
         with:
           python-version: "3.10"
       - uses: trunk-io/trunk-action/setup@v1
+      - name: Setup Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
       - name: Generate Python stubs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5524,7 +5524,6 @@ dependencies = [
  "clap",
  "context",
  "flate2",
- "indexmap 2.7.0",
  "lazy_static",
  "pretty_assertions",
  "prettyplease",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,7 +356,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -379,7 +385,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -503,7 +509,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -573,7 +579,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -794,7 +800,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1083,7 +1089,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1097,6 +1103,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -1292,6 +1304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,7 +1402,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1499,7 +1517,7 @@ dependencies = [
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
  "winnow",
 ]
 
@@ -1509,7 +1527,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6ffbeb3a5c0b8b84c3fe4133a6f8c82fa962f4caefe8d0762eced025d3eb4f7"
 dependencies = [
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1523,7 +1541,7 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "memmap2",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1557,7 +1575,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1569,7 +1587,7 @@ dependencies = [
  "bstr",
  "itoa",
  "jiff",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1615,7 +1633,7 @@ dependencies = [
  "once_cell",
  "prodash",
  "sha1_smol",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
  "walkdir",
 ]
 
@@ -1649,7 +1667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5eccc17194ed0e67d49285e4853307e4147e95407f91c1c3e4a13ba9f4e4ce"
 dependencies = [
  "faster-hex",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1671,7 +1689,7 @@ checksum = "1cd3ab68a452db63d9f3ebdacb10f30dba1fa0d31ac64f4203d395ed1102d940"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1743,7 +1761,7 @@ dependencies = [
  "gix-trace",
  "home",
  "once_cell",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1754,7 +1772,7 @@ checksum = "64a1e282216ec2ab2816cd57e6ed88f8009e634aec47562883c05ac8a7009a63"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1879,7 +1897,7 @@ dependencies = [
  "bstr",
  "gix-features",
  "gix-path",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
  "url",
 ]
 
@@ -1900,7 +1918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd520d09f9f585b34b32aba1d0b36ada89ab7fefb54a8ca3fe37fc482a750937"
 dependencies = [
  "bstr",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1970,6 +1988,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -2336,7 +2359,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2635,7 +2658,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2667,7 +2690,7 @@ checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2736,7 +2759,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2953,7 +2976,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3103,7 +3126,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3224,12 +3247,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3278,7 +3301,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.96",
  "tempfile",
 ]
 
@@ -3292,7 +3315,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3450,7 +3473,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3463,7 +3486,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3493,7 +3516,7 @@ checksum = "295a22fe8963404c42f3d62c78099dde32ec508a3e756b0dc86a1e7fa604eb34"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3507,7 +3530,7 @@ dependencies = [
  "newtype-uuid",
  "quick-xml 0.37.1",
  "strip-ansi-escapes",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
  "uuid",
 ]
 
@@ -3542,7 +3565,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -3561,7 +3584,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.4",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3647,7 +3670,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3702,6 +3725,16 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "regress"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f56e622c2378013c6c61e2bd776604c46dc1087b2dc5293275a0c20a44f0771"
+dependencies = [
+ "hashbrown 0.15.2",
+ "memchr",
+]
 
 [[package]]
 name = "reqwest"
@@ -3892,6 +3925,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 dependencies = [
  "serde",
 ]
@@ -4058,22 +4115,22 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4084,14 +4141,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4116,6 +4173,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4242,7 +4311,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4264,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4296,7 +4365,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4406,11 +4475,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.4",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -4421,18 +4490,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4527,7 +4596,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4656,7 +4725,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4727,7 +4796,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4810,7 +4879,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4840,7 +4909,54 @@ checksum = "70b20a22c42c8f1cd23ce5e34f165d4d37038f5b663ad20fb6adbdf029172483"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "typify"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03ba3643450cfd95a1aca2e1938fef63c1c1994489337998aff4ad771f21ef8"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce48219a2f3154aaa2c56cbf027728b24a3c8fe0a47ed6399781de2b3f3eeaf"
+dependencies = [
+ "heck 0.5.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn 2.0.96",
+ "thiserror 2.0.11",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b5780d745920ed73c5b7447496a9b5c42ed2681a9b70859377aec423ecf02b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.96",
+ "typify-impl",
 ]
 
 [[package]]
@@ -5060,7 +5176,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -5095,7 +5211,7 @@ checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5410,12 +5526,17 @@ dependencies = [
  "flate2",
  "indexmap 2.7.0",
  "lazy_static",
- "log",
+ "pretty_assertions",
+ "prettyplease",
  "quick-junit",
  "regex",
+ "schemars",
+ "serde",
  "serde_json",
+ "syn 2.0.96",
  "tar",
  "temp_testdir",
+ "typify",
  "uuid",
 ]
 
@@ -5439,7 +5560,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -5461,7 +5582,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5481,7 +5602,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -5510,7 +5631,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -75,7 +75,7 @@ pub fn gather_pre_test_context(upload_args: UploadArgs) -> anyhow::Result<PreTes
             #[cfg(target_os = "macos")]
             &repo.repo,
             #[cfg(target_os = "macos")]
-            &org_url_slug,
+            org_url_slug.clone(),
             #[cfg(target_os = "macos")]
             allow_empty_test_results,
         )?;
@@ -175,7 +175,7 @@ fn coalesce_junit_path_wrappers(
     bazel_bep_path: Option<String>,
     #[cfg(target_os = "macos")] xcresult_path: Option<String>,
     #[cfg(target_os = "macos")] repo: &RepoUrlParts,
-    #[cfg(target_os = "macos")] org_url_slug: &str,
+    #[cfg(target_os = "macos")] org_url_slug: String,
     #[cfg(target_os = "macos")] allow_empty_test_results: bool,
 ) -> anyhow::Result<(
     Vec<JunitReportFileWithStatus>,
@@ -293,14 +293,17 @@ fn handle_xcresult(
     junit_temp_dir: &tempfile::TempDir,
     xcresult_path: Option<String>,
     repo: &RepoUrlParts,
-    org_url_slug: &str,
+    org_url_slug: String,
 ) -> Result<Vec<JunitReportFileWithStatus>, anyhow::Error> {
     let mut temp_paths = Vec::new();
     if let Some(xcresult_path) = xcresult_path {
-        let xcresult = XCResult::new(xcresult_path, repo, org_url_slug);
-        let junits = xcresult?
-            .generate_junits()
-            .map_err(|e| anyhow::anyhow!("Failed to generate junit files from xcresult: {}", e))?;
+        let xcresult = XCResult::new(xcresult_path, org_url_slug, repo.repo_full_name())?;
+        let junits = xcresult.generate_junits();
+        if junits.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to generate junit files from xcresult."
+            ));
+        }
         for (i, junit) in junits.iter().enumerate() {
             let mut junit_writer: Vec<u8> = Vec::new();
             junit.serialize(&mut junit_writer)?;

--- a/xcresult/Cargo.toml
+++ b/xcresult/Cargo.toml
@@ -13,18 +13,27 @@ path = "src/xcresult.rs"
 
 [dependencies]
 anyhow = "1.0.89"
+chrono = "0.4.38"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 context = { path = "../context" }
-chrono = "0.4.38"
 indexmap = "2.6.0"
 lazy_static = "1.5.0"
-log = "0.4.22"
 quick-junit = "0.5.0"
 regex = "1.11.0"
+serde = { version = "1.0.215", default-features = false }
 serde_json = "1.0.133"
 uuid = { version = "1.10.0", features = ["v5"] }
 
 [dev-dependencies]
+context = { path = "../context" }
 flate2 = "1.0.34"
+pretty_assertions = "0.6"
 tar = "0.4.42"
 temp_testdir = "0.2.3"
+
+[build-dependencies]
+prettyplease = "0.2.29"
+schemars = "0.8.21"
+serde_json = "1.0.133"
+syn = "2.0.96"
+typify = "0.3.0"

--- a/xcresult/Cargo.toml
+++ b/xcresult/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = "1.0.89"
 chrono = "0.4.38"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 context = { path = "../context" }
-indexmap = "2.6.0"
 lazy_static = "1.5.0"
 quick-junit = "0.5.0"
 regex = "1.11.0"

--- a/xcresult/build.rs
+++ b/xcresult/build.rs
@@ -1,0 +1,19 @@
+use std::{env, fs, path::Path};
+
+use typify::{TypeSpace, TypeSpaceSettings};
+
+fn main() {
+    let content =
+        fs::read_to_string("./xcrun-xcresulttool-get-test-results-tests-json-schema.json").unwrap();
+    let schema = serde_json::from_str::<schemars::schema::RootSchema>(&content).unwrap();
+
+    let mut type_space = TypeSpace::new(TypeSpaceSettings::default().with_struct_builder(true));
+    type_space.add_root_schema(schema).unwrap();
+
+    let contents =
+        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap());
+
+    let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
+    out_file.push("codegen.rs");
+    fs::write(out_file, contents).unwrap();
+}

--- a/xcresult/create-json-schema.py
+++ b/xcresult/create-json-schema.py
@@ -1,0 +1,28 @@
+import json
+import pathlib
+
+# trunk-ignore(bandit/B404)
+import subprocess
+
+
+def main():
+    # trunk-ignore(bandit/B603,bandit/B607)
+    result = subprocess.run(
+        ["xcrun", "xcresulttool", "help", "get", "test-results", "tests"],
+        capture_output=True,
+        text=True,
+    ).stdout.replace("#/schemas", "#/$defs")
+    json_schema_lines = result.split("\n")[3:148]
+    json_schema = json.loads("\n".join(json_schema_lines))
+
+    json_schema["$defs"] = json_schema["schemas"]
+    del json_schema["schemas"]
+    json_schema["$ref"] = "#/$defs/Tests"
+
+    pathlib.Path(__file__).parent.resolve().joinpath(
+        "./xcrun-xcresulttool-get-test-results-tests-json-schema.json"
+    ).write_text(json.dumps(json_schema, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/xcresult/src/main.rs
+++ b/xcresult/src/main.rs
@@ -6,12 +6,12 @@ use xcresult::XCResult;
 
 #[derive(Debug, Parser)]
 pub struct Cli {
-    /// Repository URL
-    #[arg(long)]
-    pub repo_url: Option<String>,
     /// Organization URL slug
     #[arg(long)]
     pub org_url_slug: Option<String>,
+    /// Repository URL, e.g. `https://github.com/trunk-io/analytics-cli`
+    #[arg(long)]
+    pub repo_url: Option<String>,
     /// `.xcresult` directory to parse
     #[arg(required = true)]
     pub xcresult: String,
@@ -23,15 +23,19 @@ pub struct Cli {
 fn main() -> anyhow::Result<()> {
     let Cli {
         xcresult: path,
-        repo_url,
         org_url_slug,
+        repo_url,
         output_file_path,
     } = Cli::parse();
     let repo_url_parts = repo_url
         .and_then(|repo_url| RepoUrlParts::from_url(&repo_url).ok())
         .unwrap_or_default();
-    let xcresult = XCResult::new(path, &repo_url_parts, org_url_slug.unwrap_or_default())?;
-    let mut junits = xcresult.generate_junits()?;
+    let xcresult = XCResult::new(
+        path,
+        org_url_slug.unwrap_or_default(),
+        repo_url_parts.repo_full_name(),
+    )?;
+    let mut junits = xcresult.generate_junits();
     let junit_count_and_first_junit = (junits.len(), junits.pop());
     let junit = if let (1, Some(junit)) = junit_count_and_first_junit {
         junit

--- a/xcresult/src/xcresult.rs
+++ b/xcresult/src/xcresult.rs
@@ -152,18 +152,18 @@ impl XCResult {
                     }
                 }
 
-                let repetitions = Self::xcresult_repetition_to_junit_test_rerun(
+                let test_reruns = Self::xcresult_repetitions_to_junit_test_reruns(
                     xcresult_test_case.children.as_slice(),
                 );
-                if !repetitions.is_empty() {
+                if !test_reruns.is_empty() {
                     match test_case.status {
                         TestCaseStatus::Success {
                             ref mut flaky_runs, ..
                         } => {
-                            *flaky_runs = repetitions;
+                            *flaky_runs = test_reruns;
                         }
                         TestCaseStatus::NonSuccess { ref mut reruns, .. } => {
-                            *reruns = repetitions;
+                            *reruns = test_reruns;
                         }
                         _ => {}
                     }
@@ -183,7 +183,9 @@ impl XCResult {
             .collect()
     }
 
-    fn xcresult_repetition_to_junit_test_rerun(test_nodes: &[schema::TestNode]) -> Vec<TestRerun> {
+    fn xcresult_repetitions_to_junit_test_reruns(
+        test_nodes: &[schema::TestNode],
+    ) -> Vec<TestRerun> {
         test_nodes
             .iter()
             .filter(|tn| matches!(tn.node_type, schema::TestNodeType::Repetition))

--- a/xcresult/src/xcresult.rs
+++ b/xcresult/src/xcresult.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path, time::Duration};
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
 use schema::TestNode;
 
-#[allow(dead_code)]
+#[allow(clippy::all)]
 mod schema {
     include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 }

--- a/xcresult/src/xcresult.rs
+++ b/xcresult/src/xcresult.rs
@@ -1,373 +1,317 @@
-use context::repo::RepoUrlParts;
-use indexmap::indexmap;
-use lazy_static::lazy_static;
-use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite, XmlString};
-use std::str;
-use std::{fs, process::Command};
+use std::{fs, path::Path, time::Duration};
 
-const RESULTS_FIELD_VALUE: &str = "_value";
-const RESULTS_FIELD_VALUES: &str = "_values";
+use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
+use schema::TestNode;
+
+#[allow(dead_code)]
+mod schema {
+    include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
+}
 
 #[derive(Debug, Clone)]
 pub struct XCResult {
-    pub path: String,
-    results_obj: serde_json::Value,
-    pub repo_url_parts: RepoUrlParts,
-    pub org_url_slug: String,
-}
-
-const LEGACY_FLAG_MIN_VERSION: i32 = 70;
-
-fn xcrun<T: AsRef<str>>(args: &[T]) -> anyhow::Result<String> {
-    if !cfg!(target_os = "macos") {
-        return Err(anyhow::anyhow!("xcrun is only available on macOS"));
-    }
-    let mut cmd = Command::new("xcrun");
-    let bin = cmd.args(args.iter().map(|arg| arg.as_ref()));
-    let output = bin.output().map_err(|_| {
-        anyhow::anyhow!("failed to run xcrun -- please make sure you have xcode installed")
-    })?;
-    let result = String::from_utf8(output.stdout)
-        .map_err(|_| anyhow::anyhow!("got non UTF-8 data from xcrun output"))?;
-    Ok(result)
-}
-
-fn xcrun_version() -> anyhow::Result<i32> {
-    let version_raw = xcrun(&["--version"])?;
-    lazy_static! {
-        // regex to match version where the output looks like xcrun version 70.
-        static ref RE: regex::Regex = regex::Regex::new(r"xcrun version (\d+)").unwrap();
-    }
-    RE.captures(&version_raw)
-        .and_then(|capture_group| capture_group.get(1))
-        .map(|version| Ok(version.as_str().parse::<i32>().ok().unwrap_or_default()))
-        .unwrap_or_else(|| Err(anyhow::anyhow!("failed to parse xcrun version")))
-}
-
-fn xcresulttool<T: AsRef<str>>(
-    path: T,
-    options: Option<&[T]>,
-) -> anyhow::Result<serde_json::Value> {
-    let mut base_args = vec![
-        "xcresulttool",
-        "get",
-        "--path",
-        path.as_ref(),
-        "--format",
-        "json",
-    ];
-    let version = xcrun_version()?;
-    if version >= LEGACY_FLAG_MIN_VERSION {
-        base_args.push("--legacy");
-    }
-    if let Some(val) = options {
-        base_args.extend(val.iter().map(|arg| arg.as_ref()));
-    }
-    let output = xcrun(&base_args)?;
-    serde_json::from_str(&output)
-        .map_err(|_| anyhow::anyhow!("failed to parse json from xcrun output"))
+    tests: schema::Tests,
+    org_url_slug: String,
+    repo_full_name: String,
 }
 
 impl XCResult {
-    pub fn new<T: AsRef<str>, S: AsRef<str>>(
+    pub fn new<T: AsRef<Path>>(
         path: T,
-        repo_url_parts: &RepoUrlParts,
-        org_url_slug: S,
+        org_url_slug: String,
+        repo_full_name: String,
     ) -> anyhow::Result<XCResult> {
-        let binding = fs::canonicalize(path.as_ref())
-            .map_err(|_| anyhow::anyhow!("failed to get absolute path -- is the path correct?"))?;
-        let absolute_path = binding.to_str().unwrap_or_default();
-        let results_obj = xcresulttool(absolute_path, None)?;
+        let absolute_path = fs::canonicalize(path.as_ref()).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to get absolute path for {}: {}",
+                path.as_ref().display(),
+                e
+            )
+        })?;
         Ok(XCResult {
-            path: absolute_path.to_string(),
-            repo_url_parts: repo_url_parts.clone(),
-            org_url_slug: org_url_slug.as_ref().to_string(),
-            results_obj,
+            tests: xcrun_cmd::xcresulttool_get_test_results_tests(absolute_path)?,
+            org_url_slug,
+            repo_full_name,
         })
     }
 
-    fn find_tests<T: AsRef<str>>(&self, id: T) -> anyhow::Result<serde_json::Value> {
-        xcresulttool(self.path.as_str(), Some(&["--id", id.as_ref()]))
+    pub fn generate_junits(&self) -> Vec<Report> {
+        self.xcresult_test_plans_to_junit_reports(self.tests.test_nodes.as_slice())
     }
 
-    fn generate_id(&self, raw_id: &str) -> String {
+    fn xcresult_test_plans_to_junit_reports(&self, test_nodes: &[schema::TestNode]) -> Vec<Report> {
+        test_nodes
+            .iter()
+            .filter(|tn| matches!(tn.node_type, schema::TestNodeType::TestPlan))
+            .map(|test_plan| {
+                let mut report = Report::new(format!("xcresult: {}", test_plan.name));
+                report.add_test_suites(self.xcresult_test_bundles_and_suites_to_junit_test_suites(
+                    test_plan.children.as_slice(),
+                ));
+                report
+            })
+            .collect()
+    }
+
+    fn xcresult_test_bundles_and_suites_to_junit_test_suites(
+        &self,
+        test_nodes: &[schema::TestNode],
+    ) -> Vec<TestSuite> {
+        test_nodes
+            .iter()
+            .filter(|tn| {
+                matches!(
+                    tn.node_type,
+                    schema::TestNodeType::UnitTestBundle
+                        | schema::TestNodeType::UiTestBundle
+                        | schema::TestNodeType::TestSuite
+                )
+            })
+            .flat_map(|test_bundle_or_test_suite| {
+                if matches!(
+                    test_bundle_or_test_suite.node_type,
+                    schema::TestNodeType::UnitTestBundle | schema::TestNodeType::UiTestBundle
+                ) {
+                    let test_bundle = test_bundle_or_test_suite;
+                    self.xcresult_test_suites_to_junit_test_suites(
+                        test_bundle.children.as_slice(),
+                        Some(&test_bundle.name),
+                    )
+                } else {
+                    let test_suite = test_bundle_or_test_suite;
+                    vec![self
+                        .xcresult_test_suite_to_junit_test_suite(test_suite, Option::<&str>::None)]
+                }
+            })
+            .collect()
+    }
+
+    fn xcresult_test_suites_to_junit_test_suites<T: AsRef<str>>(
+        &self,
+        test_nodes: &[schema::TestNode],
+        bundle_name: Option<T>,
+    ) -> Vec<TestSuite> {
+        test_nodes
+            .iter()
+            .filter(|tn| matches!(tn.node_type, schema::TestNodeType::TestSuite))
+            .map(|test_suite| {
+                self.xcresult_test_suite_to_junit_test_suite(test_suite, bundle_name.as_ref())
+            })
+            .collect()
+    }
+
+    fn xcresult_test_suite_to_junit_test_suite<T: AsRef<str>>(
+        &self,
+        xcresult_test_suite: &schema::TestNode,
+        bundle_name: Option<T>,
+    ) -> TestSuite {
+        let name = bundle_name
+            .as_ref()
+            .map(|bn| format!("{}.{}", bn.as_ref(), xcresult_test_suite.name))
+            .unwrap_or_else(|| String::from(&xcresult_test_suite.name));
+        let mut test_suite = TestSuite::new(name);
+        test_suite.add_test_cases(
+            self.xcresult_test_cases_to_junit_test_cases(xcresult_test_suite.children.as_slice()),
+        );
+        test_suite
+    }
+
+    fn xcresult_test_cases_to_junit_test_cases(
+        &self,
+        test_nodes: &[schema::TestNode],
+    ) -> Vec<TestCase> {
+        test_nodes
+            .iter()
+            .filter(|tn| matches!(tn.node_type, schema::TestNodeType::TestCase))
+            .filter_map(|tn| tn.result.as_ref().map(|result| (tn, *result)))
+            .filter_map(|(xcresult_test_case, test_result)| {
+                let status = match test_result {
+                    schema::TestResult::Passed | schema::TestResult::ExpectedFailure => {
+                        TestCaseStatus::success()
+                    }
+                    schema::TestResult::Failed => {
+                        TestCaseStatus::non_success(NonSuccessKind::Failure)
+                    }
+                    schema::TestResult::Skipped => TestCaseStatus::skipped(),
+                    schema::TestResult::Unknown => {
+                        // TODO: Add a warning
+                        return None;
+                    }
+                };
+                let mut test_case = TestCase::new(String::from(&xcresult_test_case.name), status);
+
+                let failure_messages = Self::xcresult_failure_messages_to_strings(
+                    xcresult_test_case.children.as_slice(),
+                );
+                if !failure_messages.is_empty() {
+                    if let TestCaseStatus::NonSuccess {
+                        ref mut message, ..
+                    } = test_case.status
+                    {
+                        *message = Some(failure_messages.join("\n").into())
+                    }
+                }
+
+                let repetitions = Self::xcresult_repetition_to_junit_test_rerun(
+                    xcresult_test_case.children.as_slice(),
+                );
+                if !repetitions.is_empty() {
+                    match test_case.status {
+                        TestCaseStatus::Success {
+                            ref mut flaky_runs, ..
+                        } => {
+                            *flaky_runs = repetitions;
+                        }
+                        TestCaseStatus::NonSuccess { ref mut reruns, .. } => {
+                            *reruns = repetitions;
+                        }
+                        _ => {}
+                    }
+                }
+
+                if let Some(duration) = Self::xcresult_test_node_to_duration(xcresult_test_case) {
+                    test_case.set_time(duration);
+                }
+
+                if let Some(node_identifier) = &xcresult_test_case.node_identifier {
+                    let id = self.generate_id(node_identifier);
+                    test_case.extra.insert("id".into(), id.into());
+                }
+
+                Some(test_case)
+            })
+            .collect()
+    }
+
+    fn xcresult_repetition_to_junit_test_rerun(test_nodes: &[schema::TestNode]) -> Vec<TestRerun> {
+        test_nodes
+            .iter()
+            .filter(|tn| matches!(tn.node_type, schema::TestNodeType::Repetition))
+            .filter_map(|tn| tn.result.as_ref().map(|result| (tn, *result)))
+            .filter_map(|(repetition, test_result)| {
+                let status = match test_result {
+                    schema::TestResult::Passed | schema::TestResult::ExpectedFailure => {
+                        // A successful repetition isn't relevant to JUnit test reruns
+                        return None;
+                    }
+                    schema::TestResult::Failed => NonSuccessKind::Failure,
+                    schema::TestResult::Skipped | schema::TestResult::Unknown => {
+                        // TODO: Add a warning
+                        return None;
+                    }
+                };
+                let mut test_rerun = TestRerun::new(status);
+
+                let failure_messages =
+                    Self::xcresult_failure_messages_to_strings(repetition.children.as_slice());
+                if !failure_messages.is_empty() {
+                    test_rerun.set_message(failure_messages.join("\n"));
+                }
+
+                if let Some(duration) = Self::xcresult_test_node_to_duration(repetition) {
+                    test_rerun.set_time(duration);
+                }
+
+                Some(test_rerun)
+            })
+            .collect()
+    }
+
+    fn xcresult_failure_messages_to_strings(test_nodes: &[schema::TestNode]) -> Vec<String> {
+        test_nodes
+            .iter()
+            .filter(|tn| matches!(tn.node_type, schema::TestNodeType::FailureMessage))
+            .map(|failure_message| String::from(&failure_message.name))
+            .collect()
+    }
+
+    fn xcresult_test_node_to_duration(test_node: &TestNode) -> Option<Duration> {
+        test_node
+            .duration
+            .as_ref()
+            .and_then(|secs| secs.replace('s', "").parse::<f64>().ok())
+            .and_then(|secs| Duration::try_from_secs_f64(secs).ok())
+    }
+
+    fn generate_id<T: AsRef<str>>(&self, raw_id: T) -> String {
         // join the org and repo name to the raw id and generate uuid v5 from it
-        return uuid::Uuid::new_v5(
+        uuid::Uuid::new_v5(
             &uuid::Uuid::NAMESPACE_URL,
             format!(
                 "{}#{}#{}",
-                self.org_url_slug,
-                &self.repo_url_parts.repo_full_name(),
-                raw_id
+                &self.org_url_slug,
+                &self.repo_full_name,
+                raw_id.as_ref()
             )
             .as_bytes(),
         )
-        .to_string();
+        .to_string()
+    }
+}
+
+mod xcrun_cmd {
+    use std::{ffi::OsStr, process::Command};
+
+    use lazy_static::lazy_static;
+
+    use crate::schema;
+
+    pub fn xcresulttool_get_test_results_tests<T: AsRef<OsStr>>(
+        path: T,
+    ) -> anyhow::Result<schema::Tests> {
+        xcrun_version_check()?;
+
+        let output = xcrun(&[
+            "xcresulttool".as_ref(),
+            "get".as_ref(),
+            "test-results".as_ref(),
+            "tests".as_ref(),
+            "--path".as_ref(),
+            path.as_ref(),
+        ])?;
+
+        serde_json::from_str::<schema::Tests>(&output)
+            .map_err(|e| anyhow::anyhow!("failed to parse json from xcrun output: {}", e))
     }
 
-    fn junit_testcase(
-        &self,
-        action: &serde_json::Value,
-        testcase: &serde_json::Value,
-        testcase_group: &serde_json::Value,
-    ) -> anyhow::Result<TestCase> {
-        let name = testcase
-            .get("name")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-            .map_or_else(
-                || {
-                    log::debug!("failed to get name of testcase: {:?}", testcase);
-                    Err(anyhow::anyhow!("failed to get name of testcase"))
-                },
-                Ok,
-            )?;
-        let status = match testcase
-            .get("testStatus")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-        {
-            Some(val) => val,
-            None => {
-                log::debug!("failed to get status of testcase: {:?}", testcase);
-                return Err(anyhow::anyhow!("failed to get status of testcase"));
-            }
-        };
-        let mut testcase_status = match status {
-            "Error" => TestCaseStatus::non_success(NonSuccessKind::Error),
-            "Failure" => TestCaseStatus::non_success(NonSuccessKind::Failure),
-            "Skipped" => TestCaseStatus::skipped(),
-            "Success" | "Expected Failure" => TestCaseStatus::success(),
-            _ => TestCaseStatus::non_success(NonSuccessKind::Error),
-        };
-        let mut uri = String::new();
-        if status == "Failure" {
-            let mut failures = match action
-                .get("actionResult")
-                .and_then(|r| r.get("issues"))
-                .and_then(|r| r.get("testFailureSummaries"))
-                .and_then(|r| r.get(RESULTS_FIELD_VALUES))
-                .and_then(|r| r.as_array())
-            {
-                Some(val) => val.iter(),
-                None => {
-                    log::debug!("failed to get failures of testcase: {:?}", testcase);
-                    return Err(anyhow::anyhow!("failed to get failures of testcase"));
-                }
-            };
-            let testcase_identifier = testcase
-                .get("identifier")
-                .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-                .and_then(|r| r.as_str());
-            if let Some(testcase_identifer) = testcase_identifier {
-                let testcase_identifer_updated = testcase_identifer.replace('/', ".");
-                let testcase_identifer_updated_str = Some(testcase_identifer_updated.as_str());
-                let failure = failures.find(|f| {
-                    f.get("testCaseName")
-                        .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-                        .and_then(|r| r.as_str())
-                        == testcase_identifer_updated_str
-                });
-                if let Some(failure) = failure {
-                    let failure_message = failure
-                        .get("message")
-                        .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-                        .and_then(|r| r.as_str());
-                    let failure_uri = failure
-                        .get("documentLocationInCreatingWorkspace")
-                        .and_then(|r| r.get("url"))
-                        .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-                        .and_then(|r| r.as_str());
-                    testcase_status.set_message(failure_message.unwrap_or_default());
-                    uri = failure_uri.unwrap_or_default().replace("file://", "");
-                }
-            }
+    const LEGACY_FLAG_MIN_VERSION: usize = 70;
+    fn xcrun_version_check() -> anyhow::Result<()> {
+        let version = xcrun_version()?;
+        if version < LEGACY_FLAG_MIN_VERSION {
+            return Err(anyhow::anyhow!(
+                "xcrun version {} is not supported, please upgrade to version {} or higher",
+                version,
+                LEGACY_FLAG_MIN_VERSION
+            ));
         }
-        let mut testcase_junit = TestCase::new(name, testcase_status);
-        let id = testcase
-            .get("identifierURL")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-            .map(|r| self.generate_id(r))
-            .unwrap_or_default();
-        testcase_junit.extra.insert("id".into(), id.into());
-        let file_components = uri.split('#').collect::<Vec<&str>>();
-        if file_components.len() == 2 {
-            testcase_junit
-                .extra
-                .insert("file".into(), file_components[0].into());
-        }
-        if let Some(classname) = testcase_group
-            .get("name")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-        {
-            testcase_junit.set_classname(classname);
-        }
-
-        if let Some(duration) = testcase
-            .get("duration")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-            .and_then(|r| r.parse::<f32>().ok())
-        {
-            testcase_junit.set_time(std::time::Duration::from_secs_f32(duration));
-        }
-        Ok(testcase_junit)
+        Ok(())
     }
 
-    fn junit_testsuite(
-        &self,
-        action: &serde_json::Value,
-        testsuite: &serde_json::Value,
-    ) -> anyhow::Result<TestSuite> {
-        let testsuite_name = testsuite
-            .get("name")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str());
-        if testsuite_name.is_none() {
-            log::debug!("failed to get name of testsuite: {:?}", testsuite);
-            return Err(anyhow::anyhow!("failed to get name of testsuite"));
+    fn xcrun_version() -> anyhow::Result<usize> {
+        let version_raw = xcrun(&["--version"])?;
+
+        lazy_static! {
+            // regex to match version where the output looks like xcrun version 70.
+            static ref RE: regex::Regex = regex::Regex::new(r"xcrun version (\d+)").unwrap();
         }
-        let mut testsuite_junit = TestSuite::new(testsuite_name.unwrap_or_default());
-        if let Some(identifier) = testsuite
-            .get("identifierURL")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-        {
-            testsuite_junit.extra.append(&mut indexmap! {
-                XmlString::new("id") => XmlString::new(self.generate_id(identifier)),
-            });
+        let version_parsed = RE
+            .captures(&version_raw)
+            .and_then(|capture_group| capture_group.get(1))
+            .and_then(|version| version.as_str().parse::<usize>().ok());
+
+        if let Some(version) = version_parsed {
+            Ok(version)
+        } else {
+            Err(anyhow::anyhow!("failed to parse xcrun version"))
         }
-        if let Some(duration) = testsuite
-            .get("duration")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str())
-            .and_then(|r| r.parse::<f32>().ok())
-        {
-            testsuite_junit.set_time(std::time::Duration::from_secs_f32(duration));
-        }
-        if let Some(testcase_groups) = testsuite
-            .get("subtests")
-            .and_then(|t| t.get(RESULTS_FIELD_VALUES))
-            .and_then(|r| r.as_array())
-        {
-            for testcase_group in testcase_groups {
-                if let Some(testcases) = testcase_group
-                    .get("subtests")
-                    .and_then(|t| t.get(RESULTS_FIELD_VALUES))
-                    .and_then(|r| r.as_array())
-                {
-                    for testcase in testcases {
-                        let testcase_xml = self.junit_testcase(action, testcase, testcase_group)?;
-                        testsuite_junit.add_test_case(testcase_xml);
-                    }
-                }
-            }
-        };
-        Ok(testsuite_junit)
     }
 
-    fn junit_report(&self, action: &serde_json::Value) -> anyhow::Result<Report> {
-        let mut testsuites_junit = Report::new("xcresult");
-        let raw_id = action
-            .get("actionResult")
-            .and_then(|r| r.get("testsRef"))
-            .and_then(|r| r.get("id"))
-            .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-            .and_then(|r| r.as_str());
-        if raw_id.is_none() {
-            log::debug!("no test id found for action: {:?}", action);
-            return Ok(testsuites_junit);
+    fn xcrun<T: AsRef<OsStr>>(args: &[T]) -> anyhow::Result<String> {
+        if !cfg!(target_os = "macos") {
+            return Err(anyhow::anyhow!("xcrun is only available on macOS"));
         }
-        let id = raw_id.unwrap_or_default();
-        const DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
-        if let (Some(ended_time), Some(started_time)) = (
-            action
-                .get("endedTime")
-                .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-                .and_then(|r| r.as_str()),
-            action
-                .get("startedTime")
-                .and_then(|r| r.get(RESULTS_FIELD_VALUE))
-                .and_then(|r| r.as_str()),
-        ) {
-            let ended_time_parsed = chrono::DateTime::parse_from_str(ended_time, DATE_FORMAT)?;
-            let started_time_parsed = chrono::DateTime::parse_from_str(started_time, DATE_FORMAT)?;
-            let duration = (ended_time_parsed.timestamp_millis()
-                - started_time_parsed.timestamp_millis()) as u64;
-            testsuites_junit.set_time(std::time::Duration::from_millis(duration));
-        }
-        let found_tests = self.find_tests(id)?;
-        let test_summaries = match found_tests
-            .get("summaries")
-            .and_then(|r| r.get(RESULTS_FIELD_VALUES))
-        {
-            Some(val) => val.as_array(),
-            None => return Ok(testsuites_junit),
-        };
-        if let Some(test_summaries) = test_summaries {
-            for test_summary in test_summaries {
-                let testable_summaries = match test_summary
-                    .get("testableSummaries")
-                    .and_then(|t| t.get(RESULTS_FIELD_VALUES))
-                    .and_then(|r| r.as_array())
-                {
-                    Some(val) => val,
-                    None => {
-                        return Ok(testsuites_junit);
-                    }
-                };
-                for testable_summary in testable_summaries {
-                    let top_level_tests = match testable_summary
-                        .get("tests")
-                        .and_then(|t| t.get(RESULTS_FIELD_VALUES))
-                        .and_then(|r| r.as_array())
-                    {
-                        Some(val) => val,
-                        None => {
-                            return Ok(testsuites_junit);
-                        }
-                    };
-                    for top_level_test in top_level_tests {
-                        let testsuites = match top_level_test
-                            .get("subtests")
-                            .and_then(|t| t.get(RESULTS_FIELD_VALUES))
-                            .and_then(|r| r.as_array())
-                        {
-                            Some(val) => val,
-                            None => {
-                                return Ok(testsuites_junit);
-                            }
-                        };
-                        for testsuite in testsuites {
-                            let testsuite_junit = self.junit_testsuite(action, testsuite)?;
-                            testsuites_junit.add_test_suite(testsuite_junit);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(testsuites_junit)
-    }
-
-    pub fn generate_junits(&self) -> anyhow::Result<Vec<Report>> {
-        let mut report_junits: Vec<Report> = Vec::new();
-        if let Some(actions) = self
-            .results_obj
-            .get("actions")
-            .and_then(|a| a.get(RESULTS_FIELD_VALUES))
-            .and_then(|r| r.as_array())
-        {
-            for action in actions {
-                let report_junit = self.junit_report(action)?;
-                // only add the report if it has test suites
-                // xcresult stores build actions
-                if !report_junit.test_suites.is_empty() {
-                    report_junits.push(report_junit);
-                }
-            }
-        }
-        Ok(report_junits)
+        let output = Command::new("xcrun").args(args).output()?;
+        let result = String::from_utf8(output.stdout)?;
+        Ok(result)
     }
 }

--- a/xcresult/tests/data/test-ExpectedFailures.junit.xml
+++ b/xcresult/tests/data/test-ExpectedFailures.junit.xml
@@ -1,136 +1,140 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="xcresult" tests="52" failures="25" errors="0" time="225.926">
-    <testsuite name="AtomicBoyTests.xctest" tests="2" disabled="0" errors="0" failures="1" time="0.288" id="96fc0ef6-d4fc-5ae8-acc8-bfd014e640f2">
-        <testcase name="testExample" classname="AtomicBoyTests" time="0.019" id="f3c6a49d-9fc4-553e-9a6e-ff1173356ef9">
-            <failure/>
+<testsuites name="xcresult: Test Plan" tests="52" failures="25" errors="0">
+    <testsuite name="AtomicBoyTests.AtomicBoyTests" tests="2" disabled="0" errors="0" failures="1">
+        <testcase name="testExample" time="0.019" id="cf65b69e-8979-5704-bbce-946ce00d811d">
+            <failure message="AtomicBoyTests.m:32: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testPerformanceExample" classname="AtomicBoyTests" time="0.266" id="60b936c4-e160-5f02-938f-005b9e710a46">
+        <testcase name="testPerformanceExample" time="0.270" id="e4cab3b6-1796-5572-887b-4222c284c61d">
         </testcase>
     </testsuite>
-    <testsuite name="AtomicBoyUITests.xctest" tests="50" disabled="0" errors="0" failures="24" time="218.000" id="7e4bef0d-3ce5-5d44-b7ad-eed7fa4555a0">
-        <testcase name="testExample" classname="AtomicBoyUITests" time="3.311" id="d783b0f0-6ecd-5a1b-9903-5e925a92b208">
-            <failure/>
+    <testsuite name="AtomicBoyUITests.AtomicBoyUITests" tests="48" disabled="0" errors="0" failures="24">
+        <testcase name="testExample" time="3.000" id="1ed91096-7464-5fc9-965b-60a53eaf2b1b">
+            <failure message="AtomicBoyUITests.m:40: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample10" classname="AtomicBoyUITests" time="4.465" id="fb99da41-c379-53e8-a836-87db18e3a9e1">
+        <testcase name="testExample10" time="4.000" id="e6f37645-ab20-5c02-8b93-6a27ec1d4b98">
         </testcase>
-        <testcase name="testExample11" classname="AtomicBoyUITests" time="4.390" id="3896eff0-c0fd-5b34-ad4f-34b9d4837387">
-            <failure/>
+        <testcase name="testExample11" time="4.000" id="21d35df8-ece1-5b03-83dc-5b879c5b457b">
+            <failure message="AtomicBoyUITests.m:120: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample12" classname="AtomicBoyUITests" time="4.663" id="6ad18147-0e71-570d-b4b8-486cfe62557f">
-            <failure/>
+        <testcase name="testExample12" time="4.000" id="45a803ca-c74e-58e4-9f55-a04565f8eaa4">
+            <failure message="AtomicBoyUITests.m:128: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample13" classname="AtomicBoyUITests" time="4.970" id="9ce8640a-ba66-5cc4-9595-51d8d3161382">
-            <failure/>
+        <testcase name="testExample13" time="4.000" id="7dde653b-23f6-5b7f-ad3e-5be6303b92fb">
+            <failure message="AtomicBoyUITests.m:136: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample14" classname="AtomicBoyUITests" time="4.196" id="2b6484f2-97e0-5d7a-8d84-8627a5200972">
-            <failure/>
+        <testcase name="testExample14" time="4.000" id="2d6c208a-60dd-536f-9d82-9dd394820019">
+            <failure message="AtomicBoyUITests.m:144: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample15" classname="AtomicBoyUITests" time="4.396" id="9e67048d-4288-52f9-9436-28c74fe54a02">
-            <failure/>
+        <testcase name="testExample15" time="4.000" id="80e6d9a1-9a9d-5cce-ace5-d5f96455a0e2">
+            <failure message="AtomicBoyUITests.m:152: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample16" classname="AtomicBoyUITests" time="4.358" id="fd99a621-4b56-5a0c-b71b-2bd007eee9bf">
-            <failure/>
+        <testcase name="testExample16" time="4.000" id="5fc27dee-eae9-519c-9964-d084e15b0db4">
+            <failure message="AtomicBoyUITests.m:160: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample17" classname="AtomicBoyUITests" time="4.671" id="6964be8e-a09c-5da2-b6fc-383322e43d7d">
+        <testcase name="testExample17" time="4.000" id="aad5523c-0e17-5efd-a43c-fe61a9bf3e1c">
         </testcase>
-        <testcase name="testExample18" classname="AtomicBoyUITests" time="4.432" id="2e8c7854-1640-5344-94e1-a7deb802741d">
+        <testcase name="testExample18" time="4.000" id="ccb42790-1deb-5cca-b13f-b85f908e3cb0">
         </testcase>
-        <testcase name="testExample19" classname="AtomicBoyUITests" time="4.634" id="e08852b8-65b1-58b4-bdb2-1301075956b2">
-            <failure/>
+        <testcase name="testExample19" time="4.000" id="c439506a-25a7-5d84-91c4-6507396dd0b4">
+            <failure message="AtomicBoyUITests.m:184: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample2" classname="AtomicBoyUITests" time="4.899" id="5e65f2c2-0c7e-5002-8b96-d1e64c0152ff">
-            <failure/>
+        <testcase name="testExample2" time="4.000" id="b2e15750-d3d9-5b24-a596-9a510ea41ecb">
+            <failure message="AtomicBoyUITests.m:48: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample20" classname="AtomicBoyUITests" time="5.088" id="66012218-9934-5fab-9538-e0d17a992857">
+        <testcase name="testExample20" time="5.000" id="d5f71aee-eec4-5ff3-b0ff-a49f097ae615">
         </testcase>
-        <testcase name="testExample21" classname="AtomicBoyUITests" time="4.507" id="0201ae82-874c-5382-a5f0-e979784ee0f7">
-            <failure/>
+        <testcase name="testExample21" time="4.000" id="5415e1ed-2e6f-5386-b986-6cbdb8a28996">
+            <failure message="AtomicBoyUITests.m:200: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample22" classname="AtomicBoyUITests" time="4.250" id="cc5a84dc-40ec-5d38-892b-75e4b670b696">
-            <failure/>
+        <testcase name="testExample22" time="4.000" id="74dd1827-86de-52c2-91f4-bb98c876acb6">
+            <failure message="AtomicBoyUITests.m:208: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample23" classname="AtomicBoyUITests" time="4.287" id="f591f46d-6e94-5dc3-af05-e2e77a13cb69">
-            <failure/>
+        <testcase name="testExample23" time="4.000" id="a02d9d77-fc91-5d91-857f-5bc9793b252d">
+            <failure message="AtomicBoyUITests.m:216: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample24" classname="AtomicBoyUITests" time="4.515" id="58be5c15-1ad7-515e-840e-2040bc1c2548">
-            <failure/>
+        <testcase name="testExample24" time="4.000" id="70c5547b-e193-52c6-a6e6-9996272e4065">
+            <failure message="AtomicBoyUITests.m:224: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample25" classname="AtomicBoyUITests" time="4.380" id="7cf6ccf9-19aa-5056-a39b-80d36539ecda">
+        <testcase name="testExample25" time="4.000" id="b1c7b5d3-9d7f-5186-89a9-97992679de25">
         </testcase>
-        <testcase name="testExample26" classname="AtomicBoyUITests" time="4.389" id="46fdfeaf-e3ea-5798-b179-c3a4c4017728">
+        <testcase name="testExample26" time="4.000" id="9906b351-9d75-5605-a4df-5eeb3b50ff2e">
         </testcase>
-        <testcase name="testExample27" classname="AtomicBoyUITests" time="4.528" id="c44bd583-6845-5a8e-b3ef-2e0adeee98c1">
-            <failure/>
+        <testcase name="testExample27" time="4.000" id="4059205f-d770-587a-941a-db8d88e6e500">
+            <failure message="AtomicBoyUITests.m:248: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample28" classname="AtomicBoyUITests" time="4.280" id="a0eee77e-99eb-5d5f-b31d-7980556af034">
-            <failure/>
+        <testcase name="testExample28" time="4.000" id="308b74d5-3902-5776-a34d-6e515fbe44c0">
+            <failure message="AtomicBoyUITests.m:256: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample29" classname="AtomicBoyUITests" time="5.109" id="39decc16-5d3a-51b1-8a21-6281e1c9a13c">
-            <failure/>
+        <testcase name="testExample29" time="5.000" id="7df7e805-c934-568a-88b5-0bcb660bd244">
+            <failure message="AtomicBoyUITests.m:264: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample3" classname="AtomicBoyUITests" time="4.605" id="b7dfa4a2-4d6a-5efa-b80b-2e8a5ba7542b">
+        <testcase name="testExample3" time="4.000" id="cb3c8785-f388-5c55-b1df-766e2a70c829">
         </testcase>
-        <testcase name="testExample30" classname="AtomicBoyUITests" time="4.830" id="86a6d280-4c48-5ffa-9bb9-b002946314f7">
-            <failure/>
+        <testcase name="testExample30" time="4.000" id="07b39920-6645-56bc-a377-2b91bc719a41">
+            <failure message="AtomicBoyUITests.m:272: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample31" classname="AtomicBoyUITests" time="4.042" id="9789a1fb-1e74-5705-91ab-82b96038c769">
+        <testcase name="testExample31" time="4.000" id="08f95238-78c4-5345-9202-531c6c54694c">
         </testcase>
-        <testcase name="testExample32" classname="AtomicBoyUITests" time="4.020" id="d593fbc6-6f81-5742-876d-b1357b4c5f16">
+        <testcase name="testExample32" time="4.000" id="4e6c2e6a-6003-5318-9e9d-e9fa74ae603e">
         </testcase>
-        <testcase name="testExample33" classname="AtomicBoyUITests" time="4.043" id="67510001-ae30-5300-9a9c-7c435d77f977">
+        <testcase name="testExample33" time="4.000" id="c9b9a08a-9691-56e6-876b-9b825b29ab4f">
         </testcase>
-        <testcase name="testExample34" classname="AtomicBoyUITests" time="4.046" id="fe2be23d-c239-56d9-81b2-c155c983bc3a">
+        <testcase name="testExample34" time="4.000" id="7513c423-d4a5-5e58-8059-224e35a3ce49">
         </testcase>
-        <testcase name="testExample35" classname="AtomicBoyUITests" time="4.242" id="1deffb9f-4a23-5795-a771-bebbb30c130e">
-            <failure/>
+        <testcase name="testExample35" time="4.000" id="ee13af60-283f-5d82-a0fc-3063cdb85687">
+            <failure message="AtomicBoyUITests.m:312: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample36" classname="AtomicBoyUITests" time="4.155" id="a1b54dc5-7bbd-5463-9579-cd240f626872">
+        <testcase name="testExample36" time="4.000" id="456cb6b2-653a-50ad-8d73-7c9e543785ea">
         </testcase>
-        <testcase name="testExample37" classname="AtomicBoyUITests" time="5.152" id="15372cb0-d79d-5f01-9d35-b434e93c681f">
-            <failure/>
+        <testcase name="testExample37" time="5.000" id="0995b914-2992-53db-847d-e681dfc71904">
+            <failure message="AtomicBoyUITests.m:328: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample38" classname="AtomicBoyUITests" time="4.510" id="b2a0347a-8618-57ad-857a-401059bef837">
-            <failure/>
+        <testcase name="testExample38" time="4.000" id="b3fef145-811f-597e-ad74-bf09ed25901b">
+            <failure message="AtomicBoyUITests.m:336: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample39" classname="AtomicBoyUITests" time="4.334" id="1f7dbb08-9f2d-5cad-883d-d31818823a3f">
+        <testcase name="testExample39" time="4.000" id="d9e969a7-90e0-5d56-8b79-fd7e6fa690aa">
         </testcase>
-        <testcase name="testExample4" classname="AtomicBoyUITests" time="4.353" id="bb2af780-222c-5d2c-8958-76e88e64fbb8">
+        <testcase name="testExample4" time="4.000" id="f576337c-2dc2-5a5c-a8b0-bd82698f43ea">
         </testcase>
-        <testcase name="testExample40" classname="AtomicBoyUITests" time="4.338" id="c30a43e9-0e94-5271-937f-78b6a0ad0bb5">
-            <failure/>
+        <testcase name="testExample40" time="4.000" id="76fa961c-d27b-51e6-a82d-4ce0b9259993">
+            <failure message="AtomicBoyUITests.m:352: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample41" classname="AtomicBoyUITests" time="4.431" id="c58e441b-336d-5633-a150-2e8e44aafdaa">
+        <testcase name="testExample41" time="4.000" id="9a82b32f-9aca-5fb2-a013-342f6f0a6540">
         </testcase>
-        <testcase name="testExample42" classname="AtomicBoyUITests" time="4.823" id="aed472b8-b558-5291-83ea-08c8b2d0f487">
+        <testcase name="testExample42" time="4.000" id="5ad63ef2-ec09-5bd3-a814-acdae1ae6217">
         </testcase>
-        <testcase name="testExample43" classname="AtomicBoyUITests" time="4.258" id="6bf75b33-47b4-5a9a-8467-1c45814fbec8">
+        <testcase name="testExample43" time="4.000" id="fccf15d6-092d-58f4-9b83-c03fec524c51">
         </testcase>
-        <testcase name="testExample44" classname="AtomicBoyUITests" time="4.652" id="5135a656-02a1-56a7-a7b0-62e792938828">
+        <testcase name="testExample44" time="4.000" id="007ef314-f0c2-5a47-9843-c3144d22911b">
         </testcase>
-        <testcase name="testExample45" classname="AtomicBoyUITests" time="4.122" id="45d8885e-f401-5964-b949-ed73cb4e0c77">
+        <testcase name="testExample45" time="4.000" id="b20f6b6e-4420-58d2-b8b2-8709ae89bd4e">
         </testcase>
-        <testcase name="testExample46" classname="AtomicBoyUITests" time="4.313" id="a909baac-3962-5bbe-a1df-622d236fba9c">
+        <testcase name="testExample46" time="4.000" id="702187ab-908f-53c0-a5d5-334a9ed154a0">
         </testcase>
-        <testcase name="testExample47" classname="AtomicBoyUITests" time="4.302" id="0a9a7d35-feef-5447-a983-2d26aadaa71f">
+        <testcase name="testExample47" time="4.000" id="5b8556e2-c1a0-5267-a8eb-a1878db659c0">
         </testcase>
-        <testcase name="testExample48" classname="AtomicBoyUITests" time="5.178" id="2ed094dd-7b01-520f-922a-0d580e515fec">
-            <failure/>
+        <testcase name="testExample48" time="5.000" id="2936851b-506f-5e61-ae38-75c95d6fbfb0">
+            <failure message="AtomicBoyUITests.m:416: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample5" classname="AtomicBoyUITests" time="4.381" id="b4747c60-0af2-5f66-913a-186fa0d3a36d">
-            <failure/>
+        <testcase name="testExample5" time="4.000" id="59ee2c4c-dac7-520d-818d-cb526924e875">
+            <failure message="AtomicBoyUITests.m:72: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample6" classname="AtomicBoyUITests" time="4.420" id="2203f4dc-3f7b-5c0e-a3df-3b821bd2c078">
+        <testcase name="testExample6" time="4.000" id="b5fb0991-0455-555a-ab28-c301ca0bb368">
         </testcase>
-        <testcase name="testExample7" classname="AtomicBoyUITests" time="4.383" id="cbdf63a0-ce3e-588b-ab0f-fff1d71510c7">
+        <testcase name="testExample7" time="4.000" id="4df2735d-b1ba-5ded-a92a-4ce4dd251066">
         </testcase>
-        <testcase name="testExample8" classname="AtomicBoyUITests" time="4.263" id="71c9f4f6-8f13-5cfa-b4c3-2036c58bb0b6">
+        <testcase name="testExample8" time="4.000" id="2d5e4be5-d62a-5b1e-9025-11bfec490d95">
         </testcase>
-        <testcase name="testExample9" classname="AtomicBoyUITests" time="4.616" id="0a0a59ce-9435-5311-a6a9-adf5ae8f3563">
-            <failure/>
+        <testcase name="testExample9" time="4.000" id="9ea05503-0481-58f4-a0fa-caf9ecb7d141">
+            <failure message="AtomicBoyUITests.m:104: ((false) is true) failed"/>
         </testcase>
-        <testcase name="testExample()" classname="CobaltDog" time="4.388" id="bfc3435b-d86d-5a31-83e6-8122341befcc">
+    </testsuite>
+    <testsuite name="AtomicBoyUITests.CobaltDog" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testExample()" time="4.000" id="0593cddd-7dbb-5790-ab89-2f24f71914d6">
         </testcase>
-        <testcase name="testExample()" classname="SwiftAtomicBoyUITests" time="0.017" id="0475623c-64a2-5805-b3ec-f1cbdc675753">
+    </testsuite>
+    <testsuite name="AtomicBoyUITests.SwiftAtomicBoyUITests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testExample()" time="0.017" id="d60d11f7-2673-59ce-8ac7-2a0b3ab21f22">
         </testcase>
     </testsuite>
 </testsuites>

--- a/xcresult/tests/data/test1.junit.xml
+++ b/xcresult/tests/data/test1.junit.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="xcresult" tests="17" failures="0" errors="0" time="20.664">
-    <testsuite name="XcresultparserTests.xctest" tests="17" disabled="0" errors="0" failures="0" time="11.490" id="808a5981-6ebf-5882-a048-5e06b4318cee">
-        <testcase name="testCleanCodeErrors()" classname="XcresultparserTests" time="0.959" id="99d37723-0bfe-5158-a239-3f887805070d">
+<testsuites name="xcresult: Xcresultparser-Package" tests="17" failures="0" errors="0">
+    <testsuite name="XcresultparserTests.XcresultparserTests" tests="17" disabled="0" errors="0" failures="0">
+        <testcase name="testCleanCodeErrors()" time="0.960" id="eb1cb33b-a7ed-5c4c-98c0-31014be4c0cd">
         </testcase>
-        <testcase name="testCleanCodeWarnings()" classname="XcresultparserTests" time="0.174" id="6240defe-8527-5be7-9b44-1a997021aee5">
+        <testcase name="testCleanCodeWarnings()" time="0.170" id="f851e19c-ea03-51c9-8723-f3be81ee8f32">
         </testcase>
-        <testcase name="testCleanCodeWarningsWithRelativePath()" classname="XcresultparserTests" time="0.174" id="bc4a0bc2-ad67-5864-b95c-afcb6fecbab6">
+        <testcase name="testCleanCodeWarningsWithRelativePath()" time="0.170" id="3dca4681-19f9-5ac3-981f-42948aa703fa">
         </testcase>
-        <testcase name="testCLIResultFormatter()" classname="XcresultparserTests" time="1.143" id="22a30abb-dc6c-50d2-9142-12545c323691">
+        <testcase name="testCLIResultFormatter()" time="1.000" id="cd8ad5ab-603a-548d-928d-add3dbee8218">
         </testcase>
-        <testcase name="testCoberturaConverter()" classname="XcresultparserTests" time="1.038" id="188d55ef-cc47-55f2-ae51-48886935d5b5">
+        <testcase name="testCoberturaConverter()" time="1.000" id="ca5c2c9f-dfff-57d7-8c9a-cddba49f2f41">
         </testcase>
-        <testcase name="testCoverageConverter()" classname="XcresultparserTests" time="1.847" id="27bf164f-a983-5b0a-8adc-6ceadd9d023c">
+        <testcase name="testCoverageConverter()" time="1.000" id="f9799e48-0cf5-5f31-9399-a33706812d8c">
         </testcase>
-        <testcase name="testCoverageReportFormat()" classname="XcresultparserTests" time="0.000" id="660c6298-8214-5171-80d7-ef5dc7413ebe">
+        <testcase name="testCoverageReportFormat()" time="0.000" id="06312727-a484-534b-861c-b73240786b73">
         </testcase>
-        <testcase name="testHTMLResultFormatter()" classname="XcresultparserTests" time="0.772" id="0fc3913e-fb6a-57b6-8d38-85b40604d746">
+        <testcase name="testHTMLResultFormatter()" time="0.770" id="485fe8cc-de85-555a-9392-d710a6aadeaa">
         </testcase>
-        <testcase name="testJunitXMLJunit()" classname="XcresultparserTests" time="0.354" id="de8f386c-187d-5c15-813c-c7fe3386f0ef">
+        <testcase name="testJunitXMLJunit()" time="0.350" id="8b9e92e3-b27d-5bb6-9aa6-fb58fb563a9a">
         </testcase>
-        <testcase name="testJunitXMLMergedJunit()" classname="XcresultparserTests" time="0.552" id="94a44223-fec5-5ab8-a198-2e8cefb2b316">
+        <testcase name="testJunitXMLMergedJunit()" time="0.550" id="0b4ce049-f007-5672-aa5d-7f6e08e7b026">
         </testcase>
-        <testcase name="testJunitXMLSonar()" classname="XcresultparserTests" time="0.357" id="2c845bb4-3318-53d0-b466-64ae8d7f7341">
+        <testcase name="testJunitXMLSonar()" time="0.360" id="d9fe854f-630f-5ca4-bdc1-da83b141dbde">
         </testcase>
-        <testcase name="testMDResultFormatter()" classname="XcresultparserTests" time="0.780" id="1e4787cb-5867-5c4b-af16-39f1a45437c6">
+        <testcase name="testMDResultFormatter()" time="0.780" id="06ea66f0-2e46-59c2-a267-5581a2acee72">
         </testcase>
-        <testcase name="testOutputFormat()" classname="XcresultparserTests" time="0.001" id="af80a48e-e736-5bd9-a407-80fb2941386d">
+        <testcase name="testOutputFormat()" time="0.001" id="8127bee2-5d8b-5fa2-8dd4-0dacf661fb96">
         </testcase>
-        <testcase name="testSonarCoverageConverter()" classname="XcresultparserTests" time="1.033" id="ef079c03-82d5-5660-bff1-8113fedb8923">
+        <testcase name="testSonarCoverageConverter()" time="1.000" id="530755c5-5fe5-53a9-86c1-7c3c20780542">
         </testcase>
-        <testcase name="testTextResultFormatter()" classname="XcresultparserTests" time="0.757" id="c0fb8dfb-ccf6-5a61-9e98-7025dd85f38f">
+        <testcase name="testTextResultFormatter()" time="0.760" id="29fc3567-5f0b-53d7-a980-6dd4afc0462e">
         </testcase>
-        <testcase name="testTextResultFormatterMethodsCoverageReportFormat()" classname="XcresultparserTests" time="0.767" id="4a07ce52-f330-5fb0-9fc7-79a703d2a401">
+        <testcase name="testTextResultFormatterMethodsCoverageReportFormat()" time="0.770" id="2b201b3b-97b3-5708-a8ea-0c4fda47eab2">
         </testcase>
-        <testcase name="testTextResultFormatterTotalCoverageReportFormat()" classname="XcresultparserTests" time="0.782" id="e03854b6-5621-57c4-943d-41cf3dc1ba4e">
+        <testcase name="testTextResultFormatterTotalCoverageReportFormat()" time="0.780" id="f803694d-000e-5a06-9333-ae9d44750782">
         </testcase>
     </testsuite>
 </testsuites>

--- a/xcresult/tests/data/test4.junit.xml
+++ b/xcresult/tests/data/test4.junit.xml
@@ -1,919 +1,1115 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="xcresult" tests="452" failures="1" errors="0" time="35.619">
-    <testsuite name="CoreDataInfrastructure-Unit-CoreDataInfrastructureTests.xctest" tests="6" disabled="0" errors="0" failures="0" time="0.028" id="b545f11f-58a0-5ed6-b007-88095123dd1b">
-        <testcase name="testSaveUser()" classname="CDUserStoreTests" time="0.009" id="dcd5f355-e027-5776-a728-607c05bb0dbe">
-        </testcase>
-        <testcase name="testSaveMovieSearch()" classname="CDMovieSearchStoreTests" time="0.001" id="aab1aa42-8b03-5e13-88b7-1891a30c9fb3">
-        </testcase>
-        <testcase name="testSaveMovieVisitError()" classname="CDMovieVisitStoreTests" time="0.001" id="b0b3b64d-719e-50aa-9a25-ebe1067aa9b8">
-        </testcase>
-        <testcase name="testSaveMovieVisitSuccess()" classname="CDMovieVisitStoreTests" time="0.001" id="c4ebf66f-5c5f-5066-8c56-3621d237c502">
-        </testcase>
-        <testcase name="testFindAllGenres()" classname="CDGenreStoreTests" time="0.016" id="b7404b44-a5ae-572d-b1a6-db963cbaea65">
-        </testcase>
-        <testcase name="testSaveGenre()" classname="CDGenreStoreTests" time="0.001" id="d916163a-2a9a-5261-b5a5-30c9238e9f1c">
+<testsuites name="xcresult: UpcomingMovies" tests="452" failures="1" errors="0">
+    <testsuite name="CoreDataInfrastructure-Unit-CoreDataInfrastructureTests.CDUserStoreTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testSaveUser()" time="0.009" id="3b5195fd-9352-5ade-bd71-4a0c0be6eed6">
         </testcase>
     </testsuite>
-    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.xctest" tests="151" disabled="0" errors="0" failures="0" time="0.153" id="338305d0-84c1-5cea-8cde-b12d16556695">
-        <testcase name="testStatusMessageFromResponse()" classname="MarkAsFavoriteTests" time="0.005" id="c6e60272-851b-58c5-b3d8-5e5de4802f26">
-        </testcase>
-        <testcase name="testMissingStatusCodeFromResponse()" classname="MarkAsFavoriteTests" time="0.001" id="56b02c77-2543-5930-831e-137769343433">
-        </testcase>
-        <testcase name="testStatusCodeFromResponse()" classname="MarkAsFavoriteTests" time="0.000" id="f814fc7d-fd25-59e3-872a-d7af2a592e3a">
-        </testcase>
-        <testcase name="testMissingStatusMessageFromResponse()" classname="MarkAsFavoriteTests" time="0.000" id="34457d7b-f397-5d9a-a621-73a71ae6d073">
-        </testcase>
-        <testcase name="testMissingIdFromCastResponse()" classname="MovieCreditsTests" time="0.002" id="8b6e101d-3a39-5f6d-b478-1fa1d08a4158">
-        </testcase>
-        <testcase name="testMissingCharacterFromCastResponse()" classname="MovieCreditsTests" time="0.002" id="a9405ea4-2718-5335-aaa8-2857f34e0599">
-        </testcase>
-        <testcase name="testMissingNameFromCrewResponse()" classname="MovieCreditsTests" time="0.001" id="c70f0d98-e74c-53d1-af68-f5bfdbc72c7f">
-        </testcase>
-        <testcase name="testIdFromCrewResponse()" classname="MovieCreditsTests" time="0.000" id="498133d4-e31c-5cb1-922b-9d9fb96fa00c">
-        </testcase>
-        <testcase name="testJobFromCrewResponse()" classname="MovieCreditsTests" time="0.000" id="51f2754b-aaf1-5891-9117-56b826c0fdc0">
-        </testcase>
-        <testcase name="testNameFromCastResponse()" classname="MovieCreditsTests" time="0.000" id="e6fd823e-d849-5450-a9d3-2bcd491b18cf">
-        </testcase>
-        <testcase name="testMissingJobFromCrewResponse()" classname="MovieCreditsTests" time="0.001" id="b053a041-0722-576a-874a-caf38b849050">
-        </testcase>
-        <testcase name="testMissingIdFromCrewResponse()" classname="MovieCreditsTests" time="0.000" id="4fc2fd81-9bb4-5eb4-bd4b-f628ca6cde41">
-        </testcase>
-        <testcase name="testMissingNameFromCastResponse()" classname="MovieCreditsTests" time="0.000" id="b1ff9de3-e70c-53ff-9940-9829e1314dd9">
-        </testcase>
-        <testcase name="testIdFromCastResponse()" classname="MovieCreditsTests" time="0.000" id="1accb97c-d8b4-5f3a-8016-e79f82b05c89">
-        </testcase>
-        <testcase name="testCharacterFromCastResponse()" classname="MovieCreditsTests" time="0.000" id="dd9b6664-6f31-52c9-aefb-493ec432cff6">
-        </testcase>
-        <testcase name="testNameFromCrewResponse()" classname="MovieCreditsTests" time="0.000" id="ea84339d-c567-5b0d-a1c4-8ceb68f352ec">
-        </testcase>
-        <testcase name="testURLRequestSetJsonContentTypeNil()" classname="URLGenerationTests" time="0.001" id="f474fc15-ad9f-5590-95ea-fffc4a2cd22a">
-        </testcase>
-        <testcase name="testPercentEscapedEmptyParamters()" classname="URLGenerationTests" time="0.001" id="eaebf9df-f1a6-5f57-b630-2aa6af5d94a8">
-        </testcase>
-        <testcase name="testURLRequestSetJsonContentType()" classname="URLGenerationTests" time="0.001" id="1621f824-d779-527d-a135-02d9369a63e4">
-        </testcase>
-        <testcase name="testPercentEscapedSingleParameters()" classname="URLGenerationTests" time="0.001" id="be64e3d9-5389-5648-b82f-84475d16b011">
-        </testcase>
-        <testcase name="testPercentEscapedMultipleParameters()" classname="URLGenerationTests" time="0.000" id="defb07a3-5dbb-5728-82a6-d4e5f509954c">
-        </testcase>
-        <testcase name="testBaseURLStringFromResponse()" classname="MovieImagesConfigurationTests" time="0.002" id="b5adc832-a9d4-5aa1-ba83-9a585518f82f">
-        </testcase>
-        <testcase name="testMissingBaseURLStringFromResponse()" classname="MovieImagesConfigurationTests" time="0.000" id="987e3dd1-07a3-5670-9734-e884491fb1fb">
-        </testcase>
-        <testcase name="testMissingBackdropSizesFromResponse()" classname="MovieImagesConfigurationTests" time="0.000" id="cef95711-91d4-58ab-ae7f-ff26a1ee74c5">
-        </testcase>
-        <testcase name="testMissingPosterSizesFromResponse()" classname="MovieImagesConfigurationTests" time="0.000" id="d30ab3d0-ff5e-52f5-acc3-64f877b012ee">
-        </testcase>
-        <testcase name="testSiteFromResponse()" classname="VideosTests" time="0.001" id="9deb3f68-54b8-50dd-b113-c276063b4cce">
-        </testcase>
-        <testcase name="testKeyFromResponse()" classname="VideosTests" time="0.000" id="a2ef082d-d88a-590d-a311-003e75d229f8">
-        </testcase>
-        <testcase name="testIdFromResponse()" classname="VideosTests" time="0.000" id="0d0c1d33-dab6-57cc-a5e4-356cf2b2844d">
-        </testcase>
-        <testcase name="testNameFromResponse()" classname="VideosTests" time="0.002" id="b38284e1-44da-562a-8b07-182c744716b9">
-        </testcase>
-        <testcase name="testMissingIdFromResponse()" classname="VideosTests" time="0.000" id="1a033f3c-8e09-5b88-8f67-b65a1e7017bd">
-        </testcase>
-        <testcase name="testMissingKeyFromResponse()" classname="VideosTests" time="0.000" id="a494e17c-ab58-597f-b08b-56d8f24cc4bb">
-        </testcase>
-        <testcase name="testMissingSiteFromResponse()" classname="VideosTests" time="0.000" id="3f86bd62-9add-5f9f-b943-fed56b4f3a3a">
-        </testcase>
-        <testcase name="testMissingNameFromResponse()" classname="VideosTests" time="0.000" id="72605748-89d0-5736-bf88-78e106ef5b9b">
-        </testcase>
-        <testcase name="testContentFromResponse()" classname="MovieReviewTests" time="0.001" id="11b5bb53-936f-536b-8b62-5547333dec5a">
-        </testcase>
-        <testcase name="testMissingAuthorFromResponse()" classname="MovieReviewTests" time="0.001" id="68ef0684-b4f8-5df2-99cb-ce0ba30d2ed6">
-        </testcase>
-        <testcase name="testMissingContentFromResponse()" classname="MovieReviewTests" time="0.001" id="5b054a0e-0e9c-5e96-8cbf-c4179b89cf07">
-        </testcase>
-        <testcase name="testIdFromResponse()" classname="MovieReviewTests" time="0.004" id="aa77f8b8-7dcc-5e12-a3af-dabbdc4b55bf">
-        </testcase>
-        <testcase name="testAuthorFromResponse()" classname="MovieReviewTests" time="0.000" id="07518b36-74a0-534a-ab2b-4d1c83a5110b">
-        </testcase>
-        <testcase name="testMissingIdFromResponse()" classname="MovieReviewTests" time="0.001" id="c6cf89d4-7d0b-52df-97ff-2dc07d09a202">
-        </testcase>
-        <testcase name="testMissingSuccessFromResponse()" classname="RequestTokenTests" time="0.002" id="e6246498-3437-5db3-b92e-c8fc50d19e14">
-        </testcase>
-        <testcase name="testTokenFromResponse()" classname="RequestTokenTests" time="0.000" id="9938843e-4867-5c98-ae48-c2fad160d317">
-        </testcase>
-        <testcase name="testSuccessFromResponse()" classname="RequestTokenTests" time="0.001" id="7f96daa6-a5d5-5698-8dea-0552395ff36e">
-        </testcase>
-        <testcase name="testMissingTokenFromDResponse()" classname="RequestTokenTests" time="0.000" id="f9931b34-a85c-528b-b0c5-54ccf07c9346">
-        </testcase>
-        <testcase name="testStatusCodeFromResponse()" classname="RateMovieTests" time="0.001" id="77f81560-a39a-5e62-bf1d-9a60f9f1da93">
-        </testcase>
-        <testcase name="testMissingStatusMessageFromResponse()" classname="RateMovieTests" time="0.001" id="03ef663b-39a0-5bf2-88cc-c35670d6bfa8">
-        </testcase>
-        <testcase name="testStatusMessageFromResponse()" classname="RateMovieTests" time="0.000" id="62a2916e-b33b-56ae-8140-64fdbfec4793">
-        </testcase>
-        <testcase name="testMissingStatusCodeFromResponse()" classname="RateMovieTests" time="0.000" id="08bc8fd4-70f3-5514-904f-c334d716445b">
-        </testcase>
-        <testcase name="testCreateSessionIdError()" classname="AuthClientTests" time="0.004" id="c820dfbd-5033-5302-887c-8583d12b58ee">
-        </testcase>
-        <testcase name="testGetRequestTokenSuccess()" classname="AuthClientTests" time="0.001" id="cfeae5e5-7f56-5913-acd2-33e0ccdf069f">
-        </testcase>
-        <testcase name="testCreateSessionIdSuccess()" classname="AuthClientTests" time="0.001" id="77fe82ee-9af5-5e1e-9c78-9c1b9bbabb6d">
-        </testcase>
-        <testcase name="testGetAccessTokenError()" classname="AuthClientTests" time="0.001" id="247826b4-b692-5a35-83b2-19c9f12847c2">
-        </testcase>
-        <testcase name="testGetRequestTokenError()" classname="AuthClientTests" time="0.001" id="a352850e-0f49-5d4a-93f3-4c1e3a191eca">
-        </testcase>
-        <testcase name="testGetAccessTokenSuccess()" classname="AuthClientTests" time="0.001" id="aab57119-26aa-5416-8b07-6d47bacb71a5">
-        </testcase>
-        <testcase name="testGetPopularMoviesSuccess()" classname="MovieClientTests" time="0.003" id="11146056-5b24-5f94-b249-31aa74325be5">
-        </testcase>
-        <testcase name="testGetMovieReviewsSuccess()" classname="MovieClientTests" time="0.001" id="b9b00b44-cbc0-5ed1-8361-2d3653767063">
-        </testcase>
-        <testcase name="testGetMovieVideosSuccess()" classname="MovieClientTests" time="0.001" id="24e322f0-e62a-5e68-9794-dc663ad07e43">
-        </testcase>
-        <testcase name="testGetSimilarMoviesError()" classname="MovieClientTests" time="0.000" id="702b83e9-2196-538d-a087-00ef4c256215">
-        </testcase>
-        <testcase name="testGetMovieCreditsError()" classname="MovieClientTests" time="0.000" id="839fdde9-659b-51c2-88aa-0e524cc17ee3">
-        </testcase>
-        <testcase name="testGetSimilarMoviesSuccess()" classname="MovieClientTests" time="0.002" id="4f7e822f-c3a3-5907-b4fa-d11ffa8cd1cd">
-        </testcase>
-        <testcase name="testGetUpcomingMoviesError()" classname="MovieClientTests" time="0.001" id="7cf62e39-6cc5-5454-a065-8e3ade1afa91">
-        </testcase>
-        <testcase name="testRateMovieError()" classname="MovieClientTests" time="0.001" id="6c489de7-4534-52ef-9e0a-e2d90606601d">
-        </testcase>
-        <testcase name="testGetMoviesByGenreSuccess()" classname="MovieClientTests" time="0.001" id="c2b643b3-1214-560a-a7bf-af7d36d4238b">
-        </testcase>
-        <testcase name="testGetMovieReviewsError()" classname="MovieClientTests" time="0.001" id="88a3fc82-c38b-5638-8f9d-650f8d46bb2e">
-        </testcase>
-        <testcase name="testGetUpcomingMoviesSuccess()" classname="MovieClientTests" time="0.001" id="ef9c4a5c-8343-5905-9c72-61ae7dbb2d36">
-        </testcase>
-        <testcase name="testGetMovieAccountStateSuccess()" classname="MovieClientTests" time="0.002" id="df6b3dcc-ea9d-5b17-beb1-7bd81943f2e9">
-        </testcase>
-        <testcase name="testGetMovieDetailSuccess()" classname="MovieClientTests" time="0.002" id="bc2d2d38-e7ad-52aa-b9e3-8ccf19965d92">
-        </testcase>
-        <testcase name="testGetMovieCreditsSuccess()" classname="MovieClientTests" time="0.005" id="7585f2d5-ef73-54b9-9000-a37985ad789c">
-        </testcase>
-        <testcase name="testGetMovieVideosError()" classname="MovieClientTests" time="0.001" id="d5ff7ad8-aa33-52fa-af78-3fccd8b03698">
-        </testcase>
-        <testcase name="testGetMoviesByGenreError()" classname="MovieClientTests" time="0.001" id="2161d923-5554-506d-a14d-caf2d9b2996b">
-        </testcase>
-        <testcase name="testGetMovieAccountStateError()" classname="MovieClientTests" time="0.001" id="485a4f3e-b26d-57ae-aad2-c98a92de4480">
-        </testcase>
-        <testcase name="testGetPopularMoviesError()" classname="MovieClientTests" time="0.002" id="edc0d37a-85fa-5dd3-b08e-5b13ab144b99">
-        </testcase>
-        <testcase name="testGetMovieDetailError()" classname="MovieClientTests" time="0.001" id="8aafde02-2c1e-53cb-b0a0-f1667edb8a9d">
-        </testcase>
-        <testcase name="testGetTopRatedMoviesSuccess()" classname="MovieClientTests" time="0.001" id="eda06602-128f-565a-b168-dc01d24d2916">
-        </testcase>
-        <testcase name="testSearchMoviesError()" classname="MovieClientTests" time="0.002" id="19ae6cc7-5e61-58c9-8e6c-73ff61edc7b3">
-        </testcase>
-        <testcase name="testGetTopRatedMoviesError()" classname="MovieClientTests" time="0.004" id="ed2a2319-159f-5197-b3be-3ac3d69614ea">
-        </testcase>
-        <testcase name="testRateMovieSuccess()" classname="MovieClientTests" time="0.001" id="b5c6c7d4-7faa-525c-b383-17559a871717">
-        </testcase>
-        <testcase name="testSearchMoviesSuccess()" classname="MovieClientTests" time="0.002" id="9590b1e4-e135-5b04-af1d-8822d79403e6">
-        </testcase>
-        <testcase name="testCurrentUserId()" classname="AuthRemoteDataSourceTests" time="0.001" id="9513bfa7-ee47-5005-9d6d-4035535d6dd7">
-        </testcase>
-        <testcase name="testGetAuthURLFailure()" classname="AuthRemoteDataSourceTests" time="0.001" id="1fc24ba0-1169-5709-9a77-b9bd6ab683f0">
-        </testcase>
-        <testcase name="testSignInUserFailureInGetAccountDetails()" classname="AuthRemoteDataSourceTests" time="0.004" id="4e974d43-dfd5-5dcb-bf0f-dd63e84d2abd">
-        </testcase>
-        <testcase name="testSignInUserFailureInGetAccessToken()" classname="AuthRemoteDataSourceTests" time="0.001" id="a8a93623-ba8a-5527-85df-64ae2c6f1185">
-        </testcase>
-        <testcase name="testSignOutUser()" classname="AuthRemoteDataSourceTests" time="0.001" id="c39853b6-fdd4-5789-ad07-c51ed2dfae59">
-        </testcase>
-        <testcase name="testSignInUserFailureInCreateSessionId()" classname="AuthRemoteDataSourceTests" time="0.001" id="37d06844-528a-5531-95ff-386ca553d115">
-        </testcase>
-        <testcase name="testSignInUserSuccess()" classname="AuthRemoteDataSourceTests" time="0.001" id="940ba766-82bd-554a-ba46-d8aa3a7ae29b">
-        </testcase>
-        <testcase name="testGetAuthURLSuccess()" classname="AuthRemoteDataSourceTests" time="0.001" id="20959c4a-941f-52a9-86b1-0375fea1df4d">
-        </testcase>
-        <testcase name="testMovieResultNextPage()" classname="MovieResultPaginationTests" time="0.001" id="73026b31-212b-5d0d-8535-bb3f4a6e5a84">
-        </testcase>
-        <testcase name="testMovieResultHasMorePagesFalse()" classname="MovieResultPaginationTests" time="0.001" id="42d1c5ec-ac75-558c-942b-7e9a5a62f8d5">
-        </testcase>
-        <testcase name="testMovieResultHasMorePagesTrue()" classname="MovieResultPaginationTests" time="0.000" id="af9539dd-237d-5862-8b66-66c5569ff224">
-        </testcase>
-        <testcase name="testIdFromResponse()" classname="MovieGenreTests" time="0.001" id="57044db7-6b1b-5059-a23a-6da8e545ae60">
-        </testcase>
-        <testcase name="testNameFromResponse()" classname="MovieGenreTests" time="0.001" id="ef0956a8-cabb-5110-bfd6-d200ddd8af9e">
-        </testcase>
-        <testcase name="testMissingIdFromResponse()" classname="MovieGenreTests" time="0.000" id="05f0dc31-4d4d-5a69-af7d-c37e9105a640">
-        </testcase>
-        <testcase name="testMissingNameFromResponse()" classname="MovieGenreTests" time="0.000" id="58dd5eb9-ed3f-50ea-97a5-2a6f36a0157a">
-        </testcase>
-        <testcase name="testGetCustomListMoviesSuccess()" classname="AccountRemoteDataSourceTests" time="0.002" id="0c310c44-c89c-5d13-b8b7-cc223df8c773">
-        </testcase>
-        <testcase name="testGetCustomListMoviesNilAccessToken()" classname="AccountRemoteDataSourceTests" time="0.001" id="5eb1815d-42e0-5a70-ac78-bc6f854afc71">
-        </testcase>
-        <testcase name="testGetRecommendedListSuccess()" classname="AccountRemoteDataSourceTests" time="0.001" id="d4a989ea-833d-55d4-a812-797cf8d2331e">
-        </testcase>
-        <testcase name="testGetFavoriteListNilUserAccount()" classname="AccountRemoteDataSourceTests" time="0.001" id="5d8f7de2-37f0-5d59-90c6-85598405a0bc">
-        </testcase>
-        <testcase name="testAddToWatchlistNilUserAccount()" classname="AccountRemoteDataSourceTests" time="0.001" id="49e06e7a-3a00-5a14-9042-ffdfe5bbf5bc">
-        </testcase>
-        <testcase name="testGetRecommendedListFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="c892a74a-ceaf-5f66-a2dd-4ad81a5c3fe2">
-        </testcase>
-        <testcase name="testGetFavoriteListFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="a4f1c6ed-272c-597b-a837-354b8f0cde4c">
-        </testcase>
-        <testcase name="testAddToWatchlistFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="e5e5640d-8646-56e9-89d1-084f227e4a8c">
-        </testcase>
-        <testcase name="testGetFavoriteListSuccess()" classname="AccountRemoteDataSourceTests" time="0.001" id="cbed16bd-b77b-5d3d-94c7-d5393081b22d">
-        </testcase>
-        <testcase name="testGetAccountDetailNilUserAccount()" classname="AccountRemoteDataSourceTests" time="0.000" id="aa0cdbdc-594b-5c08-b0e1-780f8e7dd6f7">
-        </testcase>
-        <testcase name="testMarkMovieAsFavoriteNilUserAccount()" classname="AccountRemoteDataSourceTests" time="0.000" id="cf0cd0fa-97b9-5362-b6a1-ee61798c01e4">
-        </testcase>
-        <testcase name="testGetCustomListMoviesNilListResult()" classname="AccountRemoteDataSourceTests" time="0.000" id="9af0c915-77c6-507e-a118-82c28bc10256">
-        </testcase>
-        <testcase name="testMarkMovieAsFavoriteSuccess()" classname="AccountRemoteDataSourceTests" time="0.001" id="387d5bd0-d744-57de-9fa2-e3d5a00bada7">
-        </testcase>
-        <testcase name="testGetAccountDetailSuccess()" classname="AccountRemoteDataSourceTests" time="0.000" id="4f205dcb-25c4-560a-aa8f-31bb661031d6">
-        </testcase>
-        <testcase name="testGetCustomListsSuccess()" classname="AccountRemoteDataSourceTests" time="0.001" id="011c1b77-5f30-58bc-8705-996ec69eb658">
-        </testcase>
-        <testcase name="testGetCustomListMoviesFailure()" classname="AccountRemoteDataSourceTests" time="0.004" id="131375b2-8b54-5a2b-b6ba-e657b58906ab">
-        </testcase>
-        <testcase name="testGetAccountDetailFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="f9b83d93-6751-59c1-bf22-55965f1722e5">
-        </testcase>
-        <testcase name="testGetWatchlistFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="ef3272bb-afbc-5b18-b84b-1b733edf56c9">
-        </testcase>
-        <testcase name="testMarkMovieAsFavoriteFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="c5d755da-428b-5fdf-8280-4b0246edf825">
-        </testcase>
-        <testcase name="testGetWatchlistNilUserAccount()" classname="AccountRemoteDataSourceTests" time="0.000" id="5f281e03-b291-50fd-bc78-1a6b61934916">
-        </testcase>
-        <testcase name="testAddToWatchlistSuccess()" classname="AccountRemoteDataSourceTests" time="0.000" id="6204388e-d826-5640-ae93-979e85bacc0a">
-        </testcase>
-        <testcase name="testGetCustomListFailure()" classname="AccountRemoteDataSourceTests" time="0.001" id="9e82147b-c0f1-5a59-b482-37d7976367d3">
-        </testcase>
-        <testcase name="testGetRecommendedListNilAccountIdAndToken()" classname="AccountRemoteDataSourceTests" time="0.000" id="492f3211-56cd-5601-8fd8-58ff7c53d617">
-        </testcase>
-        <testcase name="testGetCustomListNilAccountIdAndToken()" classname="AccountRemoteDataSourceTests" time="0.001" id="3cfdad98-008f-577d-af4e-d62a34d50515">
-        </testcase>
-        <testcase name="testGetCustomListNilListResult()" classname="AccountRemoteDataSourceTests" time="0.000" id="e74824c3-1cdc-51a5-9799-a77a45bdbe26">
-        </testcase>
-        <testcase name="testGetWatchlistSuccess()" classname="AccountRemoteDataSourceTests" time="0.001" id="f536dd44-1bc6-579a-b622-bdf0511cc312">
-        </testcase>
-        <testcase name="testGetRecommendedListNilListResult()" classname="AccountRemoteDataSourceTests" time="0.003" id="487dc9ef-854d-5cf5-b125-13ed722a897b">
-        </testcase>
-        <testcase name="testMissingSessionIdFromDResponse()" classname="SessionTests" time="0.000" id="b527e659-a784-5285-8478-718af3cae8de">
-        </testcase>
-        <testcase name="testMissingSuccessFromResponse()" classname="SessionTests" time="0.001" id="eb4cec91-c3b6-5978-ab63-b5e3cc51bf5f">
-        </testcase>
-        <testcase name="testSuccessFromResponse()" classname="SessionTests" time="0.000" id="23554e4d-a8fb-5bf1-a44d-773e5d8e9787">
-        </testcase>
-        <testcase name="testSessionIdFromResponse()" classname="SessionTests" time="0.001" id="48fa912a-4ed5-53a6-82c5-1994a6400a73">
-        </testcase>
-        <testcase name="testWatchlistSortTypeCallAsFunctionCreatedAtDesc()" classname="MovieSortTypeTests" time="0.001" id="d8196834-3bce-5ee5-9ffc-08ec619e92b9">
-        </testcase>
-        <testcase name="testWatchlistSortTypeCallAsFunctionCreatedAtAsc()" classname="MovieSortTypeTests" time="0.001" id="d994d02a-0f46-56cc-8116-626ce0410049">
-        </testcase>
-        <testcase name="testFavoriteSortTypeCallAsFunctionCreatedAtDesc()" classname="MovieSortTypeTests" time="0.001" id="a73c005b-53c1-57b8-8414-bd68691178b7">
-        </testcase>
-        <testcase name="testFavoriteSortTypeCallAsFunctionCreatedAtAsc()" classname="MovieSortTypeTests" time="0.000" id="2cd55943-5691-5318-9223-b9b9191e7b00">
-        </testcase>
-        <testcase name="testMissingStatusMessageFromResponse()" classname="AddToWatchlistTests" time="0.001" id="ba57e39c-4d4c-5026-a714-ebd247c07e96">
-        </testcase>
-        <testcase name="testStatusCodeFromResponse()" classname="AddToWatchlistTests" time="0.000" id="56a7b217-1f36-552d-bbd4-4683ccdc1cfe">
-        </testcase>
-        <testcase name="testStatusMessageFromResponse()" classname="AddToWatchlistTests" time="0.000" id="1d8e68f1-77d0-55e2-9fd0-9113aeb5f84a">
-        </testcase>
-        <testcase name="testMissingStatusCodeFromResponse()" classname="AddToWatchlistTests" time="0.000" id="6e1ccee4-592d-5ae8-ae94-4dde1771a57a">
-        </testcase>
-        <testcase name="testMissingAccounIdFromResponse()" classname="AccessTokenTests" time="0.000" id="c5ad0a28-968f-5e82-b3a7-35ccdb9b5e50">
-        </testcase>
-        <testcase name="testMissingTokenFromResponse()" classname="AccessTokenTests" time="0.001" id="b1702c3b-ed4e-50a1-99dd-1ad1ea9e1bf6">
-        </testcase>
-        <testcase name="testAccounIdFromResponse()" classname="AccessTokenTests" time="0.001" id="f18d75fd-2b2b-53d4-8935-2f03a927bb0c">
-        </testcase>
-        <testcase name="testTokenFromResponse()" classname="AccessTokenTests" time="0.000" id="2d545b14-ecc1-5ebc-afce-464fe05eb771">
-        </testcase>
-        <testcase name="testGetWatchlistError()" classname="AccountClientTests" time="0.001" id="0160e8b4-6293-512b-8e24-93a76b640dfc">
-        </testcase>
-        <testcase name="testGetWatchlistSuccess()" classname="AccountClientTests" time="0.001" id="2dacca8f-c181-5d8a-9325-00bf9791eeb6">
-        </testcase>
-        <testcase name="testGetCustomListMoviesError()" classname="AccountClientTests" time="0.005" id="0885d727-388b-5bfc-a433-5531ff6707d2">
-        </testcase>
-        <testcase name="testGetCustomListMoviesSuccess()" classname="AccountClientTests" time="0.001" id="faaca6c8-c0ea-59e2-a232-543c0b817749">
-        </testcase>
-        <testcase name="testGetCustomListsError()" classname="AccountClientTests" time="0.001" id="e18b3bee-3689-5a42-b72b-0d00feee50fb">
-        </testcase>
-        <testcase name="testAddToWatchlistError()" classname="AccountClientTests" time="0.001" id="3ea1f771-88af-52ab-96c8-5200006f12ca">
-        </testcase>
-        <testcase name="testGetCustomListsSuccess()" classname="AccountClientTests" time="0.004" id="cf84391f-2782-508b-a3b4-33459ecb4128">
-        </testcase>
-        <testcase name="testMarkAsFavoriteError()" classname="AccountClientTests" time="0.001" id="864c4119-c27c-5961-a4b6-458d7e764f7b">
-        </testcase>
-        <testcase name="testGetAccountDetailSuccess()" classname="AccountClientTests" time="0.001" id="ad2f0561-9bf3-5447-931f-248e7e16b4be">
-        </testcase>
-        <testcase name="testGetFavoriteListSuccess()" classname="AccountClientTests" time="0.001" id="19ba369f-082c-5995-8212-35f55fcc2317">
-        </testcase>
-        <testcase name="testGetFavoriteListError()" classname="AccountClientTests" time="0.002" id="30c04794-f2ca-560a-8255-0f067ea481af">
-        </testcase>
-        <testcase name="testGetAccountDetailError()" classname="AccountClientTests" time="0.001" id="0735f573-891e-50b9-9614-c7da995fe97d">
-        </testcase>
-        <testcase name="testAddToWatchlistSuccess()" classname="AccountClientTests" time="0.001" id="86219717-9729-540f-8bdb-30d0f50e7b59">
-        </testcase>
-        <testcase name="testMarkAsFavoriteSuccess()" classname="AccountClientTests" time="0.001" id="4daccc28-a053-533d-b3e9-17a0b5070a97">
-        </testcase>
-        <testcase name="testGetRecommendedListSuccess()" classname="AccountClientTests" time="0.001" id="c16f2e03-f0c6-56f6-8d5e-cd2f7cda92e3">
-        </testcase>
-        <testcase name="testGetRecommendedListError()" classname="AccountClientTests" time="0.000" id="6313da0f-7f37-50cc-8ff4-1266809253b2">
+    <testsuite name="CoreDataInfrastructure-Unit-CoreDataInfrastructureTests.CDMovieSearchStoreTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testSaveMovieSearch()" time="0.001" id="75fb779a-570d-523d-ac6f-fcefa1903f1c">
         </testcase>
     </testsuite>
-    <testsuite name="UpcomingMoviesData-Unit-UpcomingMoviesDataTests.xctest" tests="7" disabled="0" errors="0" failures="0" time="0.004" id="fc26e0ee-ea0a-5c9f-a0d6-cb6b0b4e8d38">
-        <testcase name="testSaveMovieVisits()" classname="MovieVisitRepositoryTests" time="0.001" id="50b67368-e964-5dd1-9448-622dc3468926">
+    <testsuite name="CoreDataInfrastructure-Unit-CoreDataInfrastructureTests.CDMovieVisitStoreTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testSaveMovieVisitError()" time="0.001" id="8b71997e-c18a-5b96-bbcc-b199ae933a86">
         </testcase>
-        <testcase name="testGetMovieVisits()" classname="MovieVisitRepositoryTests" time="0.001" id="41cb78ab-2b55-5b8d-8c78-2089cc103f7c">
-        </testcase>
-        <testcase name="testGetConfiguration()" classname="ConfigurationRepositoryTests" time="0.001" id="668ed7af-7def-5695-93a6-17932aa628b3">
-        </testcase>
-        <testcase name="testSaveSearchTextCalled()" classname="MovieSearchRepositoryTests" time="0.000" id="14d9f222-a291-5dd6-9d50-81401f0fccc7">
-        </testcase>
-        <testcase name="testGetMovieSearches()" classname="MovieSearchRepositoryTests" time="0.000" id="1ebf7d13-fb91-577f-9ebf-57ea5e4eb422">
-        </testcase>
-        <testcase name="testFindUserCalled()" classname="UserRepositoryTests" time="0.000" id="99ab90d4-92d3-5873-84f0-0284ac0b9acc">
-        </testcase>
-        <testcase name="testSaveUserCalled()" classname="UserRepositoryTests" time="0.000" id="268f649a-50c3-5f58-91d6-d4f03d32339b">
+        <testcase name="testSaveMovieVisitSuccess()" time="0.001" id="5d80571f-9f60-5119-8543-57fbb086fe19">
         </testcase>
     </testsuite>
-    <testsuite name="UpcomingMoviesDomain-Unit-UpcomingMoviesDomainTests.xctest" tests="2" disabled="0" errors="0" failures="0" time="0.402" id="42249e5f-9795-54a8-83cc-93201b23e417">
-        <testcase name="testPerformanceExample()" classname="UpcomingMoviesDomainTests" time="0.402" id="f7060135-bb4e-5891-9609-97494a20421a">
+    <testsuite name="CoreDataInfrastructure-Unit-CoreDataInfrastructureTests.CDGenreStoreTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testFindAllGenres()" time="0.016" id="f75d41f2-6086-5a5b-9add-e0463a7a406b">
         </testcase>
-        <testcase name="testExample()" classname="UpcomingMoviesDomainTests" time="0.000" id="1af5a4e6-29a0-5f73-9ddc-0803c0341ba1">
+        <testcase name="testSaveGenre()" time="0.001" id="f3bb0130-2f88-5f74-8410-00dea4089f9f">
         </testcase>
     </testsuite>
-    <testsuite name="UpcomingMoviesTests.xctest" tests="286" disabled="1" errors="0" failures="1" time="5.723" id="51689642-f0c0-5e7e-beda-c7f130300a18">
-        <testcase name="testInitWithCast()" classname="CastModelTests" time="0.003" id="310d1f9a-3a73-515f-9737-4bffd0474da7">
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MarkAsFavoriteTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testStatusMessageFromResponse()" time="0.005" id="fe6d452a-58f7-5dc0-bd23-a7731bd3aa0a">
+        </testcase>
+        <testcase name="testMissingStatusCodeFromResponse()" time="0.001" id="062544d1-660d-5ddf-b4c2-e12bf293c877">
+        </testcase>
+        <testcase name="testStatusCodeFromResponse()" time="0.000" id="9efa0467-0242-5dbc-8b29-1168cd9614a6">
+        </testcase>
+        <testcase name="testMissingStatusMessageFromResponse()" time="0.000" id="759dc824-8837-5894-99b5-0a8a36a38107">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieCreditsTests" tests="12" disabled="0" errors="0" failures="0">
+        <testcase name="testMissingIdFromCastResponse()" time="0.002" id="523d27bd-aa17-5a06-91e2-f8377a485f4f">
+        </testcase>
+        <testcase name="testMissingCharacterFromCastResponse()" time="0.002" id="1158e8a5-2a3f-5fbc-a7b7-4ebd25e64f60">
+        </testcase>
+        <testcase name="testMissingNameFromCrewResponse()" time="0.001" id="2d46aebc-3d63-5f50-84bb-4a7fb1293a45">
+        </testcase>
+        <testcase name="testIdFromCrewResponse()" time="0.000" id="c55e8d74-1820-5541-a09f-3292ad8ee43b">
+        </testcase>
+        <testcase name="testJobFromCrewResponse()" time="0.000" id="1c6d7c7b-b68e-5f29-9186-d24dc9929137">
+        </testcase>
+        <testcase name="testNameFromCastResponse()" time="0.000" id="22da8c52-c6e1-58df-9401-99378da6e1e3">
+        </testcase>
+        <testcase name="testMissingJobFromCrewResponse()" time="0.001" id="66d5c481-1145-575d-bc2d-f1718a347497">
+        </testcase>
+        <testcase name="testMissingIdFromCrewResponse()" time="0.000" id="cf26aead-2c48-5dc4-a314-dc62d425af85">
+        </testcase>
+        <testcase name="testMissingNameFromCastResponse()" time="0.000" id="5ea394d2-8000-5753-b020-ef7f2e62fb1f">
+        </testcase>
+        <testcase name="testIdFromCastResponse()" time="0.000" id="f693a113-c367-5be8-ba0b-c2da62208cbb">
+        </testcase>
+        <testcase name="testCharacterFromCastResponse()" time="0.000" id="12d68d2d-5653-53ab-8273-489c98bea6d0">
+        </testcase>
+        <testcase name="testNameFromCrewResponse()" time="0.000" id="9b4eb9db-979e-5dfc-90d6-83d6511c9957">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.URLGenerationTests" tests="5" disabled="0" errors="0" failures="0">
+        <testcase name="testURLRequestSetJsonContentTypeNil()" time="0.001" id="ab39e546-1ea4-5519-bdd0-0d96d7d0dd6e">
+        </testcase>
+        <testcase name="testPercentEscapedEmptyParamters()" time="0.001" id="c2f3f6c2-7701-55cb-a3b1-e3669bfaea3b">
+        </testcase>
+        <testcase name="testURLRequestSetJsonContentType()" time="0.001" id="37fbd85a-e0e8-5eca-af4e-8c61476215bc">
+        </testcase>
+        <testcase name="testPercentEscapedSingleParameters()" time="0.001" id="008a23fb-ed7d-5d1a-8620-be85f4e2c85b">
+        </testcase>
+        <testcase name="testPercentEscapedMultipleParameters()" time="0.000" id="a31b40bb-0919-5aaf-a5ce-0e6693945cec">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieImagesConfigurationTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testBaseURLStringFromResponse()" time="0.002" id="575b1bc2-f1df-53ac-9ebc-557816975df1">
+        </testcase>
+        <testcase name="testMissingBaseURLStringFromResponse()" time="0.000" id="06bc70d4-7913-57e9-8749-7798cb8b3cae">
+        </testcase>
+        <testcase name="testMissingBackdropSizesFromResponse()" time="0.000" id="140ea6ae-0088-59e8-90fe-db99604910c0">
+        </testcase>
+        <testcase name="testMissingPosterSizesFromResponse()" time="0.000" id="fe280837-983a-5c05-bb1b-2eb3e775997c">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.VideosTests" tests="8" disabled="0" errors="0" failures="0">
+        <testcase name="testSiteFromResponse()" time="0.001" id="714b1dad-6394-50f0-aa30-df9a5e455b77">
+        </testcase>
+        <testcase name="testKeyFromResponse()" time="0.000" id="fca8492c-4477-534e-908f-bdd7b8ce338c">
+        </testcase>
+        <testcase name="testIdFromResponse()" time="0.000" id="a53cf451-6c1b-5b1a-8e8a-96e650b15f20">
+        </testcase>
+        <testcase name="testNameFromResponse()" time="0.002" id="b4b837b5-d0ce-56f5-bdc9-770120a95929">
+        </testcase>
+        <testcase name="testMissingIdFromResponse()" time="0.000" id="8aa1e2ac-0d4d-544e-86c0-2a2168f9414e">
+        </testcase>
+        <testcase name="testMissingKeyFromResponse()" time="0.000" id="26c31883-21c9-50ed-9167-16d17a103950">
+        </testcase>
+        <testcase name="testMissingSiteFromResponse()" time="0.000" id="e1e584aa-d361-5139-95a7-5c42238aa00b">
+        </testcase>
+        <testcase name="testMissingNameFromResponse()" time="0.000" id="0742f912-a81a-59dd-8d3e-30dfc29da7e5">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieReviewTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testContentFromResponse()" time="0.001" id="6091043e-916b-545f-b74d-4ffb4b107693">
+        </testcase>
+        <testcase name="testMissingAuthorFromResponse()" time="0.001" id="32a3116b-efc6-5e9e-8715-9bc94dd00957">
+        </testcase>
+        <testcase name="testMissingContentFromResponse()" time="0.001" id="de3ba22a-f72f-5a3c-b50e-44e85c557c39">
+        </testcase>
+        <testcase name="testIdFromResponse()" time="0.004" id="a4a6b29c-9d35-5b9b-a3f3-8893a9104c56">
+        </testcase>
+        <testcase name="testAuthorFromResponse()" time="0.000" id="1b9e48c8-56f8-559f-b971-6e48f88c6722">
+        </testcase>
+        <testcase name="testMissingIdFromResponse()" time="0.001" id="d344ad76-1153-59ae-abc1-66e3380197a3">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.RequestTokenTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testMissingSuccessFromResponse()" time="0.003" id="9f0dabba-d483-59c2-a205-600899cfcf1e">
+        </testcase>
+        <testcase name="testTokenFromResponse()" time="0.000" id="9070cca4-5b17-5150-b647-007a08026749">
+        </testcase>
+        <testcase name="testSuccessFromResponse()" time="0.001" id="502c4484-1651-50de-89bb-1b8f99420f06">
+        </testcase>
+        <testcase name="testMissingTokenFromDResponse()" time="0.000" id="cf43f868-0006-590d-9030-7f603d63ff2d">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.RateMovieTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testStatusCodeFromResponse()" time="0.001" id="d4f77a41-f3c2-5ddd-8d86-9c44a6e09ee0">
+        </testcase>
+        <testcase name="testMissingStatusMessageFromResponse()" time="0.001" id="095ee114-158d-5b11-96b1-687db3c96b1e">
+        </testcase>
+        <testcase name="testStatusMessageFromResponse()" time="0.000" id="1ce6cb87-6fcd-551b-ad27-726ae382a686">
+        </testcase>
+        <testcase name="testMissingStatusCodeFromResponse()" time="0.000" id="98569702-c993-5246-a72c-9a00ca0f9fb8">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.AuthClientTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testCreateSessionIdError()" time="0.004" id="91cb580a-816d-573c-ae43-ee48a7522477">
+        </testcase>
+        <testcase name="testGetRequestTokenSuccess()" time="0.001" id="7c4b4ce9-bfe4-5928-8f20-397cba05cd79">
+        </testcase>
+        <testcase name="testCreateSessionIdSuccess()" time="0.001" id="528f228b-8fb8-59a3-8215-8e6704378a9d">
+        </testcase>
+        <testcase name="testGetAccessTokenError()" time="0.001" id="c166c21d-3c82-5a52-87d2-ed99c6c68245">
+        </testcase>
+        <testcase name="testGetRequestTokenError()" time="0.001" id="62c314e0-5ce7-5b96-9049-6d7963fdbd4a">
+        </testcase>
+        <testcase name="testGetAccessTokenSuccess()" time="0.001" id="30810564-d3c0-5415-947d-55d9f53833e2">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieClientTests" tests="24" disabled="0" errors="0" failures="0">
+        <testcase name="testGetPopularMoviesSuccess()" time="0.003" id="6ad4944c-0368-5d51-b748-4db7849d1ba8">
+        </testcase>
+        <testcase name="testGetMovieReviewsSuccess()" time="0.001" id="aee20a4a-a6fb-5e4a-b3d7-efb395292807">
+        </testcase>
+        <testcase name="testGetMovieVideosSuccess()" time="0.001" id="06d34d02-a52a-507b-93d9-8520c0307a4c">
+        </testcase>
+        <testcase name="testGetSimilarMoviesError()" time="0.000" id="dfad0b6e-448d-5b7d-a98e-5c4d5a76fa8a">
+        </testcase>
+        <testcase name="testGetMovieCreditsError()" time="0.000" id="d692c2a1-8a01-55af-a169-aca7fe1441c7">
+        </testcase>
+        <testcase name="testGetSimilarMoviesSuccess()" time="0.002" id="5ea8ee05-dfc6-586a-8a70-934a5b7bfe17">
+        </testcase>
+        <testcase name="testGetUpcomingMoviesError()" time="0.001" id="4a310c81-dc89-5a33-9643-85c7e8658491">
+        </testcase>
+        <testcase name="testRateMovieError()" time="0.001" id="210a50cc-541d-5758-b5a2-c1b38194d869">
+        </testcase>
+        <testcase name="testGetMoviesByGenreSuccess()" time="0.001" id="4b8f6d09-4be6-5ec9-af0e-745a4e03ecc4">
+        </testcase>
+        <testcase name="testGetMovieReviewsError()" time="0.001" id="404b4d84-737d-5c87-b573-231da5609ddb">
+        </testcase>
+        <testcase name="testGetUpcomingMoviesSuccess()" time="0.001" id="9957a8b8-67ab-557c-9b1a-462d3306635e">
+        </testcase>
+        <testcase name="testGetMovieAccountStateSuccess()" time="0.002" id="817e58a3-fdc4-522b-9114-366892712874">
+        </testcase>
+        <testcase name="testGetMovieDetailSuccess()" time="0.002" id="8b0eb2fa-2e65-5e40-a1e0-9c747ff79362">
+        </testcase>
+        <testcase name="testGetMovieCreditsSuccess()" time="0.005" id="9d57eab5-0635-5961-8074-497884713e36">
+        </testcase>
+        <testcase name="testGetMovieVideosError()" time="0.001" id="ad353049-155d-5250-abbb-a4094d8bdfb7">
+        </testcase>
+        <testcase name="testGetMoviesByGenreError()" time="0.001" id="9aa908c1-6b86-5801-a5e6-e4a976ac9de4">
+        </testcase>
+        <testcase name="testGetMovieAccountStateError()" time="0.001" id="2f36d1f0-3411-5be1-b06a-7cdeb6819deb">
+        </testcase>
+        <testcase name="testGetPopularMoviesError()" time="0.002" id="443dc223-6d66-5784-9329-6ede560ced6e">
+        </testcase>
+        <testcase name="testGetMovieDetailError()" time="0.001" id="ddca7bbf-0628-5d42-95c8-f81bf8dd132b">
+        </testcase>
+        <testcase name="testGetTopRatedMoviesSuccess()" time="0.001" id="bb9c8f92-07fe-5f1b-b879-e2c6c59893be">
+        </testcase>
+        <testcase name="testSearchMoviesError()" time="0.002" id="9a897d2f-69ee-5cc5-a89e-cb88edc908ff">
+        </testcase>
+        <testcase name="testGetTopRatedMoviesError()" time="0.004" id="104134d5-9968-5bc1-8313-61271d455b5b">
+        </testcase>
+        <testcase name="testRateMovieSuccess()" time="0.001" id="cd587014-07d7-5e6d-a7a6-4f81571ec5fa">
+        </testcase>
+        <testcase name="testSearchMoviesSuccess()" time="0.002" id="43f8269e-8ed2-534c-b132-28ef971d774d">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.AuthRemoteDataSourceTests" tests="8" disabled="0" errors="0" failures="0">
+        <testcase name="testCurrentUserId()" time="0.001" id="5412704c-c040-5760-b434-9f6bf936df12">
+        </testcase>
+        <testcase name="testGetAuthURLFailure()" time="0.001" id="8388d94d-6920-5b97-b7d7-57c773fdae64">
+        </testcase>
+        <testcase name="testSignInUserFailureInGetAccountDetails()" time="0.004" id="ba2867a9-aa66-50ff-b369-568bb446d229">
+        </testcase>
+        <testcase name="testSignInUserFailureInGetAccessToken()" time="0.001" id="bff2c9c1-6aaa-5a86-b176-970c7d5554d6">
+        </testcase>
+        <testcase name="testSignOutUser()" time="0.001" id="7618a4fa-50a0-5a57-8fe2-5d84f1e3071a">
+        </testcase>
+        <testcase name="testSignInUserFailureInCreateSessionId()" time="0.001" id="8a1c219e-24c8-5226-b282-aac86e5f3b28">
+        </testcase>
+        <testcase name="testSignInUserSuccess()" time="0.001" id="505638f1-d762-5649-bf55-3a3c2beb573d">
+        </testcase>
+        <testcase name="testGetAuthURLSuccess()" time="0.001" id="01442da8-c02f-5574-bca0-285a6ab4e448">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieResultPaginationTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieResultNextPage()" time="0.001" id="1edd97cd-4d5c-580b-8c59-d3a7d6eff13b">
+        </testcase>
+        <testcase name="testMovieResultHasMorePagesFalse()" time="0.001" id="4546ace3-a4f0-5d5f-b319-5f9a6c7ff704">
+        </testcase>
+        <testcase name="testMovieResultHasMorePagesTrue()" time="0.000" id="e70a5ea2-b69c-5f70-bb94-ee6475a37b96">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieGenreTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testIdFromResponse()" time="0.001" id="f93ff6f5-ca0e-5772-ada9-313c2e974b75">
+        </testcase>
+        <testcase name="testNameFromResponse()" time="0.001" id="0a6f9f75-d05b-5db4-93e7-78628c9b5f36">
+        </testcase>
+        <testcase name="testMissingIdFromResponse()" time="0.000" id="435772be-37bb-558c-a8b8-366036aadd0f">
+        </testcase>
+        <testcase name="testMissingNameFromResponse()" time="0.000" id="8b7d1bc0-c6cd-55de-aded-9c82686b6876">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.AccountRemoteDataSourceTests" tests="27" disabled="0" errors="0" failures="0">
+        <testcase name="testGetCustomListMoviesSuccess()" time="0.002" id="c4c9ceab-9d3e-5211-b0a7-461da6e6a6d4">
+        </testcase>
+        <testcase name="testGetCustomListMoviesNilAccessToken()" time="0.001" id="ae1e1707-de34-50ee-91fd-537fd8028691">
+        </testcase>
+        <testcase name="testGetRecommendedListSuccess()" time="0.001" id="3ed49ac8-1e3a-56fa-8256-8f852d534b95">
+        </testcase>
+        <testcase name="testGetFavoriteListNilUserAccount()" time="0.001" id="e3613029-3a2a-5360-b726-376e41532d1d">
+        </testcase>
+        <testcase name="testAddToWatchlistNilUserAccount()" time="0.001" id="46f35032-91f5-50bc-9d3f-c1ab91cbfde2">
+        </testcase>
+        <testcase name="testGetRecommendedListFailure()" time="0.001" id="769fe60f-5e0a-5171-9bf7-e95842693b3f">
+        </testcase>
+        <testcase name="testGetFavoriteListFailure()" time="0.001" id="deec5eb3-4cdf-5799-a533-e38051a4c50d">
+        </testcase>
+        <testcase name="testAddToWatchlistFailure()" time="0.001" id="b469bd3f-4e3f-5b81-a885-ff482d1dbe0a">
+        </testcase>
+        <testcase name="testGetFavoriteListSuccess()" time="0.001" id="fca8639d-9c63-5d91-b5af-761f0b58d83d">
+        </testcase>
+        <testcase name="testGetAccountDetailNilUserAccount()" time="0.000" id="3b297787-6448-57c2-9547-f9ca07ce941f">
+        </testcase>
+        <testcase name="testMarkMovieAsFavoriteNilUserAccount()" time="0.000" id="987b6318-95e4-54da-a6e4-5ae9a1903612">
+        </testcase>
+        <testcase name="testGetCustomListMoviesNilListResult()" time="0.000" id="7cafff94-5826-51cb-8750-9754600f07bf">
+        </testcase>
+        <testcase name="testMarkMovieAsFavoriteSuccess()" time="0.001" id="9467f096-faca-5280-abeb-adbd41c1408d">
+        </testcase>
+        <testcase name="testGetAccountDetailSuccess()" time="0.000" id="36faf8f2-cc01-580e-bfe0-342a83a687ac">
+        </testcase>
+        <testcase name="testGetCustomListsSuccess()" time="0.001" id="8aba2898-84b5-52db-a16e-d66166619fb5">
+        </testcase>
+        <testcase name="testGetCustomListMoviesFailure()" time="0.004" id="d321b4a0-36d4-5947-90da-d1f3ac2b784b">
+        </testcase>
+        <testcase name="testGetAccountDetailFailure()" time="0.001" id="a6e87e19-62ff-50d0-a01b-33ddb5aee039">
+        </testcase>
+        <testcase name="testGetWatchlistFailure()" time="0.001" id="fafabe50-140b-5f03-b24e-72adcdc8c0fa">
+        </testcase>
+        <testcase name="testMarkMovieAsFavoriteFailure()" time="0.001" id="c1c120f1-8dd8-5b93-9aae-a88f2b506e1b">
+        </testcase>
+        <testcase name="testGetWatchlistNilUserAccount()" time="0.000" id="4e2c26f8-2c4d-5e20-8a11-af74fe95928c">
+        </testcase>
+        <testcase name="testAddToWatchlistSuccess()" time="0.000" id="a21af341-03f1-5a0a-8313-bacbd1ddd771">
+        </testcase>
+        <testcase name="testGetCustomListFailure()" time="0.001" id="92edc45b-e772-514a-85b7-8a4e266130bd">
+        </testcase>
+        <testcase name="testGetRecommendedListNilAccountIdAndToken()" time="0.000" id="bc6967e4-8360-58a7-9054-433d56e7a988">
+        </testcase>
+        <testcase name="testGetCustomListNilAccountIdAndToken()" time="0.001" id="8fb625a9-1ecd-5953-8b80-38dce585343c">
+        </testcase>
+        <testcase name="testGetCustomListNilListResult()" time="0.000" id="8401d4d5-e4af-5784-afeb-17e0efc87395">
+        </testcase>
+        <testcase name="testGetWatchlistSuccess()" time="0.001" id="8915feda-b949-5100-971e-444e18e5c4cc">
+        </testcase>
+        <testcase name="testGetRecommendedListNilListResult()" time="0.003" id="d6fd53f9-20cd-5327-b2ca-1e05de2a8785">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.SessionTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testMissingSessionIdFromDResponse()" time="0.000" id="a4215ace-7105-5d1b-a2ef-f6b73b0bd703">
+        </testcase>
+        <testcase name="testMissingSuccessFromResponse()" time="0.001" id="9f7327c8-3962-5e97-9321-5456d0b8c630">
+        </testcase>
+        <testcase name="testSuccessFromResponse()" time="0.000" id="c4811d83-ae92-5adf-87a6-2fb5faa48b0e">
+        </testcase>
+        <testcase name="testSessionIdFromResponse()" time="0.001" id="eebf94b5-a2af-5c3a-95be-af799b9d16ce">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.MovieSortTypeTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testWatchlistSortTypeCallAsFunctionCreatedAtDesc()" time="0.001" id="cd1d0ef8-7610-550e-a17c-6e70a412d536">
+        </testcase>
+        <testcase name="testWatchlistSortTypeCallAsFunctionCreatedAtAsc()" time="0.001" id="2a91b4e2-fd85-52e5-b509-73796549260f">
+        </testcase>
+        <testcase name="testFavoriteSortTypeCallAsFunctionCreatedAtDesc()" time="0.001" id="87c902c7-673e-5737-ba45-d46c73bb19d5">
+        </testcase>
+        <testcase name="testFavoriteSortTypeCallAsFunctionCreatedAtAsc()" time="0.000" id="66926481-8eba-5ffc-a48a-3908aa00a3d8">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.AddToWatchlistTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testMissingStatusMessageFromResponse()" time="0.001" id="10e68d1b-317d-5d9f-b7d9-5350fe203f0e">
+        </testcase>
+        <testcase name="testStatusCodeFromResponse()" time="0.000" id="acb0a435-5b2d-57c5-8570-f23e8c3474c0">
+        </testcase>
+        <testcase name="testStatusMessageFromResponse()" time="0.000" id="8f26201b-1603-5e0d-82f5-0cb85993d560">
+        </testcase>
+        <testcase name="testMissingStatusCodeFromResponse()" time="0.000" id="66e0e4c6-2264-51d7-bf5d-bc1fe3c16d8c">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.AccessTokenTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testMissingAccounIdFromResponse()" time="0.000" id="16b7cf2c-f4bb-5ac7-af56-79c61ed7872e">
+        </testcase>
+        <testcase name="testMissingTokenFromResponse()" time="0.001" id="4df886cf-b671-5cd9-a4ca-bbaac18fa518">
+        </testcase>
+        <testcase name="testAccounIdFromResponse()" time="0.001" id="56b3679d-a6ca-5606-a1aa-04dfb9e788bb">
+        </testcase>
+        <testcase name="testTokenFromResponse()" time="0.000" id="cefb2b2b-e28a-503d-8e7d-511c21331d41">
+        </testcase>
+    </testsuite>
+    <testsuite name="NetworkInfrastructure-Unit-NetworkInfrastructureTests.AccountClientTests" tests="16" disabled="0" errors="0" failures="0">
+        <testcase name="testGetWatchlistError()" time="0.001" id="f741aa08-60a4-5d55-825e-67d431624460">
+        </testcase>
+        <testcase name="testGetWatchlistSuccess()" time="0.001" id="a3b21b57-fdb1-5173-aa0c-4d0505cc5b0a">
+        </testcase>
+        <testcase name="testGetCustomListMoviesError()" time="0.005" id="0682eb98-a398-55b5-b62c-259b82332a88">
+        </testcase>
+        <testcase name="testGetCustomListMoviesSuccess()" time="0.001" id="27ab43e2-450a-587f-aae3-7fee5bbb73bc">
+        </testcase>
+        <testcase name="testGetCustomListsError()" time="0.001" id="2fdd048e-f212-522c-9500-acd2cfbb8ab8">
+        </testcase>
+        <testcase name="testAddToWatchlistError()" time="0.001" id="cf6af3b5-29ca-51f3-ab7a-baa19aa518d8">
+        </testcase>
+        <testcase name="testGetCustomListsSuccess()" time="0.004" id="f1f32e71-02d3-5a8a-a12f-f59c745c3883">
+        </testcase>
+        <testcase name="testMarkAsFavoriteError()" time="0.001" id="a9c70f86-1fac-543b-8e33-87fdf7322baa">
+        </testcase>
+        <testcase name="testGetAccountDetailSuccess()" time="0.001" id="0cd3a8e8-aada-5152-acc2-20aa4481e56a">
+        </testcase>
+        <testcase name="testGetFavoriteListSuccess()" time="0.001" id="cb5ba36c-b8fa-5639-8bd5-7798f1f74c5c">
+        </testcase>
+        <testcase name="testGetFavoriteListError()" time="0.002" id="4ece996a-8eef-51cf-ae86-905359a0d492">
+        </testcase>
+        <testcase name="testGetAccountDetailError()" time="0.001" id="4713f000-2dc3-51fc-89e0-fc64f1e86a10">
+        </testcase>
+        <testcase name="testAddToWatchlistSuccess()" time="0.001" id="85b84eef-0f94-5754-8cfe-2bea286d7986">
+        </testcase>
+        <testcase name="testMarkAsFavoriteSuccess()" time="0.001" id="68d14a0c-0b03-5072-8e6d-6182cb612a60">
+        </testcase>
+        <testcase name="testGetRecommendedListSuccess()" time="0.001" id="f63e0c2f-5203-57bf-8562-2ce21ef1aad8">
+        </testcase>
+        <testcase name="testGetRecommendedListError()" time="0.001" id="bfb4b16d-dc76-576e-a6ab-404f73d6dab6">
+        </testcase>
+    </testsuite>
+    <testsuite name="UpcomingMoviesData-Unit-UpcomingMoviesDataTests.MovieVisitRepositoryTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testSaveMovieVisits()" time="0.002" id="7a4bebed-766a-59e4-a982-0b6f88e3efdd">
+        </testcase>
+        <testcase name="testGetMovieVisits()" time="0.001" id="ea0f5aa4-660d-5480-ac07-bfe1387d563e">
+        </testcase>
+    </testsuite>
+    <testsuite name="UpcomingMoviesData-Unit-UpcomingMoviesDataTests.ConfigurationRepositoryTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testGetConfiguration()" time="0.001" id="4841dad6-9f6b-51ff-8ac7-21907232ba10">
+        </testcase>
+    </testsuite>
+    <testsuite name="UpcomingMoviesData-Unit-UpcomingMoviesDataTests.MovieSearchRepositoryTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testSaveSearchTextCalled()" time="0.000" id="72f39867-82e6-551a-b56b-47c26686bc7a">
+        </testcase>
+        <testcase name="testGetMovieSearches()" time="0.000" id="96785309-dfcd-57ac-9959-3653ecb230d3">
+        </testcase>
+    </testsuite>
+    <testsuite name="UpcomingMoviesData-Unit-UpcomingMoviesDataTests.UserRepositoryTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testFindUserCalled()" time="0.000" id="ac00c414-2684-585c-a845-f438f4f3c7ae">
+        </testcase>
+        <testcase name="testSaveUserCalled()" time="0.000" id="b0c97cef-13bd-5f5d-945a-e8ebcf1d0f92">
+        </testcase>
+    </testsuite>
+    <testsuite name="UpcomingMoviesDomain-Unit-UpcomingMoviesDomainTests.UpcomingMoviesDomainTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testPerformanceExample()" time="0.400" id="f6cc6fb3-f8e2-5a5d-aff8-adb9905109cf">
+        </testcase>
+        <testcase name="testExample()" time="0.000" id="802b4574-4a25-5e8e-a7f1-4497b2e9b2a9">
+        </testcase>
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.CastModelTests" tests="1" disabled="1" errors="0" failures="0">
+        <testcase name="testInitWithCast()" time="0.003" id="7ac895a2-4ca0-5b60-81b7-d353707304a1">
             <skipped/>
         </testcase>
-        <testcase name="testBackdropURL()" classname="SavedMovieCellViewModelTests" time="0.000" id="9c409fe5-78a5-5a4c-85a6-4a30a2278291">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SavedMovieCellViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testBackdropURL()" time="0.001" id="66c3495c-a6d6-559e-b9ea-6f5c8b097c6e">
         </testcase>
-        <testcase name="testTitle()" classname="SavedMovieCellViewModelTests" time="0.000" id="7196da40-d6f2-5ac1-a1de-80f0efb13b3e">
+        <testcase name="testTitle()" time="0.000" id="3fda1f07-ab7d-50ba-b0dd-9fc4080dc96e">
         </testcase>
-        <testcase name="testGetAccountDetailError()" classname="ProfileInteractorTests" time="0.000" id="ce9b3727-e252-53a0-bd74-f38aaecf83da">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ProfileInteractorTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testGetAccountDetailError()" time="0.000" id="fda016cb-8d45-5c78-ae0e-21e8ec700f15">
         </testcase>
-        <testcase name="testGetAccountDetailSuccess()" classname="ProfileInteractorTests" time="0.000" id="9a3221eb-7867-5159-9f49-1649a354cee8">
+        <testcase name="testGetAccountDetailSuccess()" time="0.000" id="1740c0a7-bb1c-5528-8089-c5b8c9b43b33">
         </testcase>
-        <testcase name="testSignOutUser()" classname="ProfileInteractorTests" time="0.000" id="a50e9ab5-c80e-55d1-b528-a6c533f85f45">
+        <testcase name="testSignOutUser()" time="0.000" id="12ca00a9-d99d-54b2-9da1-bf726205a1d6">
         </testcase>
-        <testcase name="testDidDismiss()" classname="AuthPermissionCoordinatorTests" time="0.001" id="3b1ae076-02b7-5a27-8492-917f0ea092fb">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.AuthPermissionCoordinatorTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testDidDismiss()" time="0.001" id="259da96b-3315-597c-a6ba-535186ec6e73">
         </testcase>
-        <testcase name="testBuild()" classname="AuthPermissionCoordinatorTests" time="0.004" id="54d1d975-52f8-5c99-97b1-6e1c3c0dd469">
+        <testcase name="testBuild()" time="0.004" id="2925ff65-c398-5372-8b7a-597d9333ccda">
         </testcase>
-        <testcase name="testShareTitle()" classname="SearchMoviesResultViewModelTests" time="0.000" id="df3b493c-0290-5ebf-9074-462f9481595a">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SearchMoviesResultViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testShareTitle()" time="0.000" id="1496c298-e68e-5877-a20e-0b82b498bf3c">
         </testcase>
-        <testcase name="testEmptySearchResultsTitle()" classname="SearchMoviesResultViewModelTests" time="0.000" id="428d634e-60f5-51ff-8801-d761dbb051cd">
+        <testcase name="testEmptySearchResultsTitle()" time="0.000" id="08d2c805-b568-566f-8974-964d0f3ac72a">
         </testcase>
-        <testcase name="testDidSelectRowAtRecommendedSection()" classname="ProfileViewControllerTests" time="0.005" id="7e94a997-d7a3-5ca2-9607-7da79b5119e2">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ProfileViewControllerTests" tests="12" disabled="0" errors="0" failures="0">
+        <testcase name="testDidSelectRowAtRecommendedSection()" time="0.005" id="03029549-aa60-51f0-a7d6-9e725a92273d">
         </testcase>
-        <testcase name="testHeightForRowAtCollectionsSection()" classname="ProfileViewControllerTests" time="0.002" id="327c77e7-0444-5dce-aa32-e71e1208d43c">
+        <testcase name="testHeightForRowAtCollectionsSection()" time="0.002" id="2a01523a-f541-5ba1-87d6-d6130936bb25">
         </testcase>
-        <testcase name="testDidSelectRowAtCustomListsSection()" classname="ProfileViewControllerTests" time="0.001" id="b11ab8a8-117b-501c-bacb-8f7e516b164a">
+        <testcase name="testDidSelectRowAtCustomListsSection()" time="0.001" id="dda64284-a41a-528a-bebf-23ca62d41821">
         </testcase>
-        <testcase name="testHeightForRowWithoutViewModel()" classname="ProfileViewControllerTests" time="0.001" id="abc30473-ffbe-52ea-8ed4-ac2a08c165bc">
+        <testcase name="testHeightForRowWithoutViewModel()" time="0.001" id="facdafb6-7812-52bf-93f8-ed0153285690">
         </testcase>
-        <testcase name="testHeightForRowAtCustomListsSection()" classname="ProfileViewControllerTests" time="0.001" id="d80c96e8-803c-5a57-be03-629e288fcca8">
+        <testcase name="testHeightForRowAtCustomListsSection()" time="0.001" id="f83c3708-c596-5522-a106-fc17dda3dc67">
         </testcase>
-        <testcase name="testDidUpdateAuthenticationState()" classname="ProfileViewControllerTests" time="1.003" id="0f646d8e-db08-5f47-b8cb-0579008864e0">
+        <testcase name="testDidUpdateAuthenticationState()" time="1.000" id="0e3eeb72-06c2-5658-a59f-f7bd318bd045">
         </testcase>
-        <testcase name="testDidSelectRowAtSignOutSection()" classname="ProfileViewControllerTests" time="0.004" id="4a3550e8-7736-5439-ada4-b0347d560f3a">
+        <testcase name="testDidSelectRowAtSignOutSection()" time="0.004" id="6900e79d-9b4a-5b88-a412-dc2c04f0f5ea">
         </testcase>
-        <testcase name="testDidSelectRowAtCollectionsSection()" classname="ProfileViewControllerTests" time="0.002" id="1dc3a540-4e85-5a44-a4d7-c23d92bc976d">
+        <testcase name="testDidSelectRowAtCollectionsSection()" time="0.002" id="06a13959-a0dc-53d0-a0d8-681f4941747f">
         </testcase>
-        <testcase name="testHeightForRowAtRecommendedSection()" classname="ProfileViewControllerTests" time="0.001" id="58cdfad0-c524-5ef8-9b7e-5da74cc82ae0">
+        <testcase name="testHeightForRowAtRecommendedSection()" time="0.001" id="6e9aabcc-42cb-5d51-b6e8-14df6e04d192">
         </testcase>
-        <testcase name="testHeightForRowAtSignOutSection()" classname="ProfileViewControllerTests" time="0.001" id="99470aa4-c199-5f57-87fc-41afcf44a6d7">
+        <testcase name="testHeightForRowAtSignOutSection()" time="0.001" id="00682112-9b20-58e8-b240-9c8b9ca3c674">
         </testcase>
-        <testcase name="testDidSelectRowAtAccountInfoSection()" classname="ProfileViewControllerTests" time="0.001" id="ce69f663-d668-568d-9f64-0ab98f41d08a">
+        <testcase name="testDidSelectRowAtAccountInfoSection()" time="0.001" id="78b1f511-b69e-5f7b-ab70-2b4a5d78bae8">
         </testcase>
-        <testcase name="testHeightForRowAtAccountInfoSection()" classname="ProfileViewControllerTests" time="0.001" id="4e89c93b-d4f9-50cf-98da-ead55e69a96d">
+        <testcase name="testHeightForRowAtAccountInfoSection()" time="0.001" id="46c6a468-b43b-5fa4-afee-beaf5da4f92a">
         </testcase>
-        <testcase name="testReleaseDate()" classname="MovieDetailTitleRenderContentTests" time="0.000" id="9b5dd4ef-ee8c-58a8-b677-e7ea9591111d">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailTitleRenderContentTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testReleaseDate()" time="0.000" id="8f088813-b061-5a0d-9295-823a187d62d7">
         </testcase>
-        <testcase name="testTitle()" classname="MovieDetailTitleRenderContentTests" time="0.000" id="a359ccf0-7d96-5c6f-8a9a-063e7d1e8646">
+        <testcase name="testTitle()" time="0.000" id="b2e56333-3dfb-54ea-b784-d5f7bce0ad4d">
         </testcase>
-        <testcase name="testVoteAverage()" classname="MovieDetailTitleRenderContentTests" time="0.000" id="f70d5d9a-ae1c-5510-a4b0-e3b1616c2c06">
+        <testcase name="testVoteAverage()" time="0.000" id="d2b44311-70c1-5a17-b604-5f72993a5005">
         </testcase>
-        <testcase name="testGenreIds()" classname="MovieDetailTitleRenderContentTests" time="0.000" id="39d5c9fa-deb4-5571-b917-43729e3a794a">
+        <testcase name="testGenreIds()" time="0.000" id="4ec5d8e5-6aac-5f77-85a6-bc067898faeb">
         </testcase>
-        <testcase name="testGetFavoriteListCalled()" classname="FavoritesSavedMoviesInteractorTests" time="0.001" id="3d9b7d90-d52c-503b-96d6-7ebfd2c03fe3">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.FavoritesSavedMoviesInteractorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testGetFavoriteListCalled()" time="0.001" id="ebca35ea-ecbb-5857-89f0-266c818336cf">
         </testcase>
-        <testcase name="testBuild()" classname="RecommendedMoviesCoordinatorTests" time="0.004" id="4a4180ab-cf44-58d8-8126-ca091a3ab348">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.RecommendedMoviesCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.004" id="d60fff18-91e9-5f6c-9bfc-3644dcd6ebfa">
         </testcase>
-        <testcase name="testBuild()" classname="MovieCreditsCoordinatorTests" time="0.003" id="eb8b05de-cb35-5c43-bc4a-0ef03c175bd3">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieCreditsCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.003" id="b830e5d1-35d3-5d15-b198-714744abfb90">
         </testcase>
-        <testcase name="testInitWithMovieSearch()" classname="MovieSearchModelTests" time="0.011" id="6a0ee60a-0a5e-5050-83ac-3eb22a6cb142" file="/Users/work/src/iOS-example/UpcomingMoviesTests/MovieSearchModelTests.swift">
-            <failure message="XCTAssertEqual failed: (&quot;12345&quot;) is not equal to (&quot;12346&quot;)"/>
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieSearchModelTests" tests="1" disabled="0" errors="0" failures="1">
+        <testcase name="testInitWithMovieSearch()" time="0.011" id="a4988fb7-1943-5c3b-8ac5-1eccca86cc46">
+            <failure message="MovieSearchModelTests.swift:21: XCTAssertEqual failed: (&quot;12345&quot;) is not equal to (&quot;12346&quot;)"/>
         </testcase>
-        <testcase name="testBuild()" classname="PopularMoviesCoordinatorTests" time="0.002" id="19472e1a-4bf6-58ef-91b6-9dfc35e63f97">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.PopularMoviesCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.002" id="de2c7796-d25a-5d03-99ab-84c816de4b29">
         </testcase>
-        <testcase name="testBuild()" classname="MovieDetailPosterCoordinatorTests" time="0.003" id="81d490cd-949f-5461-b66f-d8d7697ad024">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailPosterCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.003" id="d8ee359e-f2ee-5d39-b195-4043affeae9a">
         </testcase>
-        <testcase name="testViewWillAppear()" classname="CustomListDetailViewControllerTests" time="0.004" id="26ba4e28-a0de-5e06-8564-14fa88e3ec6d">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.CustomListDetailViewControllerTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testViewWillAppear()" time="0.004" id="60e9860b-d4c3-510d-b2cc-5cc2a0b9334c">
         </testcase>
-        <testcase name="testHeightForHeaderInSection()" classname="CustomListDetailViewControllerTests" time="0.001" id="cca4a2d7-c446-5c70-9a0f-a90f1cb804fb">
+        <testcase name="testHeightForHeaderInSection()" time="0.001" id="81b07878-9acd-58b8-88c3-bd6f6ae4ad11">
         </testcase>
-        <testcase name="testViewForHeaderInSection()" classname="CustomListDetailViewControllerTests" time="0.003" id="2274a9c2-ef70-5273-a2f4-1c3ccd800c40">
+        <testcase name="testViewForHeaderInSection()" time="0.003" id="654f7f7a-58bf-5ae6-913d-51b4ee798ba4">
         </testcase>
-        <testcase name="testEmptyMovieResultsTitle()" classname="SavedMoviesViewModelTests" time="0.000" id="0de82ef9-4917-51a0-b9c7-7920134ab580">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SavedMoviesViewModelTests" tests="9" disabled="0" errors="0" failures="0">
+        <testcase name="testEmptyMovieResultsTitle()" time="0.000" id="98a1409b-74f6-5ce0-8238-e8dac37f6b9f">
         </testcase>
-        <testcase name="testMovieCellsZeroCount()" classname="SavedMoviesViewModelTests" time="0.000" id="2cc94b7c-aac6-5371-a499-fd3ac0efde46">
+        <testcase name="testMovieCellsZeroCount()" time="0.000" id="ce39dd08-c0fa-5851-89d1-7a2929439987">
         </testcase>
-        <testcase name="testMovieCellsCount()" classname="SavedMoviesViewModelTests" time="0.001" id="3af3f9e0-2afa-5bfd-8fbf-e2f966274124">
+        <testcase name="testMovieCellsCount()" time="0.001" id="7bd1dde3-e575-589d-a284-e27eb11fbb7e">
         </testcase>
-        <testcase name="testGetCollectionListEmpty()" classname="SavedMoviesViewModelTests" time="0.000" id="bdee12e3-e215-5385-a451-52bd36fa6b4f">
+        <testcase name="testGetCollectionListEmpty()" time="0.000" id="bd24eed2-1b6b-5564-b3e1-8ef04aea10c4">
         </testcase>
-        <testcase name="testMovieIndex()" classname="SavedMoviesViewModelTests" time="0.001" id="aa22ea45-fb63-54de-850e-c470523f4e2e">
+        <testcase name="testMovieIndex()" time="0.001" id="515e9bbd-1d9c-5a30-98e3-21ef53ada8bc">
         </testcase>
-        <testcase name="testGetCollectionListError()" classname="SavedMoviesViewModelTests" time="0.000" id="5136648a-1d6c-578c-a86a-5637a0500486">
+        <testcase name="testGetCollectionListError()" time="0.000" id="ce5b657d-3f75-5dca-928b-d23f68de725e">
         </testcase>
-        <testcase name="testGetCollectionListPopulated()" classname="SavedMoviesViewModelTests" time="0.000" id="2facecaa-2cad-54be-b5c7-d702cba19138">
+        <testcase name="testGetCollectionListPopulated()" time="0.000" id="7f9d213a-3a4f-50e2-ae78-d43927320eb9">
         </testcase>
-        <testcase name="testGetCollectionListPaging()" classname="SavedMoviesViewModelTests" time="0.000" id="5e04f457-0aa6-59db-9da1-7a98ff5f9500">
+        <testcase name="testGetCollectionListPaging()" time="0.000" id="04f43900-cc44-5c5f-bd55-5551aa581bcd">
         </testcase>
-        <testcase name="testSavedMoviesTitle()" classname="SavedMoviesViewModelTests" time="0.000" id="9b718269-e83b-5ba8-89f3-74c01e3b6996">
+        <testcase name="testSavedMoviesTitle()" time="0.000" id="9914a35f-50c7-50a4-9325-c7959fc3e05d">
         </testcase>
-        <testcase name="testMovieDetailSubtitle()" classname="MovieDetailTitleViewModelTests" time="0.000" id="7a799614-1354-5feb-8def-403c39a25d26">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailTitleViewModelTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieDetailSubtitle()" time="0.000" id="4d9cd566-52bc-5cb8-8110-7c4ffbed95b2">
         </testcase>
-        <testcase name="testMovieDetailVoteAverage()" classname="MovieDetailTitleViewModelTests" time="0.002" id="b63d11c0-5c67-5374-9d57-0250b3c3885d">
+        <testcase name="testMovieDetailVoteAverage()" time="0.002" id="11c91aff-996a-5a26-abf2-446b47fc393c">
         </testcase>
-        <testcase name="testMovieDetailGenreIds()" classname="MovieDetailTitleViewModelTests" time="0.000" id="04258567-93d0-5095-943c-451daefba9d7">
+        <testcase name="testMovieDetailGenreIds()" time="0.000" id="4d7bf21d-4cc3-5a91-8494-159b481451e1">
         </testcase>
-        <testcase name="testMovieDetailTitle()" classname="MovieDetailTitleViewModelTests" time="0.000" id="54c49cf3-33e7-5513-bc60-03376c3e14cd">
+        <testcase name="testMovieDetailTitle()" time="0.000" id="f38e50c9-0b36-5c42-8864-566cfd44d147">
         </testcase>
-        <testcase name="testSignInUserError()" classname="SignInViewModelTests" time="0.001" id="d3d75832-accb-50ef-ac51-b54a136d4663">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SignInViewModelTests" tests="5" disabled="0" errors="0" failures="0">
+        <testcase name="testSignInUserError()" time="0.001" id="f3a61230-6f0a-56f4-8252-fae21a8f481b">
         </testcase>
-        <testcase name="testAuthorizationProcessSuccess()" classname="SignInViewModelTests" time="0.004" id="7b1420d4-2aaa-51a0-9b52-eb8c691a61f4">
+        <testcase name="testAuthorizationProcessSuccess()" time="0.004" id="8e5a17d5-bc56-5a7b-8f82-a8d0df67137f">
         </testcase>
-        <testcase name="testSignInUserSuccess()" classname="SignInViewModelTests" time="0.001" id="f5ad1577-d1c0-557d-8d8b-b1eb9227586b">
+        <testcase name="testSignInUserSuccess()" time="0.001" id="bf8ca1a6-7f0c-5508-9911-512f04783fc4">
         </testcase>
-        <testcase name="testAuthorizationProcessError()" classname="SignInViewModelTests" time="0.000" id="1ef6e81d-2401-5632-9f52-447327851f6c">
+        <testcase name="testAuthorizationProcessError()" time="0.000" id="6f70f1a3-1026-546b-83fe-e21c79c96142">
         </testcase>
-        <testcase name="testSignInButtonTitle()" classname="SignInViewModelTests" time="0.000" id="3b579abd-fa1b-570a-8542-299938c90f87">
+        <testcase name="testSignInButtonTitle()" time="0.000" id="51988ca4-a768-563b-9006-8ce5b6834010">
         </testcase>
-        <testcase name="testInitWithMovieVisit()" classname="MovieVisitModelTests" time="0.002" id="fa1d7170-0df2-59eb-95dd-6b5ebfa1fb24">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieVisitModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testInitWithMovieVisit()" time="0.002" id="5feabc2f-3e8e-5d7e-a253-11e7d9507cdb">
         </testcase>
-        <testcase name="testUpcomingMovieCellBackdropURL()" classname="UpcomingMovieCellViewModelTests" time="0.000" id="a8e29229-0ffd-5d55-82c5-5cf8547f0eb5">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.UpcomingMovieCellViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testUpcomingMovieCellBackdropURL()" time="0.000" id="8d24657f-7fb1-505d-995c-ed02827224ae">
         </testcase>
-        <testcase name="testUpcomingMovieCellPosterURL()" classname="UpcomingMovieCellViewModelTests" time="0.000" id="623de759-42a5-5b7f-a384-5965966d7839">
+        <testcase name="testUpcomingMovieCellPosterURL()" time="0.000" id="42012ee2-c5aa-53f6-ba91-a4472b45b3bc">
         </testcase>
-        <testcase name="testBuild()" classname="MovieReviewDetailCoordinatorTests" time="0.003" id="30257115-f1fa-5e29-a90f-fd89e438931f">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieReviewDetailCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.003" id="84be24ab-3e68-5fe5-b686-148ff23f4b9d">
         </testcase>
-        <testcase name="testSetupNavigationControllerDelegate()" classname="UpcomingMoviesCoordinatorTests" time="0.000" id="cd2b2d45-dd0c-5c3e-a0bd-ad03dd89ec93">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.UpcomingMoviesCoordinatorTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testSetupNavigationControllerDelegate()" time="0.000" id="8f56e2f5-bacd-5694-bcf2-778c392da4b4">
         </testcase>
-        <testcase name="testBuild()" classname="UpcomingMoviesCoordinatorTests" time="0.003" id="d19ad16c-2553-5b4c-875c-02ef5dce5ae6">
+        <testcase name="testBuild()" time="0.003" id="e19a97fc-1542-5576-8204-d583c94458cf">
         </testcase>
-        <testcase name="testShowMovieDetail()" classname="UpcomingMoviesCoordinatorTests" time="0.017" id="a87e2fc8-505b-5bab-8f8a-e348ed884676">
+        <testcase name="testShowMovieDetail()" time="0.017" id="1432a4a9-94bd-52c8-ae8d-e16846da2873">
         </testcase>
-        <testcase name="testRootIdentifier()" classname="UpcomingMoviesCoordinatorTests" time="0.000" id="575bd48b-1999-5675-8649-dd51b21b3950">
+        <testcase name="testRootIdentifier()" time="0.000" id="6e6eb181-76a0-5bcc-ad24-11a8ac15d8ba">
         </testcase>
-        <testcase name="testGetMovieVideosCalled()" classname="MovieVideosInteractorTests" time="0.000" id="a3a14d4f-03f8-5637-93b1-88614498e865">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieVideosInteractorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testGetMovieVideosCalled()" time="0.000" id="ffa8a311-f127-567b-bfa4-3e903c5a07aa">
         </testcase>
-        <testcase name="testUsername()" classname="ProfileAccountInfoCellViewModelTests" time="0.000" id="f2180ff2-98b2-53bd-811c-3af3fa329040">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ProfileAccountInfoCellViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testUsername()" time="0.000" id="ef692419-68bc-56ca-b3b2-b20176cd4846">
         </testcase>
-        <testcase name="testName()" classname="ProfileAccountInfoCellViewModelTests" time="0.000" id="439b8d8d-d562-5ecd-888f-243de3fc6d9c">
+        <testcase name="testName()" time="0.000" id="0491096d-40a5-56f4-b5fe-2a6de56ca0e3">
         </testcase>
-        <testcase name="testCloseBarButtonAction()" classname="AuthPermissionViewControllerTests" time="0.089" id="a964bec5-ba20-5f70-b1fd-d446b5fdd638">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.AuthPermissionViewControllerTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testCloseBarButtonAction()" time="0.089" id="2c9e0597-1c49-596d-bc88-d14b30718032">
         </testcase>
-        <testcase name="testPresentationControllerDidDismiss()" classname="AuthPermissionViewControllerTests" time="0.005" id="cd633f40-5aa0-5e69-a98e-776d5d98e1bc">
+        <testcase name="testPresentationControllerDidDismiss()" time="0.005" id="1292058b-8c66-5f5b-bcdb-6e761683ab0a">
         </testcase>
-        <testcase name="testPosterURL()" classname="MovieDetailPosterRenderContentTests" time="0.000" id="b236d70a-6e2e-5bf2-a86e-635fe513279a">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailPosterRenderContentTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testPosterURL()" time="0.000" id="d7842947-729c-53da-bcb4-026a04f13f83">
         </testcase>
-        <testcase name="testBackdropURL()" classname="MovieDetailPosterRenderContentTests" time="0.000" id="e4725d1c-9538-5e06-96d5-300d17255942">
+        <testcase name="testBackdropURL()" time="0.000" id="701be478-6bf3-5d67-b3ae-f8519152af2e">
         </testcase>
-        <testcase name="testShowReviewDetailWithoutTopViewController()" classname="MovieReviewsCoordinatorTests" time="0.000" id="3971f116-a3b7-5b37-8b4a-f4c1c47846dd">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieReviewsCoordinatorTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testShowReviewDetailWithoutTopViewController()" time="0.000" id="006d0577-e114-570b-8eda-c3ef9e493061">
         </testcase>
-        <testcase name="testShowReviewDetail()" classname="MovieReviewsCoordinatorTests" time="0.003" id="57fc96da-6b0f-517a-89f5-9d510e99afcd">
+        <testcase name="testShowReviewDetail()" time="0.003" id="207dbce9-7fe0-54de-9e0d-9ac1e14d9a12">
         </testcase>
-        <testcase name="testBuild()" classname="MovieReviewsCoordinatorTests" time="0.004" id="21de6cf1-b5d0-5848-bbff-d281a55230a8">
+        <testcase name="testBuild()" time="0.004" id="b8355b13-317c-5c07-a8ad-9c22863f7069">
         </testcase>
-        <testcase name="testBuildViewController()" classname="SplashBuilderTests" time="0.005" id="6d3adf6a-9dac-577f-a3b3-d86553054070">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SplashBuilderTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuildViewController()" time="0.005" id="577d62e1-a010-5b07-bad9-8390539375a6">
         </testcase>
-        <testcase name="testGetMoviesPopulated()" classname="UpcomingMoviesViewModelTests" time="0.001" id="c8da6876-d82e-575e-b3f9-e43bb44b801b">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.UpcomingMoviesViewModelTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testGetMoviesPopulated()" time="0.001" id="9981ee93-6e0b-5690-ae6e-327e4650f290">
         </testcase>
-        <testcase name="testGetMoviesError()" classname="UpcomingMoviesViewModelTests" time="0.001" id="2abdf599-9224-5d98-930a-a530ae6c3dae">
+        <testcase name="testGetMoviesError()" time="0.001" id="004ab10e-3fad-5130-8225-e9bb7104f697">
         </testcase>
-        <testcase name="testGetMoviesEmpty()" classname="UpcomingMoviesViewModelTests" time="0.000" id="87412e8d-15ba-5684-84ac-c0d42355787d">
+        <testcase name="testGetMoviesEmpty()" time="0.001" id="f765a1a7-00e3-5835-9bc0-13c01f068cb5">
         </testcase>
-        <testcase name="testUpcomingMovieCellBackdropURL()" classname="UpcomingMoviesViewModelTests" time="0.000" id="d78a1bfc-cbf5-5e8a-bb7a-a5a35e1d2073">
+        <testcase name="testUpcomingMovieCellBackdropURL()" time="0.000" id="c36eaab3-2b1d-54e1-a078-326d9b7488ab">
         </testcase>
-        <testcase name="testUpcomingMovieCellPosterURL()" classname="UpcomingMoviesViewModelTests" time="0.000" id="43a2b833-8027-5ef0-844d-6b89b4bd3978">
+        <testcase name="testUpcomingMovieCellPosterURL()" time="0.000" id="76501702-93bc-5fb9-aa0b-ce62ffbe385c">
         </testcase>
-        <testcase name="testGetMoviesPaging()" classname="UpcomingMoviesViewModelTests" time="0.000" id="638323eb-4181-5b78-9049-0968806ba593">
+        <testcase name="testGetMoviesPaging()" time="0.000" id="454c27b3-6422-59fa-99b0-bc31769ebc30">
         </testcase>
-        <testcase name="testAccessibility()" classname="MovieDetailOptionViewTests" time="0.001" id="53d103f9-8db6-59d7-8b8e-b9b41b38adf1">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailOptionViewTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testAccessibility()" time="0.001" id="a07d77e7-87ee-5d74-aeb4-ba8f9532a8b7">
         </testcase>
-        <testcase name="testOption()" classname="MovieDetailOptionViewTests" time="0.001" id="71dc80f2-9c20-5db0-9b65-ee1de3575a59">
+        <testcase name="testOption()" time="0.001" id="ec7d0d53-0391-5ce7-8d6b-d052d93249c7">
         </testcase>
-        <testcase name="testCellForRowRecentlyVisited()" classname="SearchOptionsDataSourceTests" time="0.005" id="5f78e5cf-5960-5655-ba5f-baea9da6271d">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SearchOptionsDataSourceTests" tests="11" disabled="0" errors="0" failures="0">
+        <testcase name="testCellForRowRecentlyVisited()" time="0.005" id="ee736c88-cd5f-597c-bef6-259333bbbf07">
         </testcase>
-        <testcase name="testNumberOfRowsInSectionRecentlyVisited()" classname="SearchOptionsDataSourceTests" time="0.001" id="713e1c2f-cc24-5999-bdd1-abfc82090eb6">
+        <testcase name="testNumberOfRowsInSectionRecentlyVisited()" time="0.001" id="819c09a0-ecd8-5751-9eb3-2e11ee4383ae">
         </testcase>
-        <testcase name="testDidSelectMovie()" classname="SearchOptionsDataSourceTests" time="0.000" id="53591e72-323d-5aea-87b2-2296b097c0b7">
+        <testcase name="testDidSelectMovie()" time="0.000" id="800ee13b-c658-5e1f-93b3-2af6ac9f6c0c">
         </testcase>
-        <testcase name="testNumberOfRowsInSectionGenres()" classname="SearchOptionsDataSourceTests" time="0.001" id="1b1ff04f-cee1-5afa-9b86-d28a26037e83">
+        <testcase name="testNumberOfRowsInSectionGenres()" time="0.001" id="e7a284d3-bac2-5001-acda-143b58683e7a">
         </testcase>
-        <testcase name="testTitleForHeaderInSectionEmptyState()" classname="SearchOptionsDataSourceTests" time="0.001" id="6ff2348f-d49c-58ec-b3df-a37a2c5659ad">
+        <testcase name="testTitleForHeaderInSectionEmptyState()" time="0.001" id="85ee1387-51d0-518f-a079-0ba7c9958418">
         </testcase>
-        <testcase name="testNumberOfSectionsEmptyState()" classname="SearchOptionsDataSourceTests" time="0.000" id="15bd4b18-9a90-57be-9ff0-7918517580ab">
+        <testcase name="testNumberOfSectionsEmptyState()" time="0.000" id="bf93718f-2a64-5c45-9a70-b581283f99f2">
         </testcase>
-        <testcase name="testCellForRowDefaultSearches()" classname="SearchOptionsDataSourceTests" time="0.002" id="92eab07d-6b5f-5408-95c8-dde6f158a104">
+        <testcase name="testCellForRowDefaultSearches()" time="0.002" id="2705f7ee-c48f-551f-b5c1-8b7182925f1d">
         </testcase>
-        <testcase name="testTitleForHeaderInSectionPopulatedState()" classname="SearchOptionsDataSourceTests" time="0.001" id="86b605ea-e039-53ef-b2aa-0b19148b6abf">
+        <testcase name="testTitleForHeaderInSectionPopulatedState()" time="0.001" id="79bd4fd9-fb17-546b-8dd3-c95104272014">
         </testcase>
-        <testcase name="testNumberOfSectionsPopulatedState()" classname="SearchOptionsDataSourceTests" time="0.000" id="f7c65c0c-cc41-5f67-9716-7f3aea0f6ed8">
+        <testcase name="testNumberOfSectionsPopulatedState()" time="0.000" id="2f5f10f8-d852-5eed-bffc-fcf06937e684">
         </testcase>
-        <testcase name="testNumberOfRowsInSectionDefaultSearches()" classname="SearchOptionsDataSourceTests" time="0.001" id="8a0abe2c-331f-5603-aaa2-fc8d1e852dbd">
+        <testcase name="testNumberOfRowsInSectionDefaultSearches()" time="0.001" id="358038bb-55ab-5cfa-ab30-e9d5704962f2">
         </testcase>
-        <testcase name="testCellForRowGenres()" classname="SearchOptionsDataSourceTests" time="0.003" id="75bf2288-111c-572a-bffe-41d574561e0e">
+        <testcase name="testCellForRowGenres()" time="0.003" id="ba175d75-3ec9-5191-8f18-b60e6959de5d">
         </testcase>
-        <testcase name="testTopRatedSubtitle()" classname="DefaultSearchOptionTests" time="0.001" id="9b59ef18-30cf-5098-ad88-932c5b7fcab9">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.DefaultSearchOptionTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testTopRatedSubtitle()" time="0.001" id="895cfcd0-f2d4-54f4-bbf2-2610ffdea5c0">
         </testcase>
-        <testcase name="testPopularSubtitle()" classname="DefaultSearchOptionTests" time="0.000" id="529a6423-1ecb-561b-b167-83d8206b0c5b">
+        <testcase name="testPopularSubtitle()" time="0.000" id="7a0d4ce1-a18c-57b4-99b2-08abc4a2ecfc">
         </testcase>
-        <testcase name="testTopRatedTitle()" classname="DefaultSearchOptionTests" time="0.000" id="5a9ab95b-4c6d-58d2-a209-370de3f46a42">
+        <testcase name="testTopRatedTitle()" time="0.000" id="1a9fc49f-ad4f-5fc3-a6d3-cd07aebf890a">
         </testcase>
-        <testcase name="testPopularTitle()" classname="DefaultSearchOptionTests" time="0.003" id="e64e1b8c-27d8-5f78-9d8f-9a50c55d29e6">
+        <testcase name="testPopularTitle()" time="0.003" id="1be77b44-0ab1-54c0-ba5e-db93eae89509">
         </testcase>
-        <testcase name="testTopRatedIcon()" classname="DefaultSearchOptionTests" time="0.000" id="4cab3ffb-37be-5853-9d1c-e784da78a763">
+        <testcase name="testTopRatedIcon()" time="0.000" id="901f2d67-4391-5bd5-a235-d8f3dfaab192">
         </testcase>
-        <testcase name="testPopularIcon()" classname="DefaultSearchOptionTests" time="0.000" id="01c5327f-2097-5507-864e-f9ed9859e30d">
+        <testcase name="testPopularIcon()" time="0.000" id="104a7122-5a04-5868-9252-d19e4890bab8">
         </testcase>
-        <testcase name="testBuild()" classname="ProfileCoordinatorTests" time="0.003" id="f9140ea1-1bc8-54e7-a19a-64ffa564a54a">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ProfileCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.003" id="ff27884a-2454-5388-abdf-e0eb028089e1">
         </testcase>
-        <testcase name="testSections()" classname="ProfileFactoryTests" time="0.001" id="50274a04-7281-59b6-8cdc-35bc87d579ec">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ProfileFactoryTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testSections()" time="0.001" id="ef1f6c75-422f-58b2-a18b-454c039b4a9e">
         </testcase>
-        <testcase name="testProfileOptionForAccountInfoSection()" classname="ProfileFactoryTests" time="0.000" id="ab92d4ba-df9c-53d4-b3a7-4836fb8c8f19">
+        <testcase name="testProfileOptionForAccountInfoSection()" time="0.000" id="383233a1-58ec-5db6-b3c4-1ab4543d9afb">
         </testcase>
-        <testcase name="testProfileOptionForSignOutSection()" classname="ProfileFactoryTests" time="0.000" id="99bb25d0-e755-5757-a68b-e5a556762612">
+        <testcase name="testProfileOptionForSignOutSection()" time="0.000" id="f33c4748-dd51-5d91-925a-1fdf466e30e9">
         </testcase>
-        <testcase name="testProfileOptionForRecommendedSection()" classname="ProfileFactoryTests" time="0.000" id="4d58fd0d-2daf-58d7-a50a-9fd035d28b9c">
+        <testcase name="testProfileOptionForRecommendedSection()" time="0.000" id="5eadb09f-35d0-57cc-ad96-bf63cf11e071">
         </testcase>
-        <testcase name="testProfileOptionForCollectionsSection()" classname="ProfileFactoryTests" time="0.000" id="e2d12836-770e-5739-aa01-765a696b9211">
+        <testcase name="testProfileOptionForCollectionsSection()" time="0.000" id="f2529e9e-87f3-5809-8455-0f86800f6806">
         </testcase>
-        <testcase name="testProfileOptionForCustomListsSection()" classname="ProfileFactoryTests" time="0.001" id="714b0464-a88c-587b-ab2f-b60a2ff62daa">
+        <testcase name="testProfileOptionForCustomListsSection()" time="0.001" id="9139421d-5496-544d-8b0a-a912f77b50a3">
         </testcase>
-        <testcase name="testPerformanceExample()" classname="AccountInteractorTests" time="0.255" id="e9fbb7ab-1291-5b29-99ca-dec374a977ce">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.AccountInteractorTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testPerformanceExample()" time="0.260" id="e04b9226-8f76-5a19-8ec9-84b23d96cf4b">
         </testcase>
-        <testcase name="testExample()" classname="AccountInteractorTests" time="0.000" id="7d62e9d4-f624-54c0-95b9-4165de264c59">
+        <testcase name="testExample()" time="0.000" id="5964970f-aa33-5e8e-9ba2-f22ade873321">
         </testcase>
-        <testcase name="testShowAuthPermission()" classname="SignInCoordinatorTests" time="0.002" id="8720dc78-1243-58b1-bdd9-fcc222779c6d">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SignInCoordinatorTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testShowAuthPermission()" time="0.002" id="5dba0278-2be2-53e4-887e-3de4808fb1df">
         </testcase>
-        <testcase name="testShowAuthPermissionWithoutTopViewController()" classname="SignInCoordinatorTests" time="0.000" id="810ac1bd-5163-5d9f-ac77-84e974feef93">
+        <testcase name="testShowAuthPermissionWithoutTopViewController()" time="0.000" id="50176052-69c7-5ec1-ba24-b34160ed1ed9">
         </testcase>
-        <testcase name="testBuild()" classname="SignInCoordinatorTests" time="0.002" id="d3fb49fe-1b91-5938-b99a-663d4998a95b">
+        <testcase name="testBuild()" time="0.003" id="69bf1815-1f03-56fe-b2e2-2868d430c251">
         </testcase>
-        <testcase name="testInitWithMovieCredits()" classname="MovieCreditsModelTests" time="0.000" id="52607206-b462-5895-9542-32b6bbfd4cfc">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieCreditsModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testInitWithMovieCredits()" time="0.000" id="b644aae8-50c4-5bbf-909e-73aad5066380">
         </testcase>
-        <testcase name="testInitWithReview()" classname="ReviewModelTests" time="0.000" id="1dc75ab9-ba4a-5a83-a112-07c04769e8a8">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ReviewModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testInitWithReview()" time="0.000" id="36281de4-7206-5ecf-9851-884293afbc45">
         </testcase>
-        <testcase name="testGetMovieReviewsCalled()" classname="MovieReviewsInteractorTests" time="0.001" id="da84258d-93fc-53de-b095-556873359806">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieReviewsInteractorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testGetMovieReviewsCalled()" time="0.001" id="ff65a504-fce1-539e-94e0-7d55a7790c1f">
         </testcase>
-        <testcase name="testMovieReviewsTitle()" classname="MovieReviewsViewModelTests" time="0.000" id="fd707fc0-579a-5db4-b836-d09a5e4916f1">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieReviewsViewModelTests" tests="7" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieReviewsTitle()" time="0.000" id="e320317e-5db3-5b59-87ef-04230a8de802">
         </testcase>
-        <testcase name="testGetReviewsError()" classname="MovieReviewsViewModelTests" time="0.000" id="61741674-4b54-5597-af35-da00e7f13c17">
+        <testcase name="testGetReviewsError()" time="0.000" id="5922605b-c8a7-5430-bdd0-f011869baeb7">
         </testcase>
-        <testcase name="testEmptyReviewResultsTitle()" classname="MovieReviewsViewModelTests" time="0.000" id="669083c7-dfd0-54a1-b5ed-5fafa7c9caf2">
+        <testcase name="testEmptyReviewResultsTitle()" time="0.000" id="87f61ece-cd63-570e-800f-ddeb7ac498d5">
         </testcase>
-        <testcase name="testRefreshReviews()" classname="MovieReviewsViewModelTests" time="0.009" id="03eaf541-ee28-5937-a4b0-53e87ffb5237">
+        <testcase name="testRefreshReviews()" time="0.009" id="f68d2191-5523-54fd-8f5c-f9ecb5cefbd7">
         </testcase>
-        <testcase name="testGetReviewsEmpty()" classname="MovieReviewsViewModelTests" time="0.000" id="93a89b14-ef4c-5bc1-8f13-fe6c1a33da2b">
+        <testcase name="testGetReviewsEmpty()" time="0.000" id="d2aa650d-8d9c-5b08-9d88-f029c13f6f97">
         </testcase>
-        <testcase name="testGetReviewsPopulated()" classname="MovieReviewsViewModelTests" time="0.001" id="bc02ed75-8f35-57b2-ab95-00d01ee5e96e">
+        <testcase name="testGetReviewsPopulated()" time="0.001" id="2ff0eb2f-98fb-58cb-86a4-dd169cfb9e35">
         </testcase>
-        <testcase name="testGetReviewsPaging()" classname="MovieReviewsViewModelTests" time="0.001" id="90ed6608-0b1f-5e60-a03a-828360a0c322">
+        <testcase name="testGetReviewsPaging()" time="0.001" id="b4657fef-ae4c-508a-b172-c1f53588a857">
         </testcase>
-        <testcase name="testInitWithVideo()" classname="VideoModelTests" time="0.000" id="2714cff0-a290-5c1f-8173-ea46fea9c2d7">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.VideoModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testInitWithVideo()" time="0.000" id="ead7d703-41db-5da7-96dd-a26c1c1b941f">
         </testcase>
-        <testcase name="testMovieDetailOptions()" classname="MovieDetailOptionsViewModelTests" time="0.000" id="555311ce-8e58-5c33-8d00-f4040ec2f369">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailOptionsViewModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieDetailOptions()" time="0.000" id="7f6737bc-2728-5a4c-9ad5-ae83d69eb521">
         </testcase>
-        <testcase name="testCurrentUserNil()" classname="AccountViewModelTests" time="0.000" id="cdcc2c25-af6e-5694-af37-51db5aacc2ed">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.AccountViewModelTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testCurrentUserNil()" time="0.000" id="4bd09e37-1d51-5f32-bf9a-1e3e909dffcc">
         </testcase>
-        <testcase name="testIsUserSignedInFalse()" classname="AccountViewModelTests" time="0.000" id="8a3c6fee-363e-5e88-8880-0f1796764bdf">
+        <testcase name="testIsUserSignedInFalse()" time="0.000" id="e24e7099-6e18-5a09-a59b-1398638ff08a">
         </testcase>
-        <testcase name="testNavigationItemTitle()" classname="AccountViewModelTests" time="0.004" id="3e03fbe0-4fe7-5548-8115-3e8544de3b7c">
+        <testcase name="testNavigationItemTitle()" time="0.004" id="877c5fef-c047-5a01-b08d-b89bed565f9e">
         </testcase>
-        <testcase name="testTitle()" classname="AccountViewModelTests" time="0.000" id="876ee967-b6ab-547e-a0de-206d35cafc46">
+        <testcase name="testTitle()" time="0.000" id="13ad87e8-26eb-5e55-b75f-acf9ad6978a9">
         </testcase>
-        <testcase name="testCurrentUserNotNil()" classname="AccountViewModelTests" time="0.001" id="2caf4412-85ff-5f54-957c-4cb1be933e59">
+        <testcase name="testCurrentUserNotNil()" time="0.001" id="d60950cc-9668-5222-8f59-c553a3f99757">
         </testcase>
-        <testcase name="testIsUserSignedInTrue()" classname="AccountViewModelTests" time="0.000" id="f9e47d52-8b82-56b9-8988-7996f5c0abcd">
+        <testcase name="testIsUserSignedInTrue()" time="0.000" id="a91514b3-b92e-50f2-b2ed-94af9321c5ac">
         </testcase>
-        <testcase name="testBuild()" classname="TopRatedMoviesCoordinatorTests" time="0.004" id="85d59946-9217-5075-a7f8-05e741de1823">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.TopRatedMoviesCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.004" id="de330175-1e6d-5b28-8b91-905175eb34c4">
         </testcase>
-        <testcase name="testOptionAction()" classname="MovieDetailOptionsViewControllerTests" time="0.001" id="1aec6b5f-b179-5813-ad47-0a7d38aed479">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailOptionsViewControllerTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testOptionAction()" time="0.001" id="011f82b3-3c10-5b0a-b2e5-4acdc5c93c63">
         </testcase>
-        <testcase name="testOptionActionInvalidTapGesture()" classname="MovieDetailOptionsViewControllerTests" time="0.001" id="a37fb3e0-6bb6-5b3e-84da-067e9f496900">
+        <testcase name="testOptionActionInvalidTapGesture()" time="0.001" id="e16e0763-aaca-5502-b7cc-bd7a69b45c34">
         </testcase>
-        <testcase name="testGetVideosEmpty()" classname="MovieVideosViewModelTests" time="0.001" id="a5de3f16-b03d-5425-9c27-fd67abed05c4">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieVideosViewModelTests" tests="5" disabled="0" errors="0" failures="0">
+        <testcase name="testGetVideosEmpty()" time="0.001" id="cf096453-2be7-59d5-bef1-8ebefd5c2349">
         </testcase>
-        <testcase name="testMovieVideosTitle()" classname="MovieVideosViewModelTests" time="0.000" id="fc9eb7e7-68a9-5d36-a43d-a6963a42b2db">
+        <testcase name="testMovieVideosTitle()" time="0.000" id="fe024f9e-491c-5b56-82e8-9a98c2ba11d8">
         </testcase>
-        <testcase name="testGetVideosPopulated()" classname="MovieVideosViewModelTests" time="0.001" id="e2fd6f03-49d8-5f7b-bd29-6768069e465d">
+        <testcase name="testGetVideosPopulated()" time="0.001" id="38d9b172-ef07-59de-bbcd-aae1d11be585">
         </testcase>
-        <testcase name="testEmptyVideoResultsTitle()" classname="MovieVideosViewModelTests" time="0.000" id="dae31760-8d55-5399-928f-4aabcfe5a467">
+        <testcase name="testEmptyVideoResultsTitle()" time="0.000" id="d4e8f234-62a3-55df-887b-a6bfdffad27d">
         </testcase>
-        <testcase name="testGetVideosError()" classname="MovieVideosViewModelTests" time="0.000" id="19985ee6-7018-5f63-817b-79e67fd2f320">
+        <testcase name="testGetVideosError()" time="0.000" id="2ed58972-fae1-5bb5-afa1-3edb4cee1583">
         </testcase>
-        <testcase name="testInitWithCrew()" classname="CrewModelTests" time="0.000" id="99293cde-3ea1-5ece-9745-da4698cd91cc">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.CrewModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testInitWithCrew()" time="0.000" id="799cd285-2053-53ce-b4e0-3b31167c000d">
         </testcase>
-        <testcase name="testLoadVisitedMoviesFirstLoad()" classname="SearchOptionsViewModelTests" time="0.001" id="ba95067e-cde7-5bb2-8c39-f0e45cd6db2a">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SearchOptionsViewModelTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testLoadVisitedMoviesFirstLoad()" time="0.001" id="b1026155-6ec6-58f0-9e5e-ffcba33b29de">
         </testcase>
-        <testcase name="testLoadGenres()" classname="SearchOptionsViewModelTests" time="0.001" id="0f096556-ca74-5d07-b95c-6554d0cf3b5d">
+        <testcase name="testLoadGenres()" time="0.001" id="9a583887-1eb2-513e-a67b-5b7d8a1f98ec">
         </testcase>
-        <testcase name="testLoadVisitedMoviesUpdate()" classname="SearchOptionsViewModelTests" time="0.001" id="bae292a9-e604-5114-a2ba-3f88e93230dd">
+        <testcase name="testLoadVisitedMoviesUpdate()" time="0.001" id="2c9b3832-b2e0-5e74-bb47-d288ef1a3d00">
         </testcase>
-        <testcase name="testGetAccountDetailSuccessInfoNotReloaded()" classname="ProfileViewModelTests" time="1.003" id="c5bfca43-6b2c-5b29-a1ca-31308c558096">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.ProfileViewModelTests" tests="9" disabled="0" errors="0" failures="0">
+        <testcase name="testGetAccountDetailSuccessInfoNotReloaded()" time="1.000" id="c61aae9a-b4bb-5c13-a6fd-719bfbb144a7">
         </testcase>
-        <testcase name="testSectionIndex()" classname="ProfileViewModelTests" time="0.001" id="cba1f9de-2d8e-5a40-af74-838426dc9ca0">
+        <testcase name="testSectionIndex()" time="0.001" id="9d3f4d2c-3426-5f60-b550-3acfa107c1b1">
         </testcase>
-        <testcase name="testCustomListsOptionIndex()" classname="ProfileViewModelTests" time="0.001" id="ffc22d8d-4a81-5459-a593-fd9b42949c83">
+        <testcase name="testCustomListsOptionIndex()" time="0.001" id="354904d8-aee0-5c54-bf3a-b85f92b3e182">
         </testcase>
-        <testcase name="testSignOutUserSuccess()" classname="ProfileViewModelTests" time="0.001" id="40872050-059b-510d-97e2-cb857b617463">
+        <testcase name="testSignOutUserSuccess()" time="0.001" id="b47aa25d-678b-53a0-b309-565e680e88c3">
         </testcase>
-        <testcase name="testSignOutUserError()" classname="ProfileViewModelTests" time="0.001" id="b80f7391-482f-5c6d-a968-822cb24efe73">
+        <testcase name="testSignOutUserError()" time="0.001" id="bae24d46-b433-5558-b359-509ed8424fa2">
         </testcase>
-        <testcase name="testNumberOfSections()" classname="ProfileViewModelTests" time="0.001" id="35f2d4f8-1c45-5206-a932-1db88477898f">
+        <testcase name="testNumberOfSections()" time="0.001" id="2fad2218-98f9-58e8-af73-4f74f5aaa170">
         </testcase>
-        <testcase name="testGetAccountDetailError()" classname="ProfileViewModelTests" time="1.004" id="93ed8050-799f-5590-8994-f37b30a61b2e">
+        <testcase name="testGetAccountDetailError()" time="1.000" id="16730350-7465-5abf-8c6e-587e511e4dec">
         </testcase>
-        <testcase name="testGetAccountDetailSuccessInfoReloaded()" classname="ProfileViewModelTests" time="0.002" id="a9c46fda-11eb-5b06-a2c4-e3113193cdb7">
+        <testcase name="testGetAccountDetailSuccessInfoReloaded()" time="0.002" id="f45c70dc-47e5-51c7-b4a3-ab9417cfb692">
         </testcase>
-        <testcase name="testCollectionOptionIndex()" classname="ProfileViewModelTests" time="0.002" id="531c3afe-b7d0-5359-a392-6f97dce1caaf">
+        <testcase name="testCollectionOptionIndex()" time="0.002" id="9951ebd0-ab73-54ce-b6c3-13d3a001180e">
         </testcase>
-        <testcase name="testDidSelectRowDefaultSearchesSection()" classname="SearchOptionsViewControllerTests" time="0.005" id="29759691-dbf6-5212-8d7e-2816c25b7f56">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SearchOptionsViewControllerTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testDidSelectRowDefaultSearchesSection()" time="0.005" id="7df27143-346f-56c0-add4-dc5ac368b4f8">
         </testcase>
-        <testcase name="testDidSelectRowRecentlyVisitedSection()" classname="SearchOptionsViewControllerTests" time="0.003" id="b0723afd-ee02-59ba-8412-4c215c41f78e">
+        <testcase name="testDidSelectRowRecentlyVisitedSection()" time="0.003" id="9e1d5263-9c2a-5b15-bfec-d995df2f65ac">
         </testcase>
-        <testcase name="testHeightForRowRecentlyVisitedSection()" classname="SearchOptionsViewControllerTests" time="0.003" id="bddb73d1-2fd5-5b52-b2cc-4e33c935d578">
+        <testcase name="testHeightForRowRecentlyVisitedSection()" time="0.003" id="81f602f3-a4e8-5bb9-ba22-5a54e81f7ae3">
         </testcase>
-        <testcase name="testDidSelectRowGenresSection()" classname="SearchOptionsViewControllerTests" time="0.001" id="f0a715c4-2e0b-5f0b-bba7-153984313799">
+        <testcase name="testDidSelectRowGenresSection()" time="0.001" id="74918717-8d2d-5c21-9cc8-fbaeb5bc0276">
         </testcase>
-        <testcase name="testHeightForRowDefaultSearchesSection()" classname="SearchOptionsViewControllerTests" time="0.001" id="1860334f-de49-592e-a166-dfc53b5ab68c">
+        <testcase name="testHeightForRowDefaultSearchesSection()" time="0.001" id="f275e7be-7182-570d-aa71-d784afcce967">
         </testcase>
-        <testcase name="testHeightForRowGenresSection()" classname="SearchOptionsViewControllerTests" time="0.001" id="964f8454-a244-51c8-a487-707b5cc1ef32">
+        <testcase name="testHeightForRowGenresSection()" time="0.001" id="71577981-3e13-5b08-95a8-ef7a04f8365c">
         </testcase>
-        <testcase name="testCreateNavigationController()" classname="MainTabBarBuilderTests" time="0.000" id="7cb1cebe-97cf-58e7-babb-3aa0f0f9a318">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MainTabBarBuilderTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testCreateNavigationController()" time="0.000" id="a46a231d-b30a-5ca3-93b1-cd37bb4210c8">
         </testcase>
-        <testcase name="testRootCoordinatorIdentifier()" classname="MainTabBarBuilderTests" time="0.000" id="75a221da-4659-5dad-b868-362f4a461473">
+        <testcase name="testRootCoordinatorIdentifier()" time="0.000" id="1bfc152f-04ee-5063-bf12-4f8865ddadd1">
         </testcase>
-        <testcase name="testBuildViewCoordinators()" classname="MainTabBarBuilderTests" time="0.006" id="c4bffbe6-6ab3-5ae6-b2ce-1898925f66cb">
+        <testcase name="testBuildViewCoordinators()" time="0.006" id="965f709f-6f09-5c77-8dfb-52bbb26324c3">
         </testcase>
-        <testcase name="testNumberOfSections()" classname="MovieCreditsViewModelTests" time="0.000" id="41f3a88e-4ea2-521b-a4aa-dd3f19994180">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieCreditsViewModelTests" tests="10" disabled="0" errors="0" failures="0">
+        <testcase name="testNumberOfSections()" time="0.000" id="e5dfd624-739f-5a14-922d-1edad846f3c8">
         </testcase>
-        <testcase name="testEmptyCreditResultsTitle()" classname="MovieCreditsViewModelTests" time="0.000" id="297fc03c-798a-5d49-9bc0-fae033c3e916">
+        <testcase name="testEmptyCreditResultsTitle()" time="0.000" id="87e7d3c9-1d95-5956-9706-428c02448cef">
         </testcase>
-        <testcase name="testToggleOpenedSection()" classname="MovieCreditsViewModelTests" time="0.001" id="62d16e64-6b28-5142-a87b-d70fdd3de4f2">
+        <testcase name="testToggleOpenedSection()" time="0.001" id="fe93fbcd-6893-538c-a4dd-e4535b3c5e2e">
         </testcase>
-        <testcase name="testNumberOfItemsCrewSection()" classname="MovieCreditsViewModelTests" time="0.001" id="6e2504f7-f688-5575-bfbe-7f7f14019719">
+        <testcase name="testNumberOfItemsCrewSection()" time="0.001" id="84ae8f0f-76d0-5b79-abb9-da71040429ce">
         </testcase>
-        <testcase name="testNumberOfItemsCastSection()" classname="MovieCreditsViewModelTests" time="0.000" id="571a1e7c-dd1a-561a-924f-901417ad7754">
+        <testcase name="testNumberOfItemsCastSection()" time="0.000" id="a3e583f7-9d1d-58a0-bfd5-220d192f99f8">
         </testcase>
-        <testcase name="testMovieCreditsTitle()" classname="MovieCreditsViewModelTests" time="0.000" id="6d229110-5088-5a45-a5ed-bd2c310f6ca6">
+        <testcase name="testMovieCreditsTitle()" time="0.000" id="a83e0723-0a80-55a1-9ed6-9bbff4b5e207">
         </testcase>
-        <testcase name="testGetMovieCreditsPopulated()" classname="MovieCreditsViewModelTests" time="0.001" id="f78dadc7-865e-57df-a083-5eec3e5c78f2">
+        <testcase name="testGetMovieCreditsPopulated()" time="0.001" id="72c7d344-d398-5355-9eee-2a41304915a6">
         </testcase>
-        <testcase name="testGetMovieCreditsEmpty()" classname="MovieCreditsViewModelTests" time="0.000" id="850f089e-c786-5805-ad7f-f97969220f1f">
+        <testcase name="testGetMovieCreditsEmpty()" time="0.000" id="d7267e3b-6dfb-5aef-8576-19e2c11314bd">
         </testcase>
-        <testcase name="testGetMovieCreditsError()" classname="MovieCreditsViewModelTests" time="0.000" id="dba3f60e-480d-502f-b95e-f5d37bfe2b2f">
+        <testcase name="testGetMovieCreditsError()" time="0.000" id="e0976d6e-0b5c-5b21-a1b6-6c89ca228d3d">
         </testcase>
-        <testcase name="testToggleClosedSection()" classname="MovieCreditsViewModelTests" time="0.000" id="4d137363-d3d9-5726-89ca-d088426cfdd5">
+        <testcase name="testToggleClosedSection()" time="0.000" id="760c6099-d9d3-5bb1-bfa9-168fe83dd35f">
         </testcase>
-        <testcase name="testMovieDetailBackdropURL()" classname="MovieDetailPosterViewModelTests" time="0.000" id="4f50ce1d-7d04-5b98-951e-eabcc32bdfe4">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailPosterViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieDetailBackdropURL()" time="0.000" id="ef2a5995-cd65-5567-8fe0-b10e28ab6776">
         </testcase>
-        <testcase name="testMovieDetailPosterURL()" classname="MovieDetailPosterViewModelTests" time="0.000" id="9d8d1d5d-bef8-5391-ade3-69b048d8b88c">
+        <testcase name="testMovieDetailPosterURL()" time="0.000" id="483645fa-b434-523d-87a0-9b55390b5ff5">
         </testcase>
-        <testcase name="testShowSharingOptions()" classname="MovieDetailCoordinatorTests" time="0.001" id="13f01c86-9fc0-587c-aada-0077b4d38c49">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailCoordinatorTests" tests="17" disabled="0" errors="0" failures="0">
+        <testcase name="testShowSharingOptions()" time="0.002" id="5ab6ceac-4f6f-5f4a-94ae-c9d800b106c0">
         </testcase>
-        <testcase name="testMultipleEmbedMovieDetailPosterShouldNotAddMoreThanOneChild()" classname="MovieDetailCoordinatorTests" time="0.005" id="91b0b4b9-c9de-5fab-887c-60bb7c607914">
+        <testcase name="testMultipleEmbedMovieDetailPosterShouldNotAddMoreThanOneChild()" time="0.005" id="34e95d75-8081-5c3c-baad-15e8580fa17e">
         </testcase>
-        <testcase name="testEmbedMovieDetailOptionsWithRenderContent()" classname="MovieDetailCoordinatorTests" time="0.002" id="485b1532-07f0-522e-adfc-3a70e0fce34a">
+        <testcase name="testEmbedMovieDetailOptionsWithRenderContent()" time="0.002" id="8e1a5df5-194d-584e-a542-17f9eb564482">
         </testcase>
-        <testcase name="testBuildWithPartialMovieInfo()" classname="MovieDetailCoordinatorTests" time="0.004" id="98deac05-0b74-518a-9876-41686f751183">
+        <testcase name="testBuildWithPartialMovieInfo()" time="0.004" id="43c64ceb-47e8-577b-b500-1029fa306bf8">
         </testcase>
-        <testcase name="testShowVideosMovieOptions()" classname="MovieDetailCoordinatorTests" time="0.002" id="a6ad771d-6470-5d5c-aad9-0e8976f429e9">
+        <testcase name="testShowVideosMovieOptions()" time="0.002" id="0b7e0b5e-d6c6-5412-a9d7-00abfb8edcf9">
         </testcase>
-        <testcase name="testMultipleEmbedMovieDetailTitleShouldNotAddMoreThanOneChild()" classname="MovieDetailCoordinatorTests" time="0.005" id="6aa027ba-713a-5080-92d4-cfed01ebfc9d">
+        <testcase name="testMultipleEmbedMovieDetailTitleShouldNotAddMoreThanOneChild()" time="0.005" id="05a039e3-ba92-58f7-ac21-92c4afd57211">
         </testcase>
-        <testcase name="testShowCreditsMovieOptions()" classname="MovieDetailCoordinatorTests" time="0.002" id="1eaf299e-26fe-5e35-ba19-e9c31dc68574">
+        <testcase name="testShowCreditsMovieOptions()" time="0.002" id="79a6cbf4-6d6f-5f69-914f-ab548e496294">
         </testcase>
-        <testcase name="testEmbedMovieDetailPoster()" classname="MovieDetailCoordinatorTests" time="0.001" id="6e35867c-67ee-55c1-b4c2-9c826482307a">
+        <testcase name="testEmbedMovieDetailPoster()" time="0.001" id="2ae1f991-7955-5eaa-ba5a-ff3bad0ef889">
         </testcase>
-        <testcase name="testEmbedMovieDetailPosterWithRenderContent()" classname="MovieDetailCoordinatorTests" time="0.001" id="6729ef4c-2235-5123-843a-824177bf950d">
+        <testcase name="testEmbedMovieDetailPosterWithRenderContent()" time="0.001" id="44a48676-abd8-5ebf-8042-d616a5aaca86">
         </testcase>
-        <testcase name="testEmbedMovieDetailOptions()" classname="MovieDetailCoordinatorTests" time="0.001" id="e68eb89c-b65d-5d5a-91b0-2302e8653356">
+        <testcase name="testEmbedMovieDetailOptions()" time="0.001" id="62deebc6-a25d-5051-983b-8da801f71f0f">
         </testcase>
-        <testcase name="testBuildWithCompleteMovieInfo()" classname="MovieDetailCoordinatorTests" time="0.001" id="a66cbbd2-533a-5c0c-bf4f-0bc23dbd10a1">
+        <testcase name="testBuildWithCompleteMovieInfo()" time="0.001" id="feeb8291-9a83-5cca-8a26-b33cafd2ce74">
         </testcase>
-        <testcase name="testEmbedMovieDetailTitle()" classname="MovieDetailCoordinatorTests" time="0.002" id="ae1400b7-b046-5d26-9136-260940cba51b">
+        <testcase name="testEmbedMovieDetailTitle()" time="0.002" id="2aefcd3c-0156-55b7-9cfc-2cac9f1839a7">
         </testcase>
-        <testcase name="testShowSimilarMoviesMovieOptions()" classname="MovieDetailCoordinatorTests" time="0.001" id="8dafb0f2-76d2-5e8e-8701-b5c7a7174856">
+        <testcase name="testShowSimilarMoviesMovieOptions()" time="0.001" id="7088dcc2-71e5-57bb-924b-4e28a551e5f8">
         </testcase>
-        <testcase name="testShowReviewsMovieOptions()" classname="MovieDetailCoordinatorTests" time="0.001" id="b8058d11-d040-5c2b-aee5-5c5ccffb5c8d">
+        <testcase name="testShowReviewsMovieOptions()" time="0.001" id="928c44ec-db71-5fce-9767-a59f4d61e930">
         </testcase>
-        <testcase name="testMultipleEmbedMovieDetailOptionsShouldNotAddMoreThanOneChild()" classname="MovieDetailCoordinatorTests" time="0.002" id="e37be967-8b28-5420-931d-d89ab6941362">
+        <testcase name="testMultipleEmbedMovieDetailOptionsShouldNotAddMoreThanOneChild()" time="0.002" id="b1ab5edc-811b-5b50-8684-219294be31c4">
         </testcase>
-        <testcase name="testEmbedMovieDetailTitleWithRenderContent()" classname="MovieDetailCoordinatorTests" time="0.001" id="c1986927-932e-5f1c-99bf-7aa352a0fe41">
+        <testcase name="testEmbedMovieDetailTitleWithRenderContent()" time="0.001" id="c5df2385-7c57-5e7f-988d-fafbf82a912b">
         </testcase>
-        <testcase name="testShowActionSheet()" classname="MovieDetailCoordinatorTests" time="0.001" id="ce5a196a-8066-5073-ac99-a2c02bacc8d0">
+        <testcase name="testShowActionSheet()" time="0.001" id="900f5047-96b1-5efa-bcae-04f56bc160f8">
         </testcase>
-        <testcase name="testListName()" classname="CustomListDetailViewModelTests" time="0.000" id="a3bece8d-c92a-5189-88d1-f5894d4cc3cb">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.CustomListDetailViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testListName()" time="0.000" id="4b3b1eaf-fb43-5764-8185-60a0bcfb57f9">
         </testcase>
-        <testcase name="testEmptyMovieResultsTitle()" classname="CustomListDetailViewModelTests" time="0.000" id="fe94bbc8-e21d-54f5-8a48-b819a9082cbe">
+        <testcase name="testEmptyMovieResultsTitle()" time="0.000" id="45038369-e210-5d1a-a95f-30b982a982dd">
         </testcase>
-        <testcase name="testGenreName()" classname="MovieListCellViewModelTests" time="0.000" id="2ccd100b-8f9a-5493-a4fd-14ec0b01dd5c">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieListCellViewModelTests" tests="5" disabled="0" errors="0" failures="0">
+        <testcase name="testGenreName()" time="0.000" id="ea5bc95b-824c-5840-97b9-ded11da03d61">
         </testcase>
-        <testcase name="testPosterURL()" classname="MovieListCellViewModelTests" time="0.000" id="1fbce9cb-fe6b-5ccd-9bf6-1347efbe61e3">
+        <testcase name="testPosterURL()" time="0.000" id="87813376-c1c5-5e07-8be9-1d01ea07ec3b">
         </testcase>
-        <testcase name="testReleaseDate()" classname="MovieListCellViewModelTests" time="0.000" id="e1c76623-603a-5cf1-b120-e9c4d92fc242">
+        <testcase name="testReleaseDate()" time="0.000" id="794d2247-071a-5b3c-b715-1fad01bf56b7">
         </testcase>
-        <testcase name="testVoteAverage()" classname="MovieListCellViewModelTests" time="0.000" id="8866dc21-5607-5b85-8b8f-e3f9815f76ff">
+        <testcase name="testVoteAverage()" time="0.000" id="7074a95e-7000-5b52-a1c8-03bef745a1c7">
         </testcase>
-        <testcase name="testName()" classname="MovieListCellViewModelTests" time="0.000" id="71dc9036-e17e-57b6-bc75-75aa76960cfb">
+        <testcase name="testName()" time="0.000" id="706f3783-9cd7-5b3c-b4aa-a4701bf15914">
         </testcase>
-        <testcase name="testGetCustomListsEmpty()" classname="CustomListsViewModelTests" time="0.001" id="2a8bcef9-0542-53ab-b72d-45239670800e">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.CustomListsViewModelTests" tests="5" disabled="0" errors="0" failures="0">
+        <testcase name="testGetCustomListsEmpty()" time="0.001" id="c3db43ad-3cc9-5f67-8ca8-837b9138df1f">
         </testcase>
-        <testcase name="testGetCustomListsPopulated()" classname="CustomListsViewModelTests" time="0.001" id="04eebb19-98a8-55a7-9e0e-f8397a7d8696">
+        <testcase name="testGetCustomListsPopulated()" time="0.001" id="d47d3f2e-e8e2-5921-bc52-245d90303b54">
         </testcase>
-        <testcase name="testGetCustomListsPaging()" classname="CustomListsViewModelTests" time="0.000" id="be09bdee-3fdb-539f-8c5c-08598c42ea3a">
+        <testcase name="testGetCustomListsPaging()" time="0.000" id="6fad3070-4935-54ee-950a-160a9f409b84">
         </testcase>
-        <testcase name="testTitle()" classname="CustomListsViewModelTests" time="0.000" id="b4608911-8a73-5fe9-958b-94975683b6c0">
+        <testcase name="testTitle()" time="0.000" id="4785341f-0b4e-51a3-a9cb-befbdb3836de">
         </testcase>
-        <testcase name="testGetCustomListsError()" classname="CustomListsViewModelTests" time="0.000" id="c74fe452-181b-5485-883d-b6b7da272380">
+        <testcase name="testGetCustomListsError()" time="0.000" id="f5a9d6af-8a44-53cc-b792-b2dc31689c7c">
         </testcase>
-        <testcase name="testBuild()" classname="SimilarMoviesCoordinatorTests" time="0.001" id="3b44c63e-f5b9-5a4c-9665-2e4d386f5f52">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SimilarMoviesCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.001" id="94ff97b2-dec6-5248-bb64-03944e1ad103">
         </testcase>
-        <testcase name="testMovieDetailOptionsReviews()" classname="MovieDetailOptionTests" time="0.000" id="45323688-f5eb-5ffc-ba76-7fbcd5503c7b">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailOptionTests" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieDetailOptionsReviews()" time="0.000" id="dda36f74-ee41-5afd-b14f-17729e1ed182">
         </testcase>
-        <testcase name="testMovieDetailOptionsCredits()" classname="MovieDetailOptionTests" time="0.000" id="aefd7af5-51f8-55c5-95ed-58e9270254ad">
+        <testcase name="testMovieDetailOptionsCredits()" time="0.000" id="8c3a84e7-6d53-59d9-87f4-3907d6661f2b">
         </testcase>
-        <testcase name="testMovieDetailOptionsSimilarMovies()" classname="MovieDetailOptionTests" time="0.000" id="5bfd928d-cc41-5792-8e15-423a373f2dee">
+        <testcase name="testMovieDetailOptionsSimilarMovies()" time="0.000" id="675520ae-bc65-532e-a560-73014396c235">
         </testcase>
-        <testcase name="testMovieDetailOptionsTrailers()" classname="MovieDetailOptionTests" time="0.000" id="ba044eee-581c-574f-b0fb-11fcfc1dec12">
+        <testcase name="testMovieDetailOptionsTrailers()" time="0.000" id="3e04134d-0d3b-576b-adf5-077f79835574">
         </testcase>
-        <testcase name="testBuild()" classname="MovieDetailOptionsCoordinatorTests" time="0.002" id="10bc29a6-f81c-5fb7-8482-55831d77f7ac">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailOptionsCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.002" id="9d8d748c-79a9-5dae-9a22-f55edcbceef9">
         </testcase>
-        <testcase name="testDidUpdateAuthenticationState()" classname="SignInViewControllerTests" time="1.006" id="d3539d1f-61ef-5713-a0a1-74f3a2a790c9">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SignInViewControllerTests" tests="5" disabled="0" errors="0" failures="0">
+        <testcase name="testDidUpdateAuthenticationState()" time="1.000" id="0963971a-6750-5299-a94c-f29ebf031ea0">
         </testcase>
-        <testcase name="testDidReceiveAuthorizationTrue()" classname="SignInViewControllerTests" time="0.008" id="9ec863ad-9863-5f5d-b90b-f5b7f9a649f9">
+        <testcase name="testDidReceiveAuthorizationTrue()" time="0.008" id="e0a458b7-8ba7-5d43-b8b7-8de297939961">
         </testcase>
-        <testcase name="testShowAuthPermission()" classname="SignInViewControllerTests" time="1.006" id="24e67076-f144-5b5e-9385-715fbb46527a">
+        <testcase name="testShowAuthPermission()" time="1.000" id="7d63ad29-7afa-50aa-846d-782ff9767867">
         </testcase>
-        <testcase name="testCloseBarButtonAction()" classname="SignInViewControllerTests" time="0.003" id="30bff2f4-e790-59b6-829d-f6ff6b1bfded">
+        <testcase name="testCloseBarButtonAction()" time="0.003" id="e4d230ce-20b1-52b3-b052-82fdf759ad50">
         </testcase>
-        <testcase name="testDidReceiveAuthorizationFalse()" classname="SignInViewControllerTests" time="0.003" id="0d9a576b-429f-5f72-bba2-02272763d96b">
+        <testcase name="testDidReceiveAuthorizationFalse()" time="0.003" id="c5d009b1-01ed-5cd9-bd34-54649f9ee436">
         </testcase>
-        <testcase name="testBuild()" classname="MoviesByGenreCoordinatorTests" time="0.010" id="a434482a-8a4c-5123-9331-5d50e9804965">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MoviesByGenreCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.010" id="a3a4021a-8f90-5534-99d0-0f69980ba020">
         </testcase>
-        <testcase name="testRatingText()" classname="CustomListDetailSectionViewModelTests" time="0.001" id="71241a99-03c6-5069-bd60-74b8b6228df7">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.CustomListDetailSectionViewModelTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testRatingText()" time="0.001" id="edbafed5-98bd-54c2-a386-82715fe5869e">
         </testcase>
-        <testcase name="testMovieRevenueTextHundredValue()" classname="CustomListDetailSectionViewModelTests" time="0.001" id="2d640263-56a8-5404-8302-3494eacfbe63">
+        <testcase name="testMovieRevenueTextHundredValue()" time="0.001" id="df4eb79a-f3aa-52af-9b35-29e40ceebe1a">
         </testcase>
-        <testcase name="testMovieRevenueTextMillionValue()" classname="CustomListDetailSectionViewModelTests" time="0.000" id="b88f9705-7547-59a8-8206-b9efdfd63340">
+        <testcase name="testMovieRevenueTextMillionValue()" time="0.000" id="ce5fb2d9-50de-582d-b079-f13bd516b940">
         </testcase>
-        <testcase name="testMovieCountText()" classname="CustomListDetailSectionViewModelTests" time="0.000" id="0e3fdb37-3967-5f4c-b6c7-30cbf58516af">
+        <testcase name="testMovieCountText()" time="0.000" id="e44fef36-8675-5a33-be63-76a03c33d8a8">
         </testcase>
-        <testcase name="testMovieRuntimeText()" classname="CustomListDetailSectionViewModelTests" time="0.000" id="fff816bb-32c7-52dd-b7ea-d05c96815cc8">
+        <testcase name="testMovieRuntimeText()" time="0.000" id="6c6b0c2c-5224-50f2-84b7-11cba8428dae">
         </testcase>
-        <testcase name="testMovieRevenueTextThousandValue()" classname="CustomListDetailSectionViewModelTests" time="0.000" id="d6632d58-63f3-5d61-a376-626be76dd8a7">
+        <testcase name="testMovieRevenueTextThousandValue()" time="0.000" id="5897311e-8a81-5ffc-a240-e998977e67c3">
         </testcase>
-        <testcase name="testCrewSection()" classname="MovieCreditsFactoryTests" time="0.000" id="46f8b4da-8431-5a78-87e4-e21b35c21d6c">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieCreditsFactoryTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testCrewSection()" time="0.000" id="24af97ed-565e-53f5-9072-3d126884a920">
         </testcase>
-        <testcase name="testCastSection()" classname="MovieCreditsFactoryTests" time="0.000" id="51c81277-9c3e-5a30-8429-8daac4240c0e">
+        <testcase name="testCastSection()" time="0.000" id="1799a9c2-383f-5292-a1ce-a3cc18d014c3">
         </testcase>
-        <testcase name="testInitWithGenre()" classname="GenreModelTests" time="0.001" id="ef80a6c7-283d-5c2a-813f-944ce3e2f368">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.GenreModelTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testInitWithGenre()" time="0.001" id="01d167b5-33a2-5441-aa9d-dd568177f684">
         </testcase>
-        <testcase name="testBuild()" classname="MovieVideosCoordinatorTests" time="0.003" id="49f0fb99-6071-5089-8542-d20ea1a78504">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieVideosCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.003" id="bd5925df-9d67-5574-8648-9dcf8059031b">
         </testcase>
-        <testcase name="testEmbedSearchController()" classname="SearchMoviesCoordinatorTests" time="0.009" id="f1c3ab11-0203-5beb-acf4-5fc0798611df">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SearchMoviesCoordinatorTests" tests="8" disabled="0" errors="0" failures="0">
+        <testcase name="testEmbedSearchController()" time="0.009" id="3fb030eb-d393-50b9-8260-3ddeeada16e9">
         </testcase>
-        <testcase name="testBuild()" classname="SearchMoviesCoordinatorTests" time="0.002" id="98dd4057-d34f-5c25-a9c5-9e48dc268c03">
+        <testcase name="testBuild()" time="0.002" id="1fdf1df5-d954-5483-90e5-e75be5db386e">
         </testcase>
-        <testcase name="testShowTopRatedMovies()" classname="SearchMoviesCoordinatorTests" time="0.001" id="9da4c804-7000-5f74-b745-91002f2c65f1">
+        <testcase name="testShowTopRatedMovies()" time="0.002" id="f0b34115-1122-5476-ad22-70b0f1e1c2e2">
         </testcase>
-        <testcase name="testShowMovieDetail()" classname="SearchMoviesCoordinatorTests" time="0.003" id="b30cbf91-da2d-5fe1-b07b-06f568f54b1a">
+        <testcase name="testShowMovieDetail()" time="0.003" id="19096181-3e1e-5c31-9730-d596fbffbb7b">
         </testcase>
-        <testcase name="testRootIdentifier()" classname="SearchMoviesCoordinatorTests" time="0.001" id="c0eb90cc-33ad-5c91-b888-01750f1ea747">
+        <testcase name="testRootIdentifier()" time="0.001" id="1689f1df-99c8-50aa-8859-40e8384426d5">
         </testcase>
-        <testcase name="testEmbedSearchOptions()" classname="SearchMoviesCoordinatorTests" time="0.005" id="0a4bfec0-139f-5aa4-9add-0584f8fc06f0">
+        <testcase name="testEmbedSearchOptions()" time="0.005" id="954a4696-13e1-5e60-a197-3a7fe95235d4">
         </testcase>
-        <testcase name="testShowMoviesByGenre()" classname="SearchMoviesCoordinatorTests" time="0.001" id="24873378-fbe4-51b4-91ec-9e136b0235cd">
+        <testcase name="testShowMoviesByGenre()" time="0.001" id="c743d3dc-2d20-52c0-82fe-63533fe0a261">
         </testcase>
-        <testcase name="testShowPopularMovies()" classname="SearchMoviesCoordinatorTests" time="0.001" id="0e41ba57-5ed8-56d3-aff2-ba0b05fd5bb8">
+        <testcase name="testShowPopularMovies()" time="0.001" id="4cab850a-fc80-591b-9762-abe70f7969c1">
         </testcase>
-        <testcase name="testProfileURLForCreditModelCreatedWithCrew()" classname="MovieCreditCellViewModelTests" time="0.001" id="47ffc60f-078c-5a8a-b45c-70916a0dbd52">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieCreditCellViewModelTests" tests="6" disabled="0" errors="0" failures="0">
+        <testcase name="testProfileURLForCreditModelCreatedWithCrew()" time="0.001" id="5618edf4-6d0d-52dd-aa60-9ab5724890a4">
         </testcase>
-        <testcase name="testNameForCreditModelCreatedWithCrew()" classname="MovieCreditCellViewModelTests" time="0.000" id="2140b812-c17d-55d8-91f8-58da63b7ce75">
+        <testcase name="testNameForCreditModelCreatedWithCrew()" time="0.000" id="a80497d0-1067-5b98-bfd6-42f5ca63d3db">
         </testcase>
-        <testcase name="testNameForCreditModelCreatedWithCast()" classname="MovieCreditCellViewModelTests" time="0.001" id="a104a599-d72d-5376-aa92-1bda40bf6001">
+        <testcase name="testNameForCreditModelCreatedWithCast()" time="0.001" id="2660fd5e-7b03-54e2-8ff2-b61dbf7cfb5d">
         </testcase>
-        <testcase name="testRoleForCreditModelCreatedWithCrew()" classname="MovieCreditCellViewModelTests" time="0.000" id="a584828c-72c7-5cb1-8c5e-4507a7c99100">
+        <testcase name="testRoleForCreditModelCreatedWithCrew()" time="0.000" id="76611032-1758-5dab-9b05-657d19acfd97">
         </testcase>
-        <testcase name="testProfileURLForCreditModelCreatedWithCast()" classname="MovieCreditCellViewModelTests" time="0.001" id="5630513e-5b42-5cfc-8b82-825c2a47a53d">
+        <testcase name="testProfileURLForCreditModelCreatedWithCast()" time="0.001" id="33ac9bc6-037b-5b20-bfbf-5d81c3e82ade">
         </testcase>
-        <testcase name="testRoleForCreditModelCreatedWithCast()" classname="MovieCreditCellViewModelTests" time="0.000" id="17a5a6b0-ddd1-5b24-84e4-fc78ce2635a1">
+        <testcase name="testRoleForCreditModelCreatedWithCast()" time="0.000" id="5b82cbc3-39b1-514f-b8d1-c23f1a5b021a">
         </testcase>
-        <testcase name="testBuild()" classname="MovieDetailTitleCoordinatorTests" time="0.003" id="a3ac9630-6103-5ed6-829c-d723015647fa">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailTitleCoordinatorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testBuild()" time="0.003" id="b1e56fd4-439f-5076-ade6-a220b53c0bda">
         </testcase>
-        <testcase name="testNameForVideoModel()" classname="MovieVideoCellViewModelTests" time="0.000" id="9f84462f-581a-597b-8c49-d692c7a209bb">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieVideoCellViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testNameForVideoModel()" time="0.000" id="d1a6e93e-75c3-5e66-a496-34c4849c9f65">
         </testcase>
-        <testcase name="testThumbnailURLForVideoModel()" classname="MovieVideoCellViewModelTests" time="0.000" id="d627d5b0-abfe-5718-8782-526211835a44">
+        <testcase name="testThumbnailURLForVideoModel()" time="0.000" id="80d1388b-b621-5452-af68-db457bf845ea">
         </testcase>
-        <testcase name="testMovieDetailOverview()" classname="MovieDetailViewModelTests" time="0.000" id="d9adda4f-76df-5d1d-9863-b89bdc3bc61e">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieDetailViewModelTests" tests="29" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieDetailOverview()" time="0.000" id="1ea0cedb-74e8-51b4-aec9-379adbe25e0d">
         </testcase>
-        <testcase name="testSaveVisitedMovie()" classname="MovieDetailViewModelTests" time="0.001" id="7eb58a3f-275d-5f58-8b28-8a0b59daff63">
+        <testcase name="testSaveVisitedMovie()" time="0.001" id="5a664a78-8f19-5e18-91b4-ffc60a0abc0c">
         </testcase>
-        <testcase name="testRemoveFromWatchlistAlertActionSuccess()" classname="MovieDetailViewModelTests" time="0.001" id="b69de258-3738-5f22-9cf0-7abca3c1e50c">
+        <testcase name="testRemoveFromWatchlistAlertActionSuccess()" time="0.001" id="234a325f-a503-5f20-bc45-8d2da6cb38a7">
         </testcase>
-        <testcase name="testScreenTitle()" classname="MovieDetailViewModelTests" time="0.000" id="a0642dc0-19f2-51ef-ae17-6425cab464a9">
+        <testcase name="testScreenTitle()" time="0.000" id="a27d45ea-6aa8-5f57-9480-1fb0f9fec539">
         </testcase>
-        <testcase name="testDidSetupMovieDetailNeedsFetchFalse()" classname="MovieDetailViewModelTests" time="0.000" id="b5405d6d-861b-5d95-8637-894efbb09e6e">
+        <testcase name="testDidSetupMovieDetailNeedsFetchFalse()" time="0.000" id="bd02666e-c8a0-5c3c-bd49-81e5414becc7">
         </testcase>
-        <testcase name="testCheckMovieAccountStateSuccess()" classname="MovieDetailViewModelTests" time="0.001" id="196ef6cd-8fb9-5ed2-9b91-e0aec640a581">
+        <testcase name="testCheckMovieAccountStateSuccess()" time="0.001" id="cf90caf7-20eb-574c-a29d-d81801291e74">
         </testcase>
-        <testcase name="testGetMovieGenreNameNil()" classname="MovieDetailViewModelTests" time="0.000" id="393ddefc-b190-5ad8-a784-d9f422e7850b">
+        <testcase name="testGetMovieGenreNameNil()" time="0.000" id="7848066c-867f-5887-b2e1-a70fc975f929">
         </testcase>
-        <testcase name="testCheckMovieAccountStateIsUserSignedInFalse()" classname="MovieDetailViewModelTests" time="0.000" id="df539b46-34e4-5b91-ad00-4522dd89f530">
+        <testcase name="testCheckMovieAccountStateIsUserSignedInFalse()" time="0.000" id="637ce4f2-6f6d-521d-90e5-d9a259e3520d">
         </testcase>
-        <testcase name="testShowErrorRetryView()" classname="MovieDetailViewModelTests" time="0.000" id="851c964b-084f-5d5e-836e-fb4aff6e1792">
+        <testcase name="testShowErrorRetryView()" time="0.000" id="667207c4-3110-53f0-8a8c-c087c1428c0a">
         </testcase>
-        <testcase name="testGetMovieGenreNameWihtoutId()" classname="MovieDetailViewModelTests" time="0.000" id="c87efaf7-92fa-571c-91a9-e652a45731c6">
+        <testcase name="testGetMovieGenreNameWihtoutId()" time="0.000" id="3dc3766a-f5e2-5cb6-a803-8dd34dc93532">
         </testcase>
-        <testcase name="testHandleFavoriteMovieIsFavoriteFalseSuccessResponse()" classname="MovieDetailViewModelTests" time="0.001" id="54b4973b-9e9b-5e33-946f-6fc62e12104d">
+        <testcase name="testHandleFavoriteMovieIsFavoriteFalseSuccessResponse()" time="0.001" id="92a4ee1e-b392-5d0a-afbb-db807fbe3312">
         </testcase>
-        <testcase name="testAddToWatchlistAlertActionSuccess()" classname="MovieDetailViewModelTests" time="0.001" id="e77786d3-3b48-5135-aa7a-d573e1c14543">
+        <testcase name="testAddToWatchlistAlertActionSuccess()" time="0.001" id="21f0abc3-228f-570c-b3d0-1d59d15642f2">
         </testcase>
-        <testcase name="testShareAlertAction()" classname="MovieDetailViewModelTests" time="0.001" id="dcd8f092-d865-550c-8768-a3db3be717ce">
+        <testcase name="testShareAlertAction()" time="0.001" id="50345dda-41a7-5b47-a3f9-80ec8edd6457">
         </testcase>
-        <testcase name="testHandleFavoriteMovieIsFavoriteNilValue()" classname="MovieDetailViewModelTests" time="0.000" id="6ad05357-08e5-5d0f-b415-83aad44658e7">
+        <testcase name="testHandleFavoriteMovieIsFavoriteNilValue()" time="0.000" id="8e0b763b-7cdb-57cb-b210-aa2d5cf86edb">
         </testcase>
-        <testcase name="testGetAvailableAlertActionsWithNoAccountState()" classname="MovieDetailViewModelTests" time="0.000" id="25053558-c951-5a0e-bd3c-f8070ddb6c9a">
+        <testcase name="testGetAvailableAlertActionsWithNoAccountState()" time="0.000" id="110979e8-b8b9-54af-a46d-a94e59a10edb">
         </testcase>
-        <testcase name="testCheckMovieAccountStateError()" classname="MovieDetailViewModelTests" time="0.001" id="bf9ba2ab-2a4d-510f-baf3-8d2224b06422">
+        <testcase name="testCheckMovieAccountStateError()" time="0.001" id="58e6f481-291d-5bb9-8bc2-e16ecd991a02">
         </testcase>
-        <testcase name="testShareTitle()" classname="MovieDetailViewModelTests" time="0.001" id="68bc8218-65b8-5c6c-a200-4c9fbbd11f7e">
+        <testcase name="testShareTitle()" time="0.001" id="d6e37455-f3d7-5356-a480-4a87eb2b86b9">
         </testcase>
-        <testcase name="testGetMovieGenreName()" classname="MovieDetailViewModelTests" time="0.001" id="46769f11-d71c-53ff-8e3c-51cc9a1a3209">
+        <testcase name="testGetMovieGenreName()" time="0.001" id="1d22e636-a250-5eb2-976c-256d682d86d5">
         </testcase>
-        <testcase name="testGetAvailableAlertActionsWithAccountStateWatchlistTrue()" classname="MovieDetailViewModelTests" time="0.000" id="be9e088f-f40d-54ac-a89a-47f0034bad36">
+        <testcase name="testGetAvailableAlertActionsWithAccountStateWatchlistTrue()" time="0.000" id="940fcb41-c3c2-5fe2-8712-6708a70267b4">
         </testcase>
-        <testcase name="testMovieDetailTitle()" classname="MovieDetailViewModelTests" time="0.000" id="3c005af8-99ac-5270-8150-eec6ff6c2b05">
+        <testcase name="testMovieDetailTitle()" time="0.000" id="81379e23-9ad1-5ec9-b9e3-52d72ec064f9">
         </testcase>
-        <testcase name="testRemoveFromWatchlistAlertActionError()" classname="MovieDetailViewModelTests" time="0.006" id="4d68ee7f-052d-5483-878c-e126856e03fc">
+        <testcase name="testRemoveFromWatchlistAlertActionError()" time="0.006" id="e24361e9-0e5b-5b12-91de-4295db757e93">
         </testcase>
-        <testcase name="testHandleFavoriteMovieIsFavoriteFalseErrorResponse()" classname="MovieDetailViewModelTests" time="0.001" id="f6ee5ee8-9faa-55cc-a50d-d74e1032e8ff">
+        <testcase name="testHandleFavoriteMovieIsFavoriteFalseErrorResponse()" time="0.001" id="df8cff86-90ca-5edc-8621-8b9bb0182726">
         </testcase>
-        <testcase name="testMovieDetailReleaseDate()" classname="MovieDetailViewModelTests" time="0.000" id="f0d02c52-b43a-576d-b428-4b6ef2e661b3">
+        <testcase name="testMovieDetailReleaseDate()" time="0.000" id="ad5642ca-7481-5c5d-b314-1cbaf1922e03">
         </testcase>
-        <testcase name="testGetAvailableAlertActionsWithAccountStateWatchlistFalse()" classname="MovieDetailViewModelTests" time="0.000" id="cc6b1389-6b67-52f0-909c-56ae188a0c85">
+        <testcase name="testGetAvailableAlertActionsWithAccountStateWatchlistFalse()" time="0.000" id="423e6261-d6d2-54f3-8a0e-d9df03bf10a9">
         </testcase>
-        <testcase name="testAddToWatchlistAlertActionError()" classname="MovieDetailViewModelTests" time="0.000" id="c3d2b7d2-75e1-577e-a710-201f3c8fe6c2">
+        <testcase name="testAddToWatchlistAlertActionError()" time="0.000" id="c1920a13-774f-5351-9060-dfb3949c9597">
         </testcase>
-        <testcase name="testCancelTitle()" classname="MovieDetailViewModelTests" time="0.000" id="9454fa3e-8aaa-5494-a03c-c0361880985d">
+        <testcase name="testCancelTitle()" time="0.000" id="9a2f70ba-64d4-5b26-a872-2feb88c56d6b">
         </testcase>
-        <testcase name="testHandleFavoriteMovieIsFavoriteTrueErrorResponse()" classname="MovieDetailViewModelTests" time="0.001" id="6ac24ac9-3d57-5084-9bab-aed7577fb520">
+        <testcase name="testHandleFavoriteMovieIsFavoriteTrueErrorResponse()" time="0.001" id="8a1d2cac-86be-584a-a53e-36a490be7964">
         </testcase>
-        <testcase name="testHandleFavoriteMovieIsFavoriteTrueSuccessResponse()" classname="MovieDetailViewModelTests" time="0.000" id="4d5dc393-68bb-5f69-942e-3feeebe83895">
+        <testcase name="testHandleFavoriteMovieIsFavoriteTrueSuccessResponse()" time="0.001" id="5e066acc-5dfd-5e37-8a8e-8552498686e4">
         </testcase>
-        <testcase name="testDidSetupMovieDetail()" classname="MovieDetailViewModelTests" time="0.000" id="5c68026f-50b5-5429-ab1e-29517ac352f9">
+        <testcase name="testDidSetupMovieDetail()" time="0.000" id="6f5d39a7-def0-5072-ac87-e9054ed1ae56">
         </testcase>
-        <testcase name="testSetupNavigationControllerDelegateExistingDelegateShouldOverride()" classname="BaseCoordinatorTests" time="0.001" id="35de0c4d-c207-5122-9b6a-a55dabec03e6">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.BaseCoordinatorTests" tests="13" disabled="0" errors="0" failures="0">
+        <testcase name="testSetupNavigationControllerDelegateExistingDelegateShouldOverride()" time="0.001" id="4c81f504-85ed-55e1-80c7-80a799cf3d0b">
         </testcase>
-        <testcase name="testDismissEmbedWithoutContainerViewCoordinatorMode()" classname="BaseCoordinatorTests" time="0.001" id="7e86e4aa-2827-54f6-8ad2-79b726b8626d">
+        <testcase name="testDismissEmbedWithoutContainerViewCoordinatorMode()" time="0.001" id="be2a3fc5-2b76-5996-956e-1e5811b8eb6d">
         </testcase>
-        <testcase name="testDismissPushCoordinatorMode()" classname="BaseCoordinatorTests" time="0.000" id="c306029a-b747-53e5-aa03-04772577ea5b">
+        <testcase name="testDismissPushCoordinatorMode()" time="0.000" id="565d1a9c-2b59-538a-a233-57b4e2f54b21">
         </testcase>
-        <testcase name="testDismissPresentCoordinatorMode()" classname="BaseCoordinatorTests" time="0.000" id="23bfb2d3-43de-59de-bdc3-722ab0bf6bb5">
+        <testcase name="testDismissPresentCoordinatorMode()" time="0.000" id="81fa2f27-b5ca-577b-b317-5486c9134501">
         </testcase>
-        <testcase name="testStartEmbedWithContainerViewCoordinatorMode()" classname="BaseCoordinatorTests" time="0.001" id="a0e1deb6-3a4d-527c-8626-37a0a9380372">
+        <testcase name="testStartEmbedWithContainerViewCoordinatorMode()" time="0.001" id="86e4271a-1e5d-5f5e-a8fe-bd3949798be6">
         </testcase>
-        <testcase name="testNavigationControllerDidShowViewControllerContainedInStack()" classname="BaseCoordinatorTests" time="0.005" id="0420e5e6-8c65-5f13-9ce8-0a38ad4391bd">
+        <testcase name="testNavigationControllerDidShowViewControllerContainedInStack()" time="0.005" id="b47626c4-ce0e-51b2-9507-f63f7e2ec8ad">
         </testcase>
-        <testcase name="testStartPushCoordinatorMode()" classname="BaseCoordinatorTests" time="0.000" id="9eebad0b-52bf-543d-9c20-af9b7eea4524">
+        <testcase name="testStartPushCoordinatorMode()" time="0.000" id="e6c35bbb-a88d-5344-bb41-92c2aeae8b67">
         </testcase>
-        <testcase name="testNavigationControllerDidShowViewControllerIsBeingPresentedTrue()" classname="BaseCoordinatorTests" time="0.000" id="a172aa54-5123-51e1-9c46-1c668c7168aa">
+        <testcase name="testNavigationControllerDidShowViewControllerIsBeingPresentedTrue()" time="0.000" id="090841ca-0a70-5621-a28e-8574776a4908">
         </testcase>
-        <testcase name="testSetupNavigationControllerDelegateExistingDelegateShouldNotOverride()" classname="BaseCoordinatorTests" time="0.000" id="ad5d801d-f146-5d7f-89d5-dfe05d0046e2">
+        <testcase name="testSetupNavigationControllerDelegateExistingDelegateShouldNotOverride()" time="0.000" id="0da7c769-1c2c-5789-a6a9-0c5d3eaaa42b">
         </testcase>
-        <testcase name="testNavigationControllerDidShow()" classname="BaseCoordinatorTests" time="0.000" id="98b52fde-4d3d-5d10-b1b6-6aa62a7bc131">
+        <testcase name="testNavigationControllerDidShow()" time="0.000" id="409bcc1c-ded3-59d5-b914-731c4a06e06f">
         </testcase>
-        <testcase name="testSetupNavigationControllerDelegate()" classname="BaseCoordinatorTests" time="0.001" id="f5c15aff-dc9a-5743-96aa-41194f83e878">
+        <testcase name="testSetupNavigationControllerDelegate()" time="0.001" id="72324c37-5819-5aa9-b748-ea2f21c5ccf1">
         </testcase>
-        <testcase name="testStartPresentCoordinatorMode()" classname="BaseCoordinatorTests" time="0.000" id="9a62fe6a-6d9a-53c6-b2df-8abe5bc166c7">
+        <testcase name="testStartPresentCoordinatorMode()" time="0.000" id="9530925d-a9e1-5070-91e8-065ad726fed9">
         </testcase>
-        <testcase name="testStartEmbedWithoutContainerViewCoordinatorMode()" classname="BaseCoordinatorTests" time="0.000" id="d5790ef0-f8f6-5a5e-9f2d-fba88665fd38">
+        <testcase name="testStartEmbedWithoutContainerViewCoordinatorMode()" time="0.000" id="d755e265-2e5f-5163-9a9e-c0120f898ac7">
         </testcase>
-        <testcase name="testGetMovieCreditsCalled()" classname="MovieCreditsInteractorTests" time="0.000" id="cdbb4763-16a2-5b9f-a966-2751fc10fbb6">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieCreditsInteractorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testGetMovieCreditsCalled()" time="0.000" id="1a6f8798-b55f-5d4e-b6ad-df327d65bb34">
         </testcase>
-        <testcase name="testGetWatchlistCalled()" classname="WatchlistSavedMoviesInteractorTests" time="0.001" id="d44c8c83-e982-5b29-b12b-92c71851eba7">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.WatchlistSavedMoviesInteractorTests" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="testGetWatchlistCalled()" time="0.001" id="6b1af901-ddfe-544b-a4b7-65ccc8d912a2">
         </testcase>
-        <testcase name="testSignInUserError()" classname="SignInInteractorTests" time="0.000" id="7a8f90a3-0c7d-5212-b4ac-f13465628cd7">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.SignInInteractorTests" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="testSignInUserError()" time="0.000" id="428df60c-1999-5bf8-951e-b7ee9566eca1">
         </testcase>
-        <testcase name="testGetAuthPermissionURL()" classname="SignInInteractorTests" time="0.000" id="786f8513-2214-5f57-8b49-7d7942dfa060">
+        <testcase name="testGetAuthPermissionURL()" time="0.000" id="d33fdd1e-5b44-5ade-ba0e-749495d76915">
         </testcase>
-        <testcase name="testSignInUserSuccess()" classname="SignInInteractorTests" time="0.000" id="a46b8fcc-ee3e-524f-9b67-1339925a5077">
+        <testcase name="testSignInUserSuccess()" time="0.000" id="5f6db9d8-4c46-5fa3-9b06-ac36e2f81488">
         </testcase>
-        <testcase name="testMovieReviewCellAuthorName()" classname="MovieReviewCellViewModelTests" time="0.000" id="1353fbfd-7e42-5124-aa07-3b7aa5eff29f">
+    </testsuite>
+    <testsuite name="UpcomingMoviesTests.MovieReviewCellViewModelTests" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="testMovieReviewCellAuthorName()" time="0.000" id="5a4ebbd4-4c23-5981-a522-7e95ad13bcf9">
         </testcase>
-        <testcase name="testMovieReviewCellContent()" classname="MovieReviewCellViewModelTests" time="0.000" id="467e2d00-8765-5447-944c-5b1e98b9b010">
+        <testcase name="testMovieReviewCellContent()" time="0.000" id="8ecefba3-21f4-5af0-855d-a624b7a6817c">
         </testcase>
     </testsuite>
 </testsuites>

--- a/xcresult/tests/xcresult.rs
+++ b/xcresult/tests/xcresult.rs
@@ -107,7 +107,7 @@ fn test_complex_xcresult_with_valid_path() {
 fn test_xcresult_with_valid_path_invalid_os() {
     let path = TEMP_DIR_TEST_1.as_ref().join("test1.xcresult");
     let path_str = path.to_str().unwrap();
-    let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
+    let xcresult = XCResult::new(path_str, ORG_URL_SLUG.clone(), REPO_FULL_NAME.clone());
     pretty_assertions::assert_eq!(
         xcresult.err().unwrap().to_string(),
         "xcrun is only available on macOS"

--- a/xcresult/tests/xcresult.rs
+++ b/xcresult/tests/xcresult.rs
@@ -6,8 +6,6 @@ use tar::Archive;
 use temp_testdir::TempDir;
 use xcresult::XCResult;
 
-const ORG_URL_SLUG: &str = "trunk";
-
 fn unpack_archive_to_temp_dir<T: AsRef<Path>>(archive_file_path: T) -> TempDir {
     let file = File::open(archive_file_path).unwrap();
     let decoder = GzDecoder::new(file);
@@ -28,11 +26,13 @@ lazy_static! {
         unpack_archive_to_temp_dir("tests/data/test4.xcresult.tar.gz");
     static ref TEMP_DIR_TEST_EXPECTED_FAILURES: TempDir =
         unpack_archive_to_temp_dir("tests/data/test-ExpectedFailures.xcresult.tar.gz");
-    static ref REPO: RepoUrlParts = RepoUrlParts {
+    static ref ORG_URL_SLUG: String = String::from("trunk");
+    static ref REPO_FULL_NAME: String = RepoUrlParts {
         host: "github.com".to_string(),
         owner: "trunk-io".to_string(),
         name: "analytics-cli".to_string()
-    };
+    }
+    .repo_full_name();
 }
 
 #[cfg(target_os = "macos")]
@@ -40,15 +40,15 @@ lazy_static! {
 fn test_xcresult_with_valid_path() {
     let path = TEMP_DIR_TEST_1.as_ref().join("test1.xcresult");
     let path_str = path.to_str().unwrap();
-    let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
+    let xcresult = XCResult::new(path_str, ORG_URL_SLUG.clone(), REPO_FULL_NAME.clone());
     assert!(xcresult.is_ok());
 
-    let mut junits = xcresult.unwrap().generate_junits().unwrap();
+    let mut junits = xcresult.unwrap().generate_junits();
     assert_eq!(junits.len(), 1);
     let junit = junits.pop().unwrap();
     let mut junit_writer: Vec<u8> = Vec::new();
     junit.serialize(&mut junit_writer).unwrap();
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         String::from_utf8(junit_writer).unwrap(),
         include_str!("data/test1.junit.xml")
     );
@@ -59,11 +59,14 @@ fn test_xcresult_with_valid_path() {
 fn test_xcresult_with_invalid_path() {
     let path = TempDir::default().join("does-not-exist.xcresult");
     let path_str = path.to_str().unwrap();
-    let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
+    let xcresult = XCResult::new(path_str, ORG_URL_SLUG.clone(), REPO_FULL_NAME.clone());
     assert!(xcresult.is_err());
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         xcresult.err().unwrap().to_string(),
-        "failed to get absolute path -- is the path correct?"
+        format!(
+            "failed to get absolute path for {}: No such file or directory (os error 2)",
+            path.to_string_lossy()
+        )
     );
 }
 
@@ -72,11 +75,11 @@ fn test_xcresult_with_invalid_path() {
 fn test_xcresult_with_invalid_xcresult() {
     let path = TEMP_DIR_TEST_3.as_ref().join("test3.xcresult");
     let path_str = path.to_str().unwrap();
-    let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
+    let xcresult = XCResult::new(path_str, ORG_URL_SLUG.clone(), REPO_FULL_NAME.clone());
     assert!(xcresult.is_err());
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         xcresult.err().unwrap().to_string(),
-        "failed to parse json from xcrun output"
+        "failed to parse json from xcrun output: EOF while parsing a value at line 1 column 0"
     );
 }
 
@@ -85,15 +88,15 @@ fn test_xcresult_with_invalid_xcresult() {
 fn test_complex_xcresult_with_valid_path() {
     let path = TEMP_DIR_TEST_4.as_ref().join("test4.xcresult");
     let path_str = path.to_str().unwrap();
-    let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
+    let xcresult = XCResult::new(path_str, ORG_URL_SLUG.clone(), REPO_FULL_NAME.clone());
     assert!(xcresult.is_ok());
 
-    let mut junits = xcresult.unwrap().generate_junits().unwrap();
+    let mut junits = xcresult.unwrap().generate_junits();
     assert_eq!(junits.len(), 1);
     let junit = junits.pop().unwrap();
     let mut junit_writer: Vec<u8> = Vec::new();
     junit.serialize(&mut junit_writer).unwrap();
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         String::from_utf8(junit_writer).unwrap(),
         include_str!("data/test4.junit.xml")
     );
@@ -105,7 +108,7 @@ fn test_xcresult_with_valid_path_invalid_os() {
     let path = TEMP_DIR_TEST_1.as_ref().join("test1.xcresult");
     let path_str = path.to_str().unwrap();
     let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         xcresult.err().unwrap().to_string(),
         "xcrun is only available on macOS"
     );
@@ -118,15 +121,15 @@ fn test_expected_failures_xcresult_with_valid_path() {
         .as_ref()
         .join("test-ExpectedFailures.xcresult");
     let path_str = path.to_str().unwrap();
-    let xcresult = XCResult::new(path_str, &REPO, ORG_URL_SLUG);
+    let xcresult = XCResult::new(path_str, ORG_URL_SLUG.clone(), REPO_FULL_NAME.clone());
     assert!(xcresult.is_ok());
 
-    let mut junits = xcresult.unwrap().generate_junits().unwrap();
+    let mut junits = xcresult.unwrap().generate_junits();
     assert_eq!(junits.len(), 1);
     let junit = junits.pop().unwrap();
     let mut junit_writer: Vec<u8> = Vec::new();
     junit.serialize(&mut junit_writer).unwrap();
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         String::from_utf8(junit_writer).unwrap(),
         include_str!("data/test-ExpectedFailures.junit.xml")
     );

--- a/xcresult/xcrun-xcresulttool-get-test-results-tests-json-schema.json
+++ b/xcresult/xcrun-xcresulttool-get-test-results-tests-json-schema.json
@@ -1,0 +1,125 @@
+{
+  "$defs": {
+    "Tests": {
+      "type": "object",
+      "properties": {
+        "testPlanConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Configuration"
+          }
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Device"
+          }
+        },
+        "testNodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestNode"
+          }
+        }
+      },
+      "required": ["testPlanConfigurations", "devices", "testNodes"]
+    },
+    "Configuration": {
+      "type": "object",
+      "properties": {
+        "configurationId": {
+          "type": "string"
+        },
+        "configurationName": {
+          "type": "string"
+        }
+      },
+      "required": ["configurationId", "configurationName"]
+    },
+    "Device": {
+      "type": "object",
+      "properties": {
+        "deviceId": {
+          "type": "string"
+        },
+        "deviceName": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "modelName": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "osVersion": {
+          "type": "string"
+        }
+      },
+      "required": ["deviceName", "architecture", "modelName", "osVersion"]
+    },
+    "TestNode": {
+      "type": "object",
+      "properties": {
+        "nodeIdentifier": {
+          "type": "string"
+        },
+        "nodeType": {
+          "$ref": "#/$defs/TestNodeType"
+        },
+        "name": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/TestResult"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestNode"
+          }
+        }
+      },
+      "required": ["nodeType", "name"]
+    },
+    "TestResult": {
+      "type": "string",
+      "enum": ["Passed", "Failed", "Skipped", "Expected Failure", "unknown"]
+    },
+    "TestNodeType": {
+      "type": "string",
+      "enum": [
+        "Test Plan",
+        "Unit test bundle",
+        "UI test bundle",
+        "Test Suite",
+        "Test Case",
+        "Device",
+        "Test Plan Configuration",
+        "Arguments",
+        "Repetition",
+        "Test Case Run",
+        "Failure Message",
+        "Source Code Reference",
+        "Attachment",
+        "Expression",
+        "Test Value"
+      ]
+    }
+  },
+  "$ref": "#/$defs/Tests"
+}


### PR DESCRIPTION
Relies on #299

Uses JSON schema provided by `xcrun xcresulttool help get test-results tests` to generate Rust types and parse JSON output. This also helps parse things like retries (now shows up as a reruns in JUnit XML) or test bundles without test suites (or maybe it's the opposite?). There are a few drawbacks though:
* No file paths to tests
* Potentially less precise test durations
* No test plan duration without extra shell out
* Requires XCode 16 or newer

/trunk skip-check

Trunk Check doesn't work with codegen very well