### PR TITLE
Add verbosity levels to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,6 +4768,7 @@ dependencies = [
  "bundle",
  "chrono",
  "clap",
+ "clap-verbosity-flag",
  "codeowners",
  "colored",
  "console",

--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -75,7 +75,7 @@ where
                 let instant = interval.tick().await;
                 let time_elapsed = instant.duration_since(check_progress_start);
                 let log_message = log_progress_message(time_elapsed, log_count);
-                log::info!("{}", log_message);
+                log::debug!("{}", log_message);
                 log_count += 1;
             }
         });

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -344,8 +344,8 @@ mod tests {
             .cloned()
             .collect::<Vec<_>>();
         assert_eq!(first_two_slow_s3_upload_logs, vec![
-            (log::Level::Info, String::from("Uploading bundle to S3 is taking longer than expected. It has taken 2 seconds so far.")),
-            (log::Level::Info, String::from("Uploading bundle to S3 is taking longer than expected. It has taken 4 seconds so far.")),
+            (log::Level::Debug, String::from("Uploading bundle to S3 is taking longer than expected. It has taken 2 seconds so far.")),
+            (log::Level::Debug, String::from("Uploading bundle to S3 is taking longer than expected. It has taken 4 seconds so far.")),
         ]);
 
         guard.flush(None);

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,7 @@ quick-junit = "0.5.0"
 colored = "2.1.0"
 console = "0.15.8"
 serde_json = "1.0"
+clap-verbosity-flag = "3.0.2"
 
 [dev-dependencies]
 test_utils = { version = "0.1.0", path = "../test_utils" }


### PR DESCRIPTION
Utilize https://github.com/clap-rs/clap-verbosity-flag for verbosity flags.

* appending `-v` will show debug statements
* appending `-q` will show warn+ statements and `-qq` will silence.
* degrade timeout logs to debug level
