### PR TITLE
Treat 'no reports found' as a suboptimal parsing issue

### DIFF
--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -236,7 +236,7 @@ async fn upload_bundle_using_bep() {
     // Uploaded file is a junit, even when using BEP
     let mut junit_parser = JunitParser::new();
     assert!(junit_parser.parse(junit_reader).is_ok());
-    assert!(junit_parser.errors().is_empty());
+    assert!(junit_parser.issues().is_empty());
 
     let mut bazel_bep_parser = BazelBepParser::new(tar_extract_directory.join("bazel_bep.json"));
     let parse_result = bazel_bep_parser.parse().ok().unwrap();

--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -93,6 +93,23 @@ fn validate_invalid_junits_no_codeowners() {
 }
 
 #[test]
+fn validate_empty_xml() {
+    let temp_dir = tempdir().unwrap();
+    let empty_xml = "";
+    write_junit_xml_to_dir(empty_xml, &temp_dir);
+
+    let assert = Command::new(CARGO_RUN.path())
+        .current_dir(&temp_dir)
+        .args(["validate", "--junit-paths", "./*"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 validation warning"))
+        .stdout(predicate::str::contains("OPTIONAL - no reports found"));
+
+    println!("{assert}");
+}
+
+#[test]
 fn validate_invalid_xml() {
     let temp_dir = tempdir().unwrap();
     let invalid_xml = "<bad<attrs<><><";

--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -75,8 +75,12 @@ describe("context-js", () => {
       </testsuites>
     `;
 
-    let report = junit_parse(Buffer.from(validJunitXml, "utf-8"));
-    let junitReportValidation = junit_validate(report[0]);
+    let parse_result = junit_parse(Buffer.from(validJunitXml, "utf-8"));
+    let report = parse_result.report;
+
+    expect(report).toBeDefined();
+
+    let junitReportValidation = junit_validate(report);
 
     expect(junitReportValidation.max_level()).toBe(JunitValidationLevel.Valid);
 
@@ -91,8 +95,12 @@ describe("context-js", () => {
       </testsuites>
     `;
 
-    report = junit_parse(Buffer.from(suboptimalJunitXml, "utf-8"));
-    junitReportValidation = junit_validate(report[0]);
+    parse_result = junit_parse(Buffer.from(suboptimalJunitXml, "utf-8"));
+    report = parse_result.report;
+
+    expect(report).toBeDefined();
+
+    junitReportValidation = junit_validate(report);
 
     expect(junitReportValidation.max_level()).toBe(
       JunitValidationLevel.SubOptimal,
@@ -116,8 +124,12 @@ describe("context-js", () => {
           </testsuite>
       </testsuites>`;
 
-    report = junit_parse(Buffer.from(nestedJunitXml, "utf-8"));
-    junitReportValidation = junit_validate(report[0]);
+    parse_result = junit_parse(Buffer.from(nestedJunitXml, "utf-8"));
+    report = parse_result.report;
+
+    expect(report).toBeDefined();
+
+    junitReportValidation = junit_validate(report);
 
     expect(junitReportValidation.max_level()).toBe(JunitValidationLevel.Valid);
   });

--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -78,8 +78,6 @@ describe("context-js", () => {
     let parse_result = junit_parse(Buffer.from(validJunitXml, "utf-8"));
     let report = parse_result.report;
 
-    expect(report).toBeDefined();
-
     let junitReportValidation = junit_validate(report);
 
     expect(junitReportValidation.max_level()).toBe(JunitValidationLevel.Valid);
@@ -97,8 +95,6 @@ describe("context-js", () => {
 
     parse_result = junit_parse(Buffer.from(suboptimalJunitXml, "utf-8"));
     report = parse_result.report;
-
-    expect(report).toBeDefined();
 
     junitReportValidation = junit_validate(report);
 
@@ -126,8 +122,6 @@ describe("context-js", () => {
 
     parse_result = junit_parse(Buffer.from(nestedJunitXml, "utf-8"));
     report = parse_result.report;
-
-    expect(report).toBeDefined();
 
     junitReportValidation = junit_validate(report);
 

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -66,17 +66,14 @@ fn junit_parse(xml: Vec<u8>) -> PyResult<junit::bindings::BindingsParseResult> {
     let issues_flat = junit_parser.issues_flat();
     let mut parsed_reports = junit_parser.into_reports();
 
-    if parsed_reports.len() != 1 {
-        return Ok(junit::bindings::BindingsParseResult {
-            report: None,
-            issues: issues_flat,
-        });
-    }
+    let report = if let (1, Some(parsed_report)) = (parsed_reports.len(), parsed_reports.pop()) {
+        Some(junit::bindings::BindingsReport::from(parsed_report))
+    } else {
+        None
+    };
 
     Ok(junit::bindings::BindingsParseResult {
-        report: Some(junit::bindings::BindingsReport::from(
-            parsed_reports.remove(0),
-        )),
+        report,
         issues: issues_flat,
     })
 }

--- a/context-py/tests/test_junit_validate.py
+++ b/context-py/tests/test_junit_validate.py
@@ -1,9 +1,8 @@
 def test_junit_validate_valid():
-    import typing as PT
     from datetime import datetime, timezone
 
     from context_py import (
-        BindingsReport,
+        BindingsParseResult,
         JunitValidationLevel,
         junit_parse,
         junit_validate,
@@ -26,10 +25,9 @@ def test_junit_validate_valid():
     </testsuites>
    """
 
-    reports: PT.List[BindingsReport] = junit_parse(str.encode(valid_junit_xml))
-
-    assert len(reports) == 1
-    report = reports[0]
+    parse_result: BindingsParseResult = junit_parse(str.encode(valid_junit_xml))
+    report = parse_result.report
+    assert report is not None
 
     junit_report_validation = junit_validate(report)
 
@@ -47,11 +45,10 @@ def test_junit_validate_valid():
 
 
 def test_junit_validate_suboptimal():
-    import typing as PT
     from datetime import datetime, timedelta, timezone
 
     from context_py import (
-        BindingsReport,
+        BindingsParseResult,
         JunitValidationLevel,
         JunitValidationType,
         junit_parse,
@@ -73,10 +70,9 @@ def test_junit_validate_suboptimal():
     </testsuites>
    """
 
-    reports: PT.List[BindingsReport] = junit_parse(str.encode(suboptimal_junit_xml))
-
-    assert len(reports) == 1
-    report = reports[0]
+    parse_result: BindingsParseResult = junit_parse(str.encode(suboptimal_junit_xml))
+    report = parse_result.report
+    assert report is not None
 
     junit_report_validation = junit_validate(report)
 

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -12,10 +12,21 @@ use quick_junit::{
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use super::validator::{
-    JunitReportValidation, JunitReportValidationFlatIssue, JunitTestSuiteValidation,
-    JunitValidationLevel, JunitValidationType,
+use super::{
+    parser::JunitParseFlatIssue,
+    validator::{
+        JunitReportValidation, JunitReportValidationFlatIssue, JunitTestSuiteValidation,
+        JunitValidationLevel, JunitValidationType,
+    },
 };
+
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
+#[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
+#[derive(Clone, Debug)]
+pub struct BindingsParseResult {
+    pub report: Option<BindingsReport>,
+    pub issues: Vec<JunitParseFlatIssue>,
+}
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]

--- a/context/tests/junit.rs
+++ b/context/tests/junit.rs
@@ -72,7 +72,7 @@ fn parse_report<T: AsRef<[u8]>>(serialized_report: T) -> Report {
         .parse(BufReader::new(&serialized_report.as_ref()[..]))
         .unwrap();
 
-    assert_eq!(junit_parser.errors(), &[]);
+    assert_eq!(junit_parser.issues(), &[]);
 
     let mut parsed_reports = junit_parser.into_reports();
     assert_eq!(parsed_reports.len(), 1);


### PR DESCRIPTION
Part of [TRUNK-14095](https://linear.app/trunk/issue/TRUNK-14095/qa-bug-no-reports-found-message-on-uploads-page)

The goal here is to not flag an invalid-level data quality error to the user in the uploads view when a bundle contains one or more empty XML files. See ticket ^ and relevant slack [thread](https://trunk-io.slack.com/archives/C07PYM8K0PQ/p1736980140133479).

However, I think we should still track that a bundle contained an empty XML file - so I decided to relegate it's error level to suboptimal (which currently won't show up in the uploads view). So,

This PR introduces the concept of 'invalid' & 'suboptimal' junit _parsing_ issues; similar to the paradigm we have for validation issues. A new `BindingsParseResult` struct is introduced such that a Python or JS client can access any invalid / suboptimal parsing issues encountered during junit parsing _in addition_ to the parsed report.

This also tangentially cleans up the `validate` CLI command to ensure its output is in line with how we're validating junits in our systems. Example output:

```
max@max-cloudtop:~$ ./src/analytics-cli/target/debug/trunk-analytics-cli validate --junit-paths="test.xml,test2.xml,test3.xml,test4.xml"
2025-01-16T19:54:37 [INFO] - Starting trunk flakytests 0.0.0 (git=714a55e17fa8e1f3c3ab4b480771109b7ac3eadc) rustc=1.80.0-nightly

Validating the following 4 files:
  File set matching test.xml:
    test.xml
  File set matching test2.xml:
    test2.xml
  File set matching test3.xml:
    test3.xml
  File set matching test4.xml:
    test4.xml

test.xml - 0 validation errors, 1 validation warnings
  OPTIONAL - no reports found
test2.xml - 1 validation errors
  INVALID - multiple reports found
test3.xml - 1 test suites, 33 test cases, 0 validation errors, 1 validation warnings
  OPTIONAL - report has stale (> 1 hour(s)) timestamps
test4.xml - 1 test suites, 1 test cases, 0 validation errors, 1 validation warnings
  OPTIONAL - report has stale (> 1 hour(s)) timestamps

3 files are valid, 1 files are not valid, 3 files have validation warnings ❌

Checking for codeowners file...
  OPTIONAL - No codeowners file found.
max@max-cloudtop:~$
``