### PR TITLE
Try to discover repo root when not explicitly specified

### DIFF
--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -61,4 +61,3 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
         TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}
         TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
-        REPO_ROOT: ../../..

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -109,13 +109,13 @@ impl UploadArgs {
         token: String,
         org_url_slug: String,
         junit_paths: Vec<String>,
-        repo_root: String,
+        repo_root: Option<String>,
     ) -> Self {
         Self {
             junit_paths,
             org_url_slug,
             token,
-            repo_root: Some(repo_root),
+            repo_root,
             allow_empty_test_results: true,
             ..Default::default()
         }

--- a/context-ruby/Rakefile
+++ b/context-ruby/Rakefile
@@ -30,7 +30,6 @@ task build: :compile
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:test) do |t|
-    ENV['REPO_ROOT'] = '..'
     Rake::Task['compile'].invoke
     t.pattern = FileList['test/*_spec.rb']
   end

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -113,7 +113,7 @@ impl MutTestReport {
         let resolved_path_str = resolved_path.path().to_str().unwrap_or_default();
         let token = env::var("TRUNK_API_TOKEN").unwrap_or_default();
         let org_url_slug = env::var("TRUNK_ORG_URL_SLUG").unwrap_or_default();
-        let repo_root = env::var("REPO_ROOT").unwrap_or(".".to_string());
+        let repo_root = env::var("REPO_ROOT").ok();
         if token.is_empty() || org_url_slug.is_empty() {
             println!("Token or org url slug not set");
             return false;


### PR DESCRIPTION
* If repo root if provided, use it directly
* If repo root is not provided, use discover to find the root