### PR TITLE
[1] Resolve Pre-test to include Rspec debug parameters

### DIFF
--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -7,7 +7,7 @@ use clap::Args;
 use constants::EXIT_FAILURE;
 
 use crate::{
-    context::gather_pre_test_context,
+    context::{gather_debug_props, gather_pre_test_context},
     upload_command::{run_upload, UploadArgs, UploadRunResult},
 };
 
@@ -37,7 +37,8 @@ pub async fn run_test(
         command,
     }: TestArgs,
 ) -> anyhow::Result<i32> {
-    let pre_test_context = gather_pre_test_context(upload_args.clone())?;
+    let token = upload_args.token.clone();
+    let pre_test_context = gather_pre_test_context(upload_args.clone(), gather_debug_props(token))?;
 
     log::info!("running command: {:?}", command);
     let test_run_result = run_test_command(&command).await?;

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -6,8 +6,9 @@ use context::bazel_bep::parser::BepParseResult;
 
 use crate::{
     context::{
-        gather_exit_code_and_quarantined_tests_context, gather_post_test_context,
-        gather_pre_test_context, gather_upload_id_context, PreTestContext,
+        gather_debug_props, gather_exit_code_and_quarantined_tests_context,
+        gather_post_test_context, gather_pre_test_context, gather_upload_id_context,
+        PreTestContext,
     },
     test_command::TestRunResult,
 };
@@ -142,7 +143,7 @@ pub async fn run_upload(
     } = if let Some(pre_test_context) = pre_test_context {
         pre_test_context
     } else {
-        gather_pre_test_context(upload_args.clone())?
+        gather_pre_test_context(upload_args.clone(), gather_debug_props(upload_args.token))?
     };
 
     let file_set_builder = gather_post_test_context(

--- a/context-ruby/Rakefile
+++ b/context-ruby/Rakefile
@@ -13,6 +13,7 @@ task :dev do
 end
 
 RSpec::Core::RakeTask.new(:test) do |t|
+  ENV['REPO_ROOT'] = '..'
   Rake::Task['compile'].invoke
   t.pattern = 'test/*_spec.rb'
 end

--- a/context-ruby/spec/trunk_spec_helper.rb
+++ b/context-ruby/spec/trunk_spec_helper.rb
@@ -78,7 +78,7 @@ end
 # it generates and submits the final test reports
 class TrunkAnalyticsListener
   def initialize
-    @testreport = TestReport.new('rspec')
+    @testreport = TestReport.new('rspec', "#{$PROGRAM_NAME} #{ARGV.join(' ')}")
   end
 
   def example_finished(notification)
@@ -86,7 +86,7 @@ class TrunkAnalyticsListener
   end
 
   def close(_notification)
-    @testreport.publish('..')
+    @testreport.publish
   end
 
   def description_generated?(example)

--- a/test_report/Cargo.toml
+++ b/test_report/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0.133"
 js-sys = { version = "0.3.70", optional = true }
 tokio = "1.42.0"
 anyhow = "1.0.94"
+bundle = { path = "../bundle" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -25,7 +25,7 @@ async fn publish_test_report() {
     env::set_var("TRUNK_ORG_URL_SLUG", "test-org");
 
     let thread_join_handle = thread::spawn(|| {
-        let test_report = MutTestReport::new("test".into());
+        let test_report = MutTestReport::new("test".into(), "".into());
         test_report.add_test(
             Some("1".into()),
             "test-name".into(),
@@ -39,7 +39,7 @@ async fn publish_test_report() {
             1001,
             "test-message".into(),
         );
-        let result = test_report.publish(".".into());
+        let result = test_report.publish();
         assert_eq!(result, true);
     });
     thread_join_handle.join().unwrap();


### PR DESCRIPTION
This addresses 2 points.

1. It allows us to understand how rspec is being invoked to improve debugging
2. It addresses a `KERN_INVALID_ADDRESS` that occurs when using arm64-darwin cydlib builds. This error happens because we are unable to access `env::args` in this mode.