### PR TITLE
Test no cross contamination of env vars

### DIFF
--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -763,3 +763,87 @@ fn test_custom_config() {
         }
     );
 }
+
+#[test]
+fn does_not_cross_contaminate() {
+    let pr_number = 123;
+    let job_url = String::from("https://example.com");
+    let actor = String::from("username");
+    let email = String::from("username@example.com");
+    let commit_author = String::from("username <username@example.com>");
+    let branch = String::from("some-branch-name");
+    let workflow = String::from("test-job-name");
+    let job = String::from("test-job-stage");
+
+    // Contains both a full set of custom and gitlab vars, but we only choose one set to parse
+    let env_vars = EnvVars::from_iter(vec![
+        (String::from("CUSTOM"), String::from("true")),
+        (String::from("JOB_URL"), String::from("custom_job_url")),
+        (String::from("JOB_NAME"), String::from("custom_job_name")),
+        (String::from("AUTHOR_EMAIL"), String::from("custom_email")),
+        (String::from("AUTHOR_NAME"), String::from("custom_name")),
+        (String::from("COMMIT_BRANCH"), String::from("custom_branch")),
+        (
+            String::from("COMMIT_MESSAGE"),
+            String::from("custom_commit_message"),
+        ),
+        (String::from("PR_NUMBER"), pr_number.to_string()),
+        (String::from("PR_TITLE"), String::from("custom_pr_title")),
+        (String::from("GITLAB_CI"), String::from("true")),
+        (String::from("CI_JOB_URL"), String::from(&job_url)),
+        (String::from("CI_MERGE_REQUEST_IID"), pr_number.to_string()),
+        (
+            String::from("CI_COMMIT_AUTHOR"),
+            String::from(&commit_author),
+        ),
+        (
+            String::from("CI_COMMIT_REF_NAME"),
+            format!("remotes/{branch}"),
+        ),
+        (String::from("CI_JOB_NAME"), String::from(&workflow)),
+        (String::from("CI_JOB_STAGE"), String::from(&job)),
+        (
+            String::from("CI_MERGE_REQUEST_EVENT_TYPE"),
+            String::from("merge_train"),
+        ),
+    ]);
+
+    let mut env_parser = EnvParser::new();
+    env_parser.parse(&env_vars);
+
+    let ci_info = env_parser.into_ci_info_parser().unwrap().info_ci_info();
+
+    pretty_assertions::assert_eq!(
+        ci_info,
+        CIInfo {
+            platform: CIPlatform::GitLabCI,
+            job_url: Some(job_url),
+            branch: Some(branch),
+            branch_class: Some(BranchClass::Merge),
+            pr_number: Some(pr_number),
+            actor: Some(actor.clone()),
+            committer_name: Some(actor.clone()),
+            committer_email: Some(email.clone()),
+            author_name: Some(actor),
+            author_email: Some(email),
+            commit_message: None,
+            title: None,
+            workflow: Some(workflow),
+            job: Some(job),
+        }
+    );
+
+    let env_validation = env::validator::validate(&ci_info);
+    assert_eq!(env_validation.max_level(), EnvValidationLevel::SubOptimal);
+    pretty_assertions::assert_eq!(
+        env_validation.issues(),
+        &[
+            EnvValidationIssue::SubOptimal(
+                EnvValidationIssueSubOptimal::CIInfoCommitMessageTooShort(String::from(""),),
+            ),
+            EnvValidationIssue::SubOptimal(EnvValidationIssueSubOptimal::CIInfoTitleTooShort(
+                String::from(""),
+            ),),
+        ]
+    );
+}

--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -831,7 +831,7 @@ fn does_not_cross_contaminate() {
         actor: Some(actor.clone()),
         committer_name: Some(actor.clone()),
         committer_email: Some(email.clone()),
-        author_name: Some(actor.clone()),
+        author_name: Some(actor),
         author_email: Some(email),
         commit_message: None,
         title: None,
@@ -845,15 +845,15 @@ fn does_not_cross_contaminate() {
         branch: Some(custom_branch),
         branch_class: Some(BranchClass::Merge),
         pr_number: Some(custom_pr_number),
-        actor: Some(actor.clone()),
+        actor: Some(custom_email.clone()),
         committer_name: Some(custom_name.clone()),
-        committer_email: Some(custom_name.clone()),
+        committer_email: Some(custom_email.clone()),
         author_name: Some(custom_name),
         author_email: Some(custom_email),
         commit_message: Some(custom_commit_message),
         title: Some(custom_pr_title),
-        workflow: None,
-        job: None,
+        workflow: Some(custom_job_name.clone()),
+        job: Some(custom_job_name),
     };
 
     assert!(


### PR DESCRIPTION
Adds a test to confirm that in the case where env vars are present for two possible ci providers, we only choose from one, to avoid a situation where a messy env causes cross-contamination.