### PR TITLE
Remove metadata from openssl version

### DIFF
--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -19,7 +19,7 @@ js-sys = { version = "0.3.70", optional = true }
 lazy_static = "1.5.0"
 log = "0.4.14"
 openssl = { version = "0.10.66", features = ["vendored"], optional = true }
-openssl-src = { version = "=300.3.1+3.3.1", optional = true }
+openssl-src = { version = "=300.3.1", optional = true }
 pyo3-stub-gen = { version = "0.6.0", optional = true }
 quick-junit = "0.5.0"
 quick-xml = "0.36.2"


### PR DESCRIPTION
This generates a warning and is dropped anyway.