### PR TITLE
Fix retries on server errors

### DIFF
--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -91,7 +91,6 @@ impl AbortableRetry for reqwest::Error {
 
                     // 500
                     StatusCode::NOT_IMPLEMENTED => true,
-                    StatusCode::SERVICE_UNAVAILABLE => true,
                     StatusCode::HTTP_VERSION_NOT_SUPPORTED => true,
                     StatusCode::VARIANT_ALSO_NEGOTIATES => true,
                     StatusCode::INSUFFICIENT_STORAGE => true,


### PR DESCRIPTION
Server errors were not being reported as reqwest errors, which meant that we would try to decode them as json, leading to a decoding error. Since we don't retry invalid json, this meant we never retried any server errors. The fix is to use reqest's methods for converting from a Response with an error code into an error.