### PR TITLE
test improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "bundle",
  "chrono",
  "codeowners",
+ "constants",
  "context",
  "escargot",
  "junit-mock",

--- a/cli-tests/Cargo.toml
+++ b/cli-tests/Cargo.toml
@@ -12,6 +12,7 @@ bazel-bep = { path = "../bazel-bep" }
 bundle = { path = "../bundle" }
 chrono = "0.4.33"
 codeowners = { path = "../codeowners" }
+constants = { path = "../constants" }
 context = { path = "../context" }
 escargot = "0.5.12"
 junit-mock = { path = "../junit-mock" }

--- a/cli-tests/src/quarantine.rs
+++ b/cli-tests/src/quarantine.rs
@@ -9,6 +9,7 @@ use api::{
 };
 use assert_cmd::Command;
 use axum::{extract::State, Json};
+use constants::{TRUNK_API_CLIENT_RETRY_COUNT_ENV, TRUNK_PUBLIC_API_ADDRESS_ENV};
 use lazy_static::lazy_static;
 use predicates::prelude::*;
 use tempfile::tempdir;
@@ -100,7 +101,8 @@ async fn quarantines_tests_regardless_of_upload() {
     let mut command = Command::new(CARGO_RUN.path());
     command
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args);

--- a/cli-tests/src/test.rs
+++ b/cli-tests/src/test.rs
@@ -3,6 +3,7 @@ use std::{fs, io::BufReader};
 use assert_cmd::Command;
 use assert_matches::assert_matches;
 use bundle::BundleMeta;
+use constants::{TRUNK_API_CLIENT_RETRY_COUNT_ENV, TRUNK_PUBLIC_API_ADDRESS_ENV};
 use predicates::prelude::*;
 use tempfile::tempdir;
 use test_utils::mock_server::{MockServerBuilder, RequestPayload};
@@ -38,7 +39,8 @@ async fn test_command_succeeds_with_successful_upload() {
 
     Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -72,7 +74,8 @@ async fn test_command_fails_with_successful_upload() {
 
     Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -104,7 +107,8 @@ async fn test_command_fails_with_no_junit_files_no_quarantine_successful_upload(
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -169,7 +173,8 @@ async fn test_command_succeeds_with_upload_not_connected() {
 
     Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", "https://localhost:10")
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, "https://localhost:10")
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -201,7 +206,8 @@ async fn test_command_fails_with_upload_not_connected() {
 
     Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", "https://localhost:10")
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, "https://localhost:10")
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -9,6 +9,7 @@ use assert_cmd::Command;
 use assert_matches::assert_matches;
 use bundle::{BundleMeta, FileSetType};
 use codeowners::CodeOwners;
+use constants::{TRUNK_API_CLIENT_RETRY_COUNT_ENV, TRUNK_PUBLIC_API_ADDRESS_ENV};
 use context::{
     bazel_bep::parser::BazelBepParser, junit::parser::JunitParser, repo::RepoUrlParts as Repo,
 };
@@ -41,7 +42,8 @@ async fn upload_bundle() {
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -218,7 +220,8 @@ async fn upload_bundle_using_bep() {
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -286,7 +289,8 @@ async fn upload_bundle_success_status_code() {
     // so the upload command should have a successful exit code
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -339,7 +343,8 @@ async fn upload_bundle_success_timestamp_status_code() {
     // so the upload command should have a successful exit code
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -364,7 +369,8 @@ async fn upload_bundle_empty_junit_paths() {
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .args(&[
             "upload",
@@ -451,7 +457,8 @@ async fn upload_bundle_no_files_allow_missing_junit_files() {
 
         let mut assert = Command::new(CARGO_RUN.path())
             .current_dir(&temp_dir)
-            .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+            .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+            .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
             .env("CI", "1")
             .args(&args)
             .assert();
@@ -488,7 +495,8 @@ async fn upload_bundle_valid_repo_root() {
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .args(&[
             "upload",
@@ -528,7 +536,8 @@ async fn upload_bundle_when_server_down() {
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", "https://localhost:10")
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, "https://localhost:10")
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args(args)
@@ -547,7 +556,8 @@ async fn upload_bundle_with_no_junit_files_no_quarantine_successful_upload() {
 
     let assert = Command::new(CARGO_RUN.path())
         .current_dir(&temp_dir)
-        .env("TRUNK_PUBLIC_API_ADDRESS", &state.host)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
         .env("CI", "1")
         .env("GITHUB_JOB", "test-job")
         .args([

--- a/cli/src/api_client/mod.rs
+++ b/cli/src/api_client/mod.rs
@@ -290,7 +290,7 @@ fn status_code_help<T: FnMut(&Response) -> String>(
 
 #[cfg(test)]
 mod tests {
-    use std::{env, time::Duration};
+    use std::time::Duration;
 
     use axum::{http::StatusCode, response::Response};
     use tempfile::NamedTempFile;
@@ -315,8 +315,8 @@ mod tests {
 
         let state = mock_server_builder.spawn_mock_server().await;
 
-        env::set_var("TRUNK_PUBLIC_API_ADDRESS", &state.host);
-        let api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        let mut api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        api_client.host.clone_from(&state.host);
 
         let bundle_file = NamedTempFile::new().unwrap();
         api_client
@@ -339,7 +339,7 @@ mod tests {
 
         guard.flush(None);
         assert_eq!(
-            *events.lock().unwrap(),
+            *events.try_lock().unwrap(),
             vec![(
                 sentry::Level::Error,
                 String::from("Uploading bundle to S3 is taking longer than 10 seconds"),
@@ -364,8 +364,8 @@ mod tests {
 
         let state = mock_server_builder.spawn_mock_server().await;
 
-        env::set_var("TRUNK_PUBLIC_API_ADDRESS", &state.host);
-        let api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        let mut api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        api_client.host.clone_from(&state.host);
 
         assert!(api_client
             .get_quarantining_config(&api::GetQuarantineBulkTestStatusRequest {

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -20,6 +20,7 @@ pub const CODEOWNERS_LOCATIONS: &[&str] = &[".github", ".bitbucket", ".", "docs"
 
 pub const DEFAULT_ORIGIN: &str = "https://api.trunk.io";
 pub const TRUNK_PUBLIC_API_ADDRESS_ENV: &str = "TRUNK_PUBLIC_API_ADDRESS";
+pub const TRUNK_API_CLIENT_RETRY_COUNT_ENV: &str = "TRUNK_API_CLIENT_RETRY_COUNT";
 pub const ENVS_TO_GET: &[&str] = &[
     "CI",
     "GIT_BRANCH",


### PR DESCRIPTION
* helps prevent races when testing is done with `cargo test` instead of `cargo-nextest` (`cargo test` is runs each test binary in the same process and `cargo-nextest` runs each test of each test binary in a different process)
* reduce retries for CLI integration tests where possible for expediency