### PR TITLE
Change "test suite name too short" error message

### DIFF
--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -84,7 +84,7 @@ fn validate_invalid_junits_no_codeowners() {
         .failure()
         .stdout(predicate::str::contains("1 validation error"))
         .stdout(predicate::str::contains(
-            "INVALID - test suite name too short",
+            "INVALID - test suite names are missing",
         ))
         .stdout(predicate::str::contains("Checking for codeowners file..."))
         .stdout(predicate::str::contains(

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -523,7 +523,7 @@ pub enum JunitTestSuiteValidationIssueSubOptimal {
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum JunitTestSuiteValidationIssueInvalid {
-    #[error("test suite name too short")]
+    #[error("test suite names are missing")]
     TestSuiteNameTooShort(String),
 }
 


### PR DESCRIPTION
Thread for context - https://trunk-io.slack.com/archives/C07PYM8K0PQ/p1738868935422339?thread_ts=1738868074.771829&cid=C07PYM8K0PQ

TL:DR - while we investigate if this is actually still really a true error, I want to make the error message clearer

Very open to messaging changes