### PR TITLE
Add reusable test framework for cli tests

### DIFF
--- a/cli-tests/src/command_builder.rs
+++ b/cli-tests/src/command_builder.rs
@@ -1,0 +1,397 @@
+use std::{collections::HashMap, path::Path};
+
+use assert_cmd::Command;
+use constants::{TRUNK_API_CLIENT_RETRY_COUNT_ENV, TRUNK_PUBLIC_API_ADDRESS_ENV};
+
+use crate::utils::CARGO_RUN;
+
+const DEFAULT_JUNIT_PATHS: &str = "./*";
+
+pub struct UploadArgs {
+    repo_root: Option<String>,
+    repo_url: Option<String>,
+    repo_head_sha: Option<String>,
+    repo_head_branch: Option<String>,
+    repo_head_commit_epoch: Option<String>,
+    tags: Option<Vec<String>>,
+    print_files: Option<bool>,
+    no_upload: Option<bool>,
+    team: Option<String>,
+    codeowners_path: Option<String>,
+    use_quarantining: Option<bool>,
+    allow_empty_test_results: Option<bool>,
+}
+
+impl UploadArgs {
+    pub fn empty() -> Self {
+        UploadArgs {
+            repo_root: None,
+            repo_url: None,
+            repo_head_sha: None,
+            repo_head_branch: None,
+            repo_head_commit_epoch: None,
+            tags: None,
+            print_files: None,
+            no_upload: None,
+            team: None,
+            codeowners_path: None,
+            use_quarantining: None,
+            allow_empty_test_results: None,
+        }
+    }
+
+    pub fn build_args(&self) -> Vec<String> {
+        vec![
+            String::from("--org-url-slug"),
+            String::from("test-org"),
+            String::from("--token"),
+            String::from("test-token"),
+        ]
+        .into_iter()
+        .chain(
+            self.repo_root
+                .clone()
+                .into_iter()
+                .flat_map(|repo_root: String| vec![String::from("--repo-root"), repo_root]),
+        )
+        .chain(
+            self.repo_url
+                .clone()
+                .into_iter()
+                .flat_map(|repo_url: String| vec![String::from("--repo-url"), repo_url]),
+        )
+        .chain(
+            self.repo_head_branch
+                .clone()
+                .into_iter()
+                .flat_map(|repo_head_branch: String| {
+                    vec![String::from("--repo-head-branch"), repo_head_branch]
+                }),
+        )
+        .chain(
+            self.repo_head_sha
+                .clone()
+                .into_iter()
+                .flat_map(|repo_head_sha: String| {
+                    vec![String::from("--repo-head-sha"), repo_head_sha]
+                }),
+        )
+        .chain(self.repo_head_commit_epoch.clone().into_iter().flat_map(
+            |repo_head_commit_epoch: String| {
+                vec![
+                    String::from("--repo-head-commit-epoch"),
+                    repo_head_commit_epoch,
+                ]
+            },
+        ))
+        .chain(self.tags.clone().into_iter().flat_map(|tags: Vec<String>| {
+            if tags.is_empty() {
+                vec![]
+            } else {
+                let mut args = vec![String::from("--tags")];
+                args.extend(tags);
+                args
+            }
+        }))
+        .chain(self.print_files.into_iter().flat_map(|print_files: bool| {
+            if print_files {
+                vec![String::from("--print-files")]
+            } else {
+                vec![]
+            }
+        }))
+        .chain(self.no_upload.into_iter().flat_map(|no_upload: bool| {
+            if no_upload {
+                vec![String::from("--repo-root")]
+            } else {
+                vec![]
+            }
+        }))
+        .chain(
+            self.team
+                .clone()
+                .into_iter()
+                .flat_map(|team: String| vec![String::from("--team"), team]),
+        )
+        .chain(
+            self.codeowners_path
+                .clone()
+                .into_iter()
+                .flat_map(|codeowners_path: String| {
+                    vec![String::from("--codeowners-path"), codeowners_path]
+                }),
+        )
+        .chain(
+            self.use_quarantining
+                .into_iter()
+                .flat_map(|use_quarantining: bool| {
+                    if use_quarantining {
+                        vec![String::from("--use-quarantining")]
+                    } else {
+                        vec![String::from("--use-quarantining=false")]
+                    }
+                }),
+        )
+        .chain(self.allow_empty_test_results.into_iter().flat_map(
+            |allow_empty_test_results: bool| {
+                if allow_empty_test_results {
+                    vec![String::from("--allow-empty-test-results")]
+                } else {
+                    vec![]
+                }
+            },
+        ))
+        .collect()
+    }
+}
+
+pub enum CommandType {
+    Upload {
+        upload_args: UploadArgs,
+        server_host: String,
+    },
+    Quarantine {
+        upload_args: UploadArgs,
+        server_host: String,
+    },
+    Test {
+        upload_args: UploadArgs,
+        command: Vec<String>,
+        server_host: String,
+    },
+    Validate {
+        show_warnings: Option<bool>,
+        codeowners_path: Option<String>,
+    },
+}
+
+impl CommandType {
+    pub fn name(&self) -> String {
+        match self {
+            CommandType::Upload { .. } => String::from("upload"),
+            CommandType::Quarantine { .. } => String::from("quarantine"),
+            CommandType::Test { .. } => String::from("test"),
+            CommandType::Validate { .. } => String::from("validate"),
+        }
+    }
+
+    pub fn build_args(&self) -> Vec<String> {
+        match self {
+            CommandType::Upload { upload_args, .. } => upload_args.build_args(),
+            CommandType::Quarantine { upload_args, .. } => upload_args.build_args(),
+            CommandType::Test {
+                upload_args,
+                command,
+                ..
+            } => [upload_args.build_args(), command.clone()].concat(),
+            CommandType::Validate {
+                show_warnings,
+                codeowners_path,
+            } => show_warnings
+                .iter()
+                .flat_map(|show_warnings: &bool| {
+                    if *show_warnings {
+                        vec![String::from("--show-warnings")]
+                    } else {
+                        vec![]
+                    }
+                })
+                .chain(codeowners_path.iter().flat_map(|codeowners_path: &String| {
+                    vec![String::from("--codeowners-path"), codeowners_path.clone()]
+                }))
+                .collect(),
+        }
+    }
+
+    pub fn build_envs(&self) -> HashMap<String, String> {
+        match self {
+            CommandType::Upload { server_host, .. } => HashMap::from([(
+                String::from(TRUNK_PUBLIC_API_ADDRESS_ENV),
+                server_host.clone(),
+            )]),
+            CommandType::Quarantine { server_host, .. } => HashMap::from([(
+                String::from(TRUNK_PUBLIC_API_ADDRESS_ENV),
+                server_host.clone(),
+            )]),
+            CommandType::Test { server_host, .. } => HashMap::from([(
+                String::from(TRUNK_PUBLIC_API_ADDRESS_ENV),
+                server_host.clone(),
+            )]),
+            CommandType::Validate { .. } => {
+                let empty: HashMap<String, String> = HashMap::new();
+                empty
+            }
+        }
+    }
+
+    pub fn use_quarantining(&mut self, new_flag: bool) -> &mut Self {
+        match self {
+            CommandType::Upload { upload_args, .. } => {
+                upload_args.use_quarantining = Some(new_flag)
+            }
+            CommandType::Quarantine { upload_args, .. } => {
+                upload_args.use_quarantining = Some(new_flag)
+            }
+            CommandType::Test { upload_args, .. } => upload_args.use_quarantining = Some(new_flag),
+            CommandType::Validate { .. } => (),
+        }
+        self
+    }
+
+    pub fn print_files(&mut self, new_flag: bool) -> &mut Self {
+        match self {
+            CommandType::Upload { upload_args, .. } => upload_args.print_files = Some(new_flag),
+            CommandType::Quarantine { upload_args, .. } => upload_args.print_files = Some(new_flag),
+            CommandType::Test { upload_args, .. } => upload_args.print_files = Some(new_flag),
+            CommandType::Validate { .. } => (),
+        }
+        self
+    }
+
+    pub fn repo_root(&mut self, new_value: &str) -> &mut Self {
+        match self {
+            CommandType::Upload { upload_args, .. } => {
+                upload_args.repo_root = Some(String::from(new_value))
+            }
+            CommandType::Quarantine { upload_args, .. } => {
+                upload_args.repo_root = Some(String::from(new_value))
+            }
+            CommandType::Test { upload_args, .. } => {
+                upload_args.repo_root = Some(String::from(new_value))
+            }
+            CommandType::Validate { .. } => (),
+        }
+        self
+    }
+}
+
+#[derive(Clone)]
+pub enum PathsState {
+    JunitPaths(String),
+    BazelBepPath(String),
+}
+
+impl PathsState {
+    pub fn build_args(&self) -> Vec<String> {
+        match self {
+            PathsState::JunitPaths(path) => vec![String::from("--junit-paths"), path.clone()],
+            PathsState::BazelBepPath(path) => vec![String::from("--bazel-bep-path"), path.clone()],
+        }
+    }
+}
+
+pub struct CommandBuilder<'a> {
+    command_type: CommandType,
+    current_dir: &'a Path,
+    paths_state: Option<PathsState>,
+}
+
+impl<'b> CommandBuilder<'b> {
+    pub fn upload(current_dir: &'b Path, server_host: String) -> Self {
+        CommandBuilder {
+            command_type: CommandType::Upload {
+                upload_args: UploadArgs::empty(),
+                server_host,
+            },
+            current_dir,
+            paths_state: None,
+        }
+    }
+
+    pub fn quarantine(current_dir: &'b Path, server_host: String) -> Self {
+        CommandBuilder {
+            command_type: CommandType::Quarantine {
+                upload_args: UploadArgs::empty(),
+                server_host,
+            },
+            current_dir,
+            paths_state: None,
+        }
+    }
+
+    pub fn test(current_dir: &'b Path, server_host: String, command: Vec<String>) -> Self {
+        CommandBuilder {
+            command_type: CommandType::Test {
+                upload_args: UploadArgs::empty(),
+                command,
+                server_host,
+            },
+            current_dir,
+            paths_state: None,
+        }
+    }
+
+    pub fn validate(current_dir: &'b Path) -> Self {
+        CommandBuilder {
+            command_type: CommandType::Validate {
+                show_warnings: None,
+                codeowners_path: None,
+            },
+            current_dir,
+            paths_state: None,
+        }
+    }
+
+    pub fn junit_paths(&mut self, new_paths: &str) -> &mut Self {
+        self.paths_state = Some(PathsState::JunitPaths(String::from(new_paths)));
+        self
+    }
+
+    pub fn bazel_bep_path(&mut self, new_paths: &str) -> &mut Self {
+        self.paths_state = Some(PathsState::BazelBepPath(String::from(new_paths)));
+        self
+    }
+
+    pub fn use_quarantining(&mut self, new_flag: bool) -> &mut Self {
+        self.command_type.use_quarantining(new_flag);
+        self
+    }
+
+    pub fn print_files(&mut self, new_flag: bool) -> &mut Self {
+        self.command_type.print_files(new_flag);
+        self
+    }
+
+    pub fn repo_root(&mut self, new_value: &str) -> &mut Self {
+        self.command_type.repo_root(new_value);
+        self
+    }
+
+    pub fn command(&self) -> Command {
+        let mut command = Command::new(CARGO_RUN.path());
+        let args = self.build_args();
+        let envs = self.build_envs();
+        command.current_dir(self.current_dir).envs(envs).args(args);
+        command
+    }
+
+    pub fn build_args(&self) -> Vec<String> {
+        let paths_args = self
+            .paths_state
+            .clone()
+            .map(|paths_state: PathsState| paths_state.build_args())
+            .unwrap_or(vec![
+                String::from("--junit-paths"),
+                String::from(DEFAULT_JUNIT_PATHS),
+            ]);
+
+        [self.command_type.name()]
+            .into_iter()
+            .chain(paths_args)
+            .chain(self.command_type.build_args())
+            .collect()
+    }
+
+    fn build_envs(&self) -> HashMap<String, String> {
+        let mut base_env: HashMap<String, String> = HashMap::from([
+            (
+                String::from(TRUNK_API_CLIENT_RETRY_COUNT_ENV),
+                String::from("0"),
+            ),
+            (String::from("CI"), String::from("1")),
+            (String::from("GITHUB_JOB"), String::from("test-job")),
+        ]);
+        base_env.extend(self.command_type.build_envs());
+        base_env
+    }
+}

--- a/cli-tests/src/main.rs
+++ b/cli-tests/src/main.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+mod command_builder;
+#[cfg(test)]
 mod quarantine;
 #[cfg(test)]
 mod test;

--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -1,11 +1,13 @@
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::tempdir;
 
-use crate::utils::{
-    generate_mock_codeowners, generate_mock_invalid_junit_xmls,
-    generate_mock_missing_filepath_suboptimal_junit_xmls, generate_mock_suboptimal_junit_xmls,
-    generate_mock_valid_junit_xmls, write_junit_xml_to_dir, CARGO_RUN,
+use crate::{
+    command_builder::CommandBuilder,
+    utils::{
+        generate_mock_codeowners, generate_mock_invalid_junit_xmls,
+        generate_mock_missing_filepath_suboptimal_junit_xmls, generate_mock_suboptimal_junit_xmls,
+        generate_mock_valid_junit_xmls, write_junit_xml_to_dir,
+    },
 };
 
 #[test]
@@ -14,9 +16,8 @@ fn validate_success() {
     generate_mock_valid_junit_xmls(&temp_dir);
     generate_mock_codeowners(&temp_dir);
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .success()
         .stdout(predicate::str::contains("0 validation errors"))
@@ -31,12 +32,14 @@ fn validate_success() {
 fn validate_junit_and_bep() {
     let temp_dir = tempdir().unwrap();
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*", "--bazel-bep-path", "bep.json"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .bazel_bep_path("bep.json")
+        .command()
+        .arg("--junit-paths")
+        .arg("./*")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("the argument '--junit-paths <JUNIT_PATHS>' cannot be used with '--bazel-bep-path <BAZEL_BEP_PATH>'"));
+        .stderr(predicate::str::contains("the argument '--bazel-bep-path <BAZEL_BEP_PATH>' cannot be used with '--junit-paths <JUNIT_PATHS>'"));
 
     println!("{assert}");
 }
@@ -45,9 +48,8 @@ fn validate_junit_and_bep() {
 fn validate_no_junits() {
     let temp_dir = tempdir().unwrap();
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .failure()
         .stderr(predicate::str::contains("No JUnit files found to validate"));
@@ -59,9 +61,9 @@ fn validate_no_junits() {
 fn validate_empty_junit_paths() {
     let temp_dir = tempdir().unwrap();
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", ""])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .junit_paths("")
+        .command()
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -76,9 +78,8 @@ fn validate_invalid_junits_no_codeowners() {
     let temp_dir = tempdir().unwrap();
     generate_mock_invalid_junit_xmls(&temp_dir);
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .failure()
         .stdout(predicate::str::contains("1 validation error"))
@@ -99,9 +100,8 @@ fn validate_empty_xml() {
     let empty_xml = "";
     write_junit_xml_to_dir(empty_xml, &temp_dir);
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .success()
         .stdout(predicate::str::contains("1 validation warning"))
@@ -116,9 +116,8 @@ fn validate_invalid_xml() {
     let invalid_xml = "<bad<attrs<><><";
     write_junit_xml_to_dir(&invalid_xml, &temp_dir);
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .failure()
         .stdout(predicate::str::contains("1 validation error"))
@@ -134,9 +133,8 @@ fn validate_suboptimal_junits() {
     let temp_dir = tempdir().unwrap();
     generate_mock_suboptimal_junit_xmls(&temp_dir);
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -155,9 +153,8 @@ fn validate_missing_filepath_suboptimal_junits() {
     generate_mock_missing_filepath_suboptimal_junit_xmls(&temp_dir);
     generate_mock_codeowners(&temp_dir);
 
-    let assert = Command::new(CARGO_RUN.path())
-        .current_dir(&temp_dir)
-        .args(&["validate", "--junit-paths", "./*"])
+    let assert = CommandBuilder::validate(temp_dir.path())
+        .command()
         .assert()
         .success()
         .stdout(predicate::str::contains(


### PR DESCRIPTION
Abstracts out the arg and env orchestration for cli invocation to a builder pattern. The builder fills in default values for parts that are common across existing usages. While we have all of the flags supported by the cli in the builder, we don't have methods for setting all of them because not every flag is actually tested, so those methods would be unused.