### PR TITLE
[TRUNK-13843] Don't retry on invalid json or some errors

### DIFF
--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -43,10 +43,8 @@ pub trait AbortableRetry {
 
 impl AbortableRetry for anyhow::Error {
     fn should_retry(&self) -> bool {
-        println!("Should retrying anyhow error {:#?}", self);
         let self_text = format!("{self}");
-        println!("it had text {:#?}", self_text);
-        let x = !self_text.contains(UNAUTHORIZED_CONTEXT)
+        !self_text.contains(UNAUTHORIZED_CONTEXT)
             && !self_text.contains(NOT_FOUND_CONTEXT)
             && self.chain().fold(true, |acc: bool, cause| {
                 let cause_should_retry =
@@ -56,16 +54,13 @@ impl AbortableRetry for anyhow::Error {
                         true
                     };
                 acc && cause_should_retry
-            });
-        println!("anyhow result was {:#?}", x);
-        x
+            })
     }
 }
 
 impl AbortableRetry for reqwest::Error {
     fn should_retry(&self) -> bool {
-        println!("Should retrying reqwest error {:#?}", self);
-        let x = !(self.is_decode()
+        !(self.is_decode()
             || self.status().map_or(false, |status: StatusCode| {
                 // List of codes for which we do not retry
                 match status {
@@ -106,9 +101,7 @@ impl AbortableRetry for reqwest::Error {
 
                     _ => false,
                 }
-            }));
-        println!("reqwest Result was {:#?}", x);
-        x
+            }))
     }
 }
 

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -260,18 +260,28 @@ impl ApiClient {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum CheckUnauthorized {
+pub(crate) enum CheckUnauthorized {
     Check,
     DoNotCheck,
 }
 
 #[derive(Debug, Clone, Copy)]
-enum CheckNotFound {
+pub(crate) enum CheckNotFound {
     Check,
     DoNotCheck,
 }
 
-fn status_code_help<T: FnMut(&Response) -> String>(
+pub(crate) const UNAUTHORIZED_CONTEXT: &str = concat!(
+    "Your Trunk token may be incorrect - find it on the Trunk app ",
+    "(Settings -> Manage Organization -> Organization API Token -> View).",
+);
+
+pub(crate) const NOT_FOUND_CONTEXT: &str = concat!(
+    "Your Trunk organization URL slug may be incorrect - find it on the Trunk app ",
+    "(Settings -> Manage Organization -> Organization Slug).",
+);
+
+pub(crate) fn status_code_help<T: FnMut(&Response) -> String>(
     response: &Response,
     check_unauthorized: CheckUnauthorized,
     check_not_found: CheckNotFound,
@@ -282,14 +292,8 @@ fn status_code_help<T: FnMut(&Response) -> String>(
     }
 
     let error_message = match (response.status(), check_unauthorized, check_not_found) {
-        (StatusCode::UNAUTHORIZED, CheckUnauthorized::Check, _) => concat!(
-            "Your Trunk token may be incorrect - find it on the Trunk app ",
-            "(Settings -> Manage Organization -> Organization API Token -> View).",
-        ),
-        (StatusCode::NOT_FOUND, _, CheckNotFound::Check) => concat!(
-            "Your Trunk organization URL slug may be incorrect - find it on the Trunk app ",
-            "(Settings -> Manage Organization -> Organization Slug).",
-        ),
+        (StatusCode::UNAUTHORIZED, CheckUnauthorized::Check, _) => UNAUTHORIZED_CONTEXT,
+        (StatusCode::NOT_FOUND, _, CheckNotFound::Check) => NOT_FOUND_CONTEXT,
         _ => &create_error_message(response),
     };
 


### PR DESCRIPTION
Adds logic to check for specific errors or invalid json, and only retry when we don't hit those conditions. The list of errors is mostly derived from https://stackoverflow.com/questions/47680711/which-http-errors-should-never-trigger-an-automatic-retry