### PR TITLE
Add missing upload parameters

### DIFF
--- a/.github/actions/update_version/action.yaml
+++ b/.github/actions/update_version/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: Release version
   file:
     description: File to update
-    default: ./cli/Cargo.toml
+    required: true
 
 runs:
   using: composite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,12 @@ jobs:
         uses: ./.github/actions/setup_rust_cargo
         if: "!cancelled()"
 
-      - name: Update version
+      - name: Update CLI version
         uses: ./.github/actions/update_version
         if: "!cancelled()"
         with:
           version: ${{ github.event.inputs.release_tag }}
+          file: ./cli/Cargo.toml
 
       - name: Build darwin target
         uses: ./.github/actions/build_cli_macos_target

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -55,7 +55,14 @@ jobs:
           bundler-cache: true
           working-directory: context-ruby
 
-      - name: Update version
+      - name: Update CLI version
+        uses: ./.github/actions/update_version
+        if: "!cancelled()"
+        with:
+          version: ${{ github.event.inputs.release_tag }}
+          file: ./cli/Cargo.toml
+
+      - name: Update Gem version
         uses: ./.github/actions/update_version
         if: "!cancelled()"
         with:

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -354,6 +354,10 @@ fn parse_num_tests(file_sets: &[FileSet]) -> usize {
         .filter_map(|(file, bundled_file)| {
             let file_buf_reader = BufReader::new(file);
             let mut junit_parser = JunitParser::new();
+            // skip .bin files
+            if !bundled_file.original_path.ends_with(".xml") {
+                return None;
+            }
             if let Err(e) = junit_parser.parse(file_buf_reader) {
                 log::warn!(
                     "Encountered error while parsing file {}: {}",

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -29,6 +29,7 @@ pub struct TestRunResult {
     pub command: String,
     pub exec_start: SystemTime,
     pub exit_code: i32,
+    pub num_tests: Option<usize>,
 }
 
 pub async fn run_test(
@@ -93,6 +94,7 @@ pub async fn run_test_command<T: AsRef<str>>(command: &[T]) -> anyhow::Result<Te
     Ok(TestRunResult {
         exit_code,
         exec_start,
+        num_tests: None,
         command: command
             .iter()
             .map(|s| s.as_ref())

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -102,7 +102,6 @@ pub struct UploadArgs {
         default_missing_value = "true",
     )]
     pub allow_empty_test_results: bool,
-    pub num_tests: Option<usize>,
 }
 
 impl UploadArgs {
@@ -111,7 +110,7 @@ impl UploadArgs {
         org_url_slug: String,
         junit_paths: Vec<String>,
         repo_root: Option<String>,
-        num_tests: Option<usize>,
+        use_quarantining: bool,
     ) -> Self {
         Self {
             junit_paths,
@@ -119,7 +118,7 @@ impl UploadArgs {
             token,
             repo_root,
             allow_empty_test_results: true,
-            num_tests,
+            use_quarantining,
             ..Default::default()
         }
     }
@@ -157,7 +156,7 @@ pub async fn run_upload(
         upload_args.allow_empty_test_results,
         &test_run_result,
     )?;
-    if let Some(num_tests) = upload_args.num_tests {
+    if let Some(num_tests) = test_run_result.clone().and_then(|r| r.num_tests) {
         meta.junit_props.num_tests = num_tests;
     }
 

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -102,6 +102,7 @@ pub struct UploadArgs {
         default_missing_value = "true",
     )]
     pub allow_empty_test_results: bool,
+    pub num_tests: Option<usize>,
 }
 
 impl UploadArgs {
@@ -110,6 +111,7 @@ impl UploadArgs {
         org_url_slug: String,
         junit_paths: Vec<String>,
         repo_root: Option<String>,
+        num_tests: Option<usize>,
     ) -> Self {
         Self {
             junit_paths,
@@ -117,6 +119,7 @@ impl UploadArgs {
             token,
             repo_root,
             allow_empty_test_results: true,
+            num_tests,
             ..Default::default()
         }
     }
@@ -154,6 +157,9 @@ pub async fn run_upload(
         upload_args.allow_empty_test_results,
         &test_run_result,
     )?;
+    if let Some(num_tests) = upload_args.num_tests {
+        meta.junit_props.num_tests = num_tests;
+    }
 
     if upload_args.print_files {
         println!("Files to upload:");

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -124,12 +124,12 @@ impl MutTestReport {
                 nanos: Utc::now().timestamp_subsec_nanos() as i32,
             });
         }
-        // TODO - handle finding the repo root automatically
         let upload_args = trunk_analytics_cli::upload_command::UploadArgs::new(
             token,
             org_url_slug,
             vec![resolved_path_str.into()],
             repo_root,
+            Some(self.0.borrow().test_result.test_case_runs.len()),
         );
         let debug_props = BundleMetaDebugProps {
             command_line: self.0.borrow().command.clone(),

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, env, fs};
+use std::{cell::RefCell, env, fs, time::SystemTime};
 
 use bundle::BundleMetaDebugProps;
 use chrono::prelude::*;
@@ -14,6 +14,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 pub struct TestReport {
     test_result: TestResult,
     command: String,
+    started_at: SystemTime,
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
@@ -83,6 +84,7 @@ pub struct MutTestReport(RefCell<TestReport>);
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl MutTestReport {
     pub fn new(origin: String, command: String) -> Self {
+        let started_at = SystemTime::now();
         let mut test_result = TestResult::default();
         test_result.uploader_metadata = Some(UploaderMetadata {
             origin: origin.clone(),
@@ -92,6 +94,7 @@ impl MutTestReport {
         Self(RefCell::new(TestReport {
             test_result,
             command,
+            started_at,
         }))
     }
 
@@ -101,10 +104,6 @@ impl MutTestReport {
 
     // sends out to the trunk api
     pub fn publish(&self) -> bool {
-        let path = self.save();
-        if path.is_err() {
-            return false;
-        }
         let resolved_path = if let Ok(path) = self.save() {
             path
         } else {
@@ -129,18 +128,27 @@ impl MutTestReport {
             org_url_slug,
             vec![resolved_path_str.into()],
             repo_root,
-            Some(self.0.borrow().test_result.test_case_runs.len()),
+            false,
         );
         let debug_props = BundleMetaDebugProps {
             command_line: self.0.borrow().command.clone(),
+        };
+        let test_run_result = trunk_analytics_cli::test_command::TestRunResult {
+            command: self.0.borrow().command.clone(),
+            exec_start: self.0.borrow().started_at,
+            exit_code: 0,
+            num_tests: Some(self.0.borrow().test_result.test_case_runs.len()),
         };
         if let Ok(pre_test_context) = gather_pre_test_context(upload_args.clone(), debug_props) {
             match tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .unwrap()
-                .block_on(run_upload(upload_args, Some(pre_test_context), None))
-            {
+                .block_on(run_upload(
+                    upload_args,
+                    Some(pre_test_context),
+                    Some(test_run_result),
+                )) {
                 Ok(_) => true,
                 Err(e) => {
                     println!("Error uploading: {:?}", e);
@@ -157,7 +165,12 @@ impl MutTestReport {
     fn save(&self) -> Result<tempfile::NamedTempFile, anyhow::Error> {
         let buf = self.serialize_test_result();
         let named_temp_file = tempfile::Builder::new().suffix(".bin").tempfile()?;
-        fs::write(&named_temp_file, buf).unwrap_or_default();
+        fs::write(&named_temp_file, buf)?;
+        // file modification uses filetime which is less precise than systemTime
+        // we need to update it to the current time to avoid race conditions later down the line
+        // when the start time ends up being after the file modification time
+        let file = fs::File::open(&named_temp_file).unwrap();
+        file.set_modified(SystemTime::now())?;
         Ok(named_temp_file)
     }
 

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -25,7 +25,7 @@ async fn publish_test_report() {
     env::set_var("TRUNK_ORG_URL_SLUG", "test-org");
 
     let thread_join_handle = thread::spawn(|| {
-        let test_report = MutTestReport::new("test".into(), "".into());
+        let test_report = MutTestReport::new("test".into(), "test-command 123".into());
         test_report.add_test(
             Some("1".into()),
             "test-name".into(),
@@ -81,7 +81,7 @@ async fn publish_test_report() {
     let time_since_upload = chrono::Utc::now()
         - chrono::DateTime::from_timestamp(base_props.upload_time_epoch as i64, 0).unwrap();
     more_asserts::assert_lt!(time_since_upload.num_minutes(), 5);
-    assert_eq!(base_props.test_command, None);
+    assert_eq!(base_props.test_command, Some("test-command 123".into()));
     assert!(base_props.os_info.is_some());
     assert!(base_props.quarantined_tests.is_empty());
 

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -92,7 +92,7 @@ async fn publish_test_report() {
 
     let junit_props = bundle_meta.junit_props;
     assert_eq!(junit_props.num_files, 1);
-    assert_eq!(junit_props.num_tests, 0);
+    assert_eq!(junit_props.num_tests, 1);
 
     let bundled_file = file_set.files.first().unwrap();
     assert_eq!(bundled_file.path, "internal/0");


### PR DESCRIPTION
We were missing the test count and version information.

Test count was caused by us only parsing out the count for junit. Instead we'll allow the uploader specify it. Otherwise we have a circular dependency between upload and test report.

Version information was missing because we weren't updating it when publishing the gem.


<img width="1494" alt="Screenshot 2025-02-05 at 10 34 55 AM" src="https://github.com/user-attachments/assets/f4883e2f-ec27-4dd8-b0c8-fa6336aaba49" />
