### PR TITLE
Prevent retry on client errors

### DIFF
--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -339,7 +339,7 @@ mod tests {
                 let http_response = http::Response::builder().status(404).body("body").unwrap();
                 let response = Response::from(http_response);
                 status_code_help(
-                    &response,
+                    response,
                     CheckUnauthorized::DoNotCheck,
                     CheckNotFound::Check,
                     |_e| String::from("Test message"),


### PR DESCRIPTION
Our handling of client errors was obscuring the Error that we'd expect to see, which prevented the retry mechanism from catching them.