### PR TITLE
Re-add errors

### DIFF
--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -83,7 +83,7 @@ impl BundlerUtil {
                     .iter()
                     .fold(tempfile::tempfile()?, |f, event| {
                         if let Err(e) = serde_json::to_writer(&f, event) {
-                            tracing::warn!("Failed to write BEP event: {}", e);
+                            tracing::error!("Failed to write BEP event: {}", e);
                         }
                         f
                     });

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -67,7 +67,7 @@ impl FailedTestsExtractor {
                 let file = match std::fs::File::open(&file.original_path) {
                     Ok(file) => file,
                     Err(e) => {
-                        tracing::error!("Error opening file: {}", e);
+                        tracing::warn!("Error opening file: {}", e);
                         continue;
                     }
                 };
@@ -182,7 +182,7 @@ pub async fn gather_quarantine_context(
         let result = api_client.get_quarantining_config(request).await;
 
         if let Err(ref err) = result {
-            tracing::warn!("{}", err);
+            tracing::error!("{}", err);
         }
 
         result.unwrap_or_default()

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -67,7 +67,7 @@ impl FailedTestsExtractor {
                 let file = match std::fs::File::open(&file.original_path) {
                     Ok(file) => file,
                     Err(e) => {
-                        tracing::warn!("Error opening file: {}", e);
+                        tracing::error!("Error opening file: {}", e);
                         continue;
                     }
                 };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> anyhow::Result<()> {
                         std::process::exit(exitcode::OK);
                     }
                     _ => {
-                        tracing::warn!("Error: {:?}", e);
+                        tracing::error!("Error: {:?}", e);
                         std::process::exit(exitcode::SOFTWARE);
                     }
                 },

--- a/cli/src/quarantine_command.rs
+++ b/cli/src/quarantine_command.rs
@@ -23,7 +23,7 @@ pub async fn run_quarantine(QuarantineArgs { upload_args }: QuarantineArgs) -> a
              upload_bundle_error,
          }| {
             if let Some(e) = upload_bundle_error {
-                tracing::warn!("Error uploading test results: {:?}", e);
+                tracing::error!("Error uploading test results: {:?}", e);
             }
             exit_code
         },

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -72,7 +72,7 @@ pub async fn run_test(
             },
         )
         .or_else(|e| {
-            tracing::warn!("Error uploading test results: {:?}", e);
+            tracing::error!("Error uploading test results: {:?}", e);
             Ok(test_run_result_exit_code)
         })
 }

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -169,7 +169,7 @@ impl MutTestReport {
                 )) {
                 Ok(_) => true,
                 Err(e) => {
-                    tracing::warn!("Error uploading: {:?}", e);
+                    tracing::error!("Error uploading: {:?}", e);
                     false
                 }
             }


### PR DESCRIPTION
Re-adds errors that were warnified in b2c1733033d8. Specifically targeting failures when connecting to web services, and did not errorify messages about parsing codeowners, waiting for a test subcommand to complete, and gathering pre-test context.