### PR TITLE
Force sentry dev on prs

### DIFF
--- a/.github/actions/build_cli_linux_target/action.yaml
+++ b/.github/actions/build_cli_linux_target/action.yaml
@@ -6,6 +6,9 @@ inputs:
     description: Rust target triple, e.g. x86_64-unknown-linux-musl
   profile:
     description: Rust profile to build, e.g. release-with-debug
+  force-sentry-dev:
+    description: Force sentry to use a devenv (set to true for testing, but not for releases)
+    default: false
 
 runs:
   using: composite
@@ -21,6 +24,7 @@ runs:
       with:
         target: ${{ inputs.target }}
         profile: ${{ inputs.profile }}
+        force-sentry-dev: ${{ inputs.force-sentry-dev }}
 
     - name: Strip debug info
       shell: bash

--- a/.github/actions/build_cli_macos_target/action.yaml
+++ b/.github/actions/build_cli_macos_target/action.yaml
@@ -6,6 +6,9 @@ inputs:
     description: Rust target triple, e.g. x86_64-apple-darwin
   profile:
     description: Rust profile to build, e.g. release-with-debug
+  force-sentry-dev:
+    description: Force sentry to use a devenv (set to true for testing, but not for releases)
+    default: false
 
 runs:
   using: composite
@@ -15,6 +18,7 @@ runs:
       with:
         target: ${{ inputs.target }}
         profile: ${{ inputs.profile }}
+        force-sentry-dev: ${{ inputs.force-sentry-dev }}
 
     - name: Strip debug info
       shell: bash

--- a/.github/actions/build_cli_target/action.yaml
+++ b/.github/actions/build_cli_target/action.yaml
@@ -9,6 +9,9 @@ inputs:
   toolchain:
     description: Rust toolchain to use, e.g. nightly
     default: nightly
+  force-sentry-dev:
+    description: Force sentry to use a devenv (set to true for testing, but not for releases)
+    default: false
 
 runs:
   using: composite
@@ -30,7 +33,7 @@ runs:
         target: ${{ inputs.target }}
         toolchain: ${{ inputs.toolchain }}
         # NOTE: DO NOT BUILD WORKSPACE OTHERWISE THE CLI MAY BE LINKED TO UNNECESSARY LIBRARIES
-        args: "-p trunk-analytics-cli --profile=${{ inputs.profile }} --target=${{ inputs.target }}"
+        args: "-p trunk-analytics-cli --profile=${{ inputs.profile }} --target=${{ inputs.target }} ${{ (inputs.force-sentry-dev == 'true' && '--features force-sentry-env-dev') || '' }}"
         use-rust-cache: false
 
     - name: Build CLI ${{ inputs.target }} target
@@ -38,7 +41,7 @@ runs:
       if: ${{ contains(inputs.target, 'darwin') }}
       # NOTE: DO NOT BUILD WORKSPACE OTHERWISE THE CLI MAY BE LINKED TO UNNECESSARY LIBRARIES
       run: |
-        cargo build -p trunk-analytics-cli --profile=${{ inputs.profile }} --target=${{ inputs.target }}
+        cargo build -p trunk-analytics-cli --profile=${{ inputs.profile }} --target=${{ inputs.target }} ${{ (inputs.force-sentry-dev == 'true') && '--features force-sentry-env-dev') || '' }}
 
     - name: Create binary with debug info
       shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           profile: release
+          force-sentry-dev: true
 
       - name: Build unix target
         uses: ./.github/actions/build_cli_linux_target
@@ -75,6 +76,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           profile: release
+          force-sentry-dev: true
 
       - name: Upload results using action from ${{ matrix.platform.target }}
         uses: ./.github/actions/upload_test_results


### PR DESCRIPTION
Sentry was creating errors whenever a pr failed tests, so forcing sentry to use dev in prs.