### PR TITLE
[release] Use sha instead of ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create --prerelease --latest=false \
-            --target ${{ github.ref }} \
+            --target ${{ github.sha }} \
             --generate-notes ${{ github.event.inputs.release_tag }} \
             ./build/*.tar.gz
 


### PR DESCRIPTION
The target for running the release does not support using `tag` as a ref. This is problematic because we do tagged beta releases before a full release. Instead grab the `sha` and specify that.

Example failure:
https://github.com/trunk-io/analytics-cli/actions/runs/12997141985/job/36248241679

Example success (with this PR):
https://github.com/trunk-io/analytics-cli/actions/runs/13143067876
