### PR TITLE
Fix quarantining logic

### DIFF
--- a/cli-tests/src/quarantine.rs
+++ b/cli-tests/src/quarantine.rs
@@ -15,6 +15,20 @@ use predicates::prelude::*;
 use tempfile::tempdir;
 use test_utils::mock_server::{MockServerBuilder, SharedMockServerState};
 
+#[derive(Debug, Clone, Copy)]
+enum QuarantineConfigResponse {
+    Disabled,
+    None,
+    Some,
+    All,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CreateBundleResponse {
+    Error,
+    Success,
+}
+
 // NOTE: must be multi threaded to start a mock server
 #[tokio::test(flavor = "multi_thread")]
 async fn quarantines_tests_regardless_of_upload() {
@@ -25,12 +39,6 @@ async fn quarantines_tests_regardless_of_upload() {
 
     let mut mock_server_builder = MockServerBuilder::new();
 
-    #[derive(Debug, Clone, Copy)]
-    enum QuarantineConfigResponse {
-        None,
-        Some,
-        All,
-    }
     lazy_static! {
         static ref QUARANTINE_CONFIG_RESPONSE: Arc<Mutex<QuarantineConfigResponse>> =
             Arc::new(Mutex::new(QuarantineConfigResponse::None));
@@ -44,24 +52,23 @@ async fn quarantines_tests_regardless_of_upload() {
                 .collect::<Vec<_>>();
             let quarantine_config_response = *QUARANTINE_CONFIG_RESPONSE.lock().unwrap();
             let quarantined_tests = match quarantine_config_response {
+                QuarantineConfigResponse::Disabled => Vec::new(),
                 QuarantineConfigResponse::None => Vec::new(),
                 QuarantineConfigResponse::Some => test_ids.split_off(1),
                 QuarantineConfigResponse::All => test_ids,
             };
-            async {
+            let is_disabled = matches!(
+                quarantine_config_response,
+                QuarantineConfigResponse::Disabled
+            );
+            async move {
                 Json(GetQuarantineConfigResponse {
-                    is_disabled: false,
+                    is_disabled,
                     quarantined_tests,
                 })
             }
         },
     );
-
-    #[derive(Debug, Clone, Copy)]
-    enum CreateBundleResponse {
-        Error,
-        Success,
-    }
     lazy_static! {
         static ref CREATE_BUNDLE_RESPONSE: Arc<Mutex<CreateBundleResponse>> =
             Arc::new(Mutex::new(CreateBundleResponse::Error));
@@ -129,4 +136,125 @@ async fn quarantines_tests_regardless_of_upload() {
         .assert()
         .success()
         .stderr(upload_failure.clone().not());
+
+    // Fifth run will run with quarantining disabled, but will log upload failure
+    // there is no provided exit code, so it will default to success.
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::Disabled;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().success().stderr(upload_failure.clone());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn do_no_quarantines_tests_when_use_quarantined_disabled() {
+    let temp_dir = tempdir().unwrap();
+    generate_mock_git_repo(&temp_dir);
+    generate_mock_valid_junit_xmls(&temp_dir);
+    generate_mock_codeowners(&temp_dir);
+
+    let mut mock_server_builder = MockServerBuilder::new();
+
+    lazy_static! {
+        static ref QUARANTINE_CONFIG_RESPONSE: Arc<Mutex<QuarantineConfigResponse>> =
+            Arc::new(Mutex::new(QuarantineConfigResponse::None));
+    }
+    mock_server_builder.set_get_quarantining_config_handler(
+        |Json(get_quarantine_bulk_test_status_request): Json<GetQuarantineConfigRequest>| {
+            let mut test_ids = get_quarantine_bulk_test_status_request
+                .test_identifiers
+                .into_iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>();
+            let quarantine_config_response = *QUARANTINE_CONFIG_RESPONSE.lock().unwrap();
+            let quarantined_tests = match quarantine_config_response {
+                QuarantineConfigResponse::Disabled => Vec::new(),
+                QuarantineConfigResponse::None => Vec::new(),
+                QuarantineConfigResponse::Some => test_ids.split_off(1),
+                QuarantineConfigResponse::All => test_ids,
+            };
+            let is_disabled = matches!(
+                quarantine_config_response,
+                QuarantineConfigResponse::Disabled
+            );
+            async move {
+                Json(GetQuarantineConfigResponse {
+                    is_disabled,
+                    quarantined_tests,
+                })
+            }
+        },
+    );
+    lazy_static! {
+        static ref CREATE_BUNDLE_RESPONSE: Arc<Mutex<CreateBundleResponse>> =
+            Arc::new(Mutex::new(CreateBundleResponse::Error));
+    }
+    mock_server_builder.set_create_bundle_handler(
+        |State(state): State<SharedMockServerState>, _: Json<CreateBundleUploadRequest>| {
+            let create_bundle_response = *CREATE_BUNDLE_RESPONSE.lock().unwrap();
+            let result = match create_bundle_response {
+                CreateBundleResponse::Error => Err(String::from("Server is down")),
+                CreateBundleResponse::Success => {
+                    let host = &state.host;
+                    Ok(Json(CreateBundleUploadResponse {
+                        id: String::from("test-bundle-upload-id"),
+                        id_v2: String::from("test-bundle-upload-id-v2"),
+                        url: format!("{host}/s3upload"),
+                        key: String::from("unused"),
+                    }))
+                }
+            };
+            async { result }
+        },
+    );
+    let state = mock_server_builder.spawn_mock_server().await;
+
+    let args = &[
+        "quarantine",
+        "--junit-paths",
+        "./*",
+        "--org-url-slug",
+        "test-org",
+        "--token",
+        "test-token",
+        "--use-quarantining=false",
+    ];
+
+    let mut command = Command::new(CARGO_RUN.path());
+    command
+        .current_dir(&temp_dir)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
+        .env("CI", "1")
+        .env("GITHUB_JOB", "test-job")
+        .args(args);
+
+    let upload_failure = predicate::str::contains("Error uploading test results");
+    // there is no provided exit code, so all of the options below will default to success.
+
+    // First run won't quarantine any tests
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::None;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().success().stderr(upload_failure.clone());
+
+    // Second run won't quarantine even when config generates 1 quarantined test
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::Some;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().success().stderr(upload_failure.clone());
+
+    // Third run won't quarantine even when config generates all tests quarantined
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::All;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().success().stderr(upload_failure.clone());
+
+    // Fourth run won't quarantine tests even when config generates all tests quarantined and upload is successful
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::All;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Success;
+    command
+        .assert()
+        .success()
+        .stderr(upload_failure.clone().not());
+
+    // Fifth run will run with quarantining disabled, but will log upload failure
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::Disabled;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().success().stderr(upload_failure.clone());
 }

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -1,23 +1,29 @@
+use std::sync::{Arc, Mutex};
 use std::{fs, io::BufReader};
 
 use crate::utils::{
     generate_mock_bazel_bep, generate_mock_codeowners, generate_mock_git_repo,
     generate_mock_valid_junit_xmls, CARGO_RUN,
 };
-use api::message::{BundleUploadStatus, CreateRepoRequest, UpdateBundleUploadRequest};
+use api::message::{
+    BundleUploadStatus, CreateBundleUploadRequest, CreateBundleUploadResponse, CreateRepoRequest,
+    GetQuarantineConfigRequest, GetQuarantineConfigResponse, UpdateBundleUploadRequest,
+};
 use assert_cmd::Command;
 use assert_matches::assert_matches;
+use axum::{extract::State, Json};
 use bundle::{BundleMeta, FileSetType};
 use codeowners::CodeOwners;
 use constants::{TRUNK_API_CLIENT_RETRY_COUNT_ENV, TRUNK_PUBLIC_API_ADDRESS_ENV};
 use context::{
     bazel_bep::parser::BazelBepParser, junit::parser::JunitParser, repo::RepoUrlParts as Repo,
 };
+use lazy_static::lazy_static;
 use predicates::prelude::*;
 use tempfile::tempdir;
 use test_utils::{
     inputs::get_test_file_path,
-    mock_server::{MockServerBuilder, RequestPayload},
+    mock_server::{MockServerBuilder, RequestPayload, SharedMockServerState},
 };
 
 // NOTE: must be multi threaded to start a mock server
@@ -578,4 +584,129 @@ async fn upload_bundle_with_no_junit_files_no_quarantine_successful_upload() {
 
     // HINT: View CLI output with `cargo test -- --nocapture`
     println!("{assert}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn quarantines_tests_regardless_of_upload() {
+    let temp_dir = tempdir().unwrap();
+    generate_mock_git_repo(&temp_dir);
+    generate_mock_valid_junit_xmls(&temp_dir);
+    generate_mock_codeowners(&temp_dir);
+
+    let mut mock_server_builder = MockServerBuilder::new();
+
+    lazy_static! {
+        static ref QUARANTINE_CONFIG_RESPONSE: Arc<Mutex<QuarantineConfigResponse>> =
+            Arc::new(Mutex::new(QuarantineConfigResponse::None));
+    }
+    #[derive(Debug, Clone, Copy)]
+    enum QuarantineConfigResponse {
+        Disabled,
+        None,
+        Some,
+        All,
+    }
+    mock_server_builder.set_get_quarantining_config_handler(
+        |Json(get_quarantine_bulk_test_status_request): Json<GetQuarantineConfigRequest>| {
+            let mut test_ids = get_quarantine_bulk_test_status_request
+                .test_identifiers
+                .into_iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>();
+            let quarantine_config_response = *QUARANTINE_CONFIG_RESPONSE.lock().unwrap();
+            let quarantined_tests = match quarantine_config_response {
+                QuarantineConfigResponse::Disabled => Vec::new(),
+                QuarantineConfigResponse::None => Vec::new(),
+                QuarantineConfigResponse::Some => test_ids.split_off(1),
+                QuarantineConfigResponse::All => test_ids,
+            };
+            let is_disabled = matches!(
+                quarantine_config_response,
+                QuarantineConfigResponse::Disabled
+            );
+            async move {
+                Json(GetQuarantineConfigResponse {
+                    is_disabled,
+                    quarantined_tests,
+                })
+            }
+        },
+    );
+    #[derive(Debug, Clone, Copy)]
+    enum CreateBundleResponse {
+        Error,
+        Success,
+    }
+    lazy_static! {
+        static ref CREATE_BUNDLE_RESPONSE: Arc<Mutex<CreateBundleResponse>> =
+            Arc::new(Mutex::new(CreateBundleResponse::Error));
+    }
+    mock_server_builder.set_create_bundle_handler(
+        |State(state): State<SharedMockServerState>, _: Json<CreateBundleUploadRequest>| {
+            let create_bundle_response = *CREATE_BUNDLE_RESPONSE.lock().unwrap();
+            let result = match create_bundle_response {
+                CreateBundleResponse::Error => Err(String::from("Server is down")),
+                CreateBundleResponse::Success => {
+                    let host = &state.host;
+                    Ok(Json(CreateBundleUploadResponse {
+                        id: String::from("test-bundle-upload-id"),
+                        id_v2: String::from("test-bundle-upload-id-v2"),
+                        url: format!("{host}/s3upload"),
+                        key: String::from("unused"),
+                    }))
+                }
+            };
+            async { result }
+        },
+    );
+    let state = mock_server_builder.spawn_mock_server().await;
+
+    let args = &[
+        "upload",
+        "--junit-paths",
+        "./*",
+        "--org-url-slug",
+        "test-org",
+        "--token",
+        "test-token",
+    ];
+
+    let mut command = Command::new(CARGO_RUN.path());
+    command
+        .current_dir(&temp_dir)
+        .env(TRUNK_PUBLIC_API_ADDRESS_ENV, &state.host)
+        .env(TRUNK_API_CLIENT_RETRY_COUNT_ENV, "0")
+        .env("CI", "1")
+        .env("GITHUB_JOB", "test-job")
+        .args(args);
+
+    // First run won't quarantine any tests
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::None;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().failure();
+
+    // Second run quarantines all, but 1 test
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::Some;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().failure();
+
+    // Third run will not quarantine all tests because of upload failure
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::All;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().failure();
+
+    // Fourth run will quarantine all tests, and upload them
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::All;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Success;
+    command.assert().success();
+
+    // Fifth run will run with quarantining disabled, but will fail to upload
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::Disabled;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Error;
+    command.assert().failure();
+
+    // Sixth run will run with quarantining disabled, and will succeed with upload
+    *QUARANTINE_CONFIG_RESPONSE.lock().unwrap() = QuarantineConfigResponse::Disabled;
+    *CREATE_BUNDLE_RESPONSE.lock().unwrap() = CreateBundleResponse::Success;
+    command.assert().success();
 }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -242,12 +242,15 @@ pub async fn gather_exit_code_and_quarantined_tests_context(
                 ..
             },
     } = if !use_quarantining {
-        QuarantineContext {
-            exit_code: test_run_result
-                .as_ref()
-                .map(|t| t.exit_code)
-                .unwrap_or_else(|| failed_tests_extractor.exit_code()),
-            ..Default::default()
+        // use the exit code of the test run result if exists
+        if let Some(test_run_result) = test_run_result {
+            QuarantineContext {
+                exit_code: test_run_result.exit_code,
+                ..Default::default()
+            }
+        } else {
+            // default to success if no test run result (i.e. `upload`)
+            QuarantineContext::default()
         }
     } else {
         gather_quarantine_context(

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -167,7 +167,7 @@ pub async fn gather_quarantine_context(
         )
     });
 
-    let exit_code = test_run_exit_code.unwrap_or_else(|| failed_tests_extractor.exit_code());
+    let mut exit_code = test_run_exit_code.unwrap_or(EXIT_SUCCESS);
 
     if file_set_builder.no_files_found() {
         log::info!("No JUnit files found, not quarantining any tests");
@@ -198,6 +198,9 @@ pub async fn gather_quarantine_context(
             exit_code,
             quarantine_status: QuarantineBulkTestStatus::default(),
         };
+    } else {
+        // quarantining is enabled, continue with quarantine process and update exit code
+        exit_code = test_run_exit_code.unwrap_or_else(|| failed_tests_extractor.exit_code());
     }
 
     // quarantine the failed tests


### PR DESCRIPTION
When `use-quarantining` is set to true we should defer to the cloud config. When it is set to false we should disable quarantining. Previously we were ignoring the state of that flag and treating everything as though it should be quarantined by always inspecting failures when exit codes were not specified. These exit codes are not specified for the `upload` and `quarantine` commands, so you would essentially always have quarantining enabled when using those commands. In the future this should be renamed and flipped, but this PR updates it to handle those cases appropriately. 

* Add tests to validate upload and quarantine behaviors match expectations