### PR TITLE
Fix bazel Bep when using `test` command

### DIFF
--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -144,12 +144,17 @@ pub fn gather_post_test_context<U: AsRef<Path>>(
     allow_empty_test_results: bool,
     test_run_result: &Option<TestRunResult>,
 ) -> anyhow::Result<FileSetBuilder> {
+    let exec_start = if let Some(test_run_result) = test_run_result {
+        test_run_result.exec_start
+    } else {
+        None
+    };
     let mut file_set_builder = FileSetBuilder::build_file_sets(
         &meta.base_props.repo.repo_root,
         &junit_path_wrappers,
         team,
         codeowners_path,
-        test_run_result.as_ref().map(|r| r.exec_start),
+        exec_start,
     )?;
 
     if !allow_empty_test_results && file_set_builder.no_files_found() {

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -27,7 +27,7 @@ pub struct TestArgs {
 #[derive(Debug, Clone)]
 pub struct TestRunResult {
     pub command: String,
-    pub exec_start: SystemTime,
+    pub exec_start: Option<SystemTime>,
     pub exit_code: i32,
     pub num_tests: Option<usize>,
 }
@@ -42,8 +42,11 @@ pub async fn run_test(
     let pre_test_context = gather_pre_test_context(upload_args.clone(), gather_debug_props(token))?;
 
     log::info!("running command: {:?}", command);
-    let test_run_result = run_test_command(&command).await?;
+    let mut test_run_result = run_test_command(&command).await?;
     let test_run_result_exit_code = test_run_result.exit_code;
+    if upload_args.bazel_bep_path.is_some() {
+        test_run_result.exec_start = None;
+    }
 
     let upload_run_result =
         run_upload(upload_args, Some(pre_test_context), Some(test_run_result)).await;
@@ -93,7 +96,7 @@ pub async fn run_test_command<T: AsRef<str>>(command: &[T]) -> anyhow::Result<Te
 
     Ok(TestRunResult {
         exit_code,
-        exec_start,
+        exec_start: Some(exec_start),
         num_tests: None,
         command: command
             .iter()

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -158,7 +158,7 @@ impl MutTestReport {
         };
         let test_run_result = trunk_analytics_cli::test_command::TestRunResult {
             command: self.0.borrow().command.clone(),
-            exec_start: self.0.borrow().started_at,
+            exec_start: Some(self.0.borrow().started_at),
             exit_code: 0,
             num_tests: Some(self.0.borrow().test_result.test_case_runs.len()),
         };


### PR DESCRIPTION
Bazel is generating xml files that we mark as stale when using the `test` subcommand. This works as expected with `upload` because it doesn't check the modification time of the files. Override `exec_start` to be None when using bazel-bep. This is moving that check into bazel since we're treating it as a stronger source of truth.