### PR TITLE
Add better logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -24,6 +24,7 @@ tokio-retry = { version = "0.3", default-features = false }
 constants = { version = "0.0.0", path = "../constants" }
 tracing = "0.1.41"
 sentry = { version = "=0.36.0", features = ["debug-images"] }
+url = "2.5.4"
 
 [dev-dependencies]
 axum = { version = "0.7.5", features = ["macros"] }

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -10,7 +10,7 @@ use crate::call_api::CallApi;
 use crate::message;
 
 pub struct ApiClient {
-    host: String,
+    pub host: String,
     s3_client: Client,
     trunk_client: Client,
     version_path_prefix: String,

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,3 +1,4 @@
 mod call_api;
 pub mod client;
 pub mod message;
+pub mod urls;

--- a/api/src/urls.rs
+++ b/api/src/urls.rs
@@ -1,0 +1,64 @@
+use bundle::Test;
+use context::repo::RepoUrlParts;
+use url::{form_urlencoded, ParseError, Url};
+
+pub fn url_for_test_case(
+    public_api_address: &String,
+    org_url_slug: &String,
+    repo: &RepoUrlParts,
+    test_case: &Test,
+) -> Result<String, ParseError> {
+    let mut url = Url::parse(convert_to_app(public_api_address).as_str())?;
+    url.set_path(test_path(org_url_slug, test_case).as_str());
+    url.set_query(Some(repo_query(repo).as_str()));
+    Ok(url.to_string())
+}
+
+fn convert_to_app(public_api_address: &String) -> String {
+    public_api_address.replace("https://api.", "https://app.")
+}
+
+fn test_path(org_url_slug: &String, test_case: &Test) -> String {
+    format!("{}/flaky-tests/test/{}", org_url_slug, test_case.id)
+}
+
+fn repo_query(repo: &RepoUrlParts) -> String {
+    let value: String =
+        form_urlencoded::byte_serialize(format!("{}/{}", repo.owner, repo.name).as_bytes())
+            .collect();
+    format!("repo={}", value)
+}
+
+#[test]
+fn test_url_generated() {
+    let repo = RepoUrlParts {
+        host: String::from("https://github.com"),
+        owner: String::from("bad-app"),
+        name: String::from("ios-app"),
+    };
+
+    let test = Test {
+        name: String::from("can math"),
+        parent_name: String::from("basic suite"),
+        class_name: None,
+        file: None,
+        id: String::from("c33a7f64-8f3e-5db9-b37b-2ea870d2441b"),
+        timestamp_millis: None,
+    };
+
+    let actual = url_for_test_case(
+        &String::from("https://api.trunk-staging.io"),
+        &String::from("bad-app-org"),
+        &repo,
+        &test,
+    );
+
+    assert_eq!(
+    actual,
+    Ok(
+      String::from(
+        "https://app.trunk-staging.io/bad-app-org/flaky-tests/test/c33a7f64-8f3e-5db9-b37b-2ea870d2441b?repo=bad-app%2Fios-app"
+      )
+    ),
+  );
+}

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use api::client::ApiClient;
+use api::{client::ApiClient, urls::url_for_test_case};
 use bundle::{FileSet, FileSetBuilder, QuarantineBulkTestStatus, Test};
 use constants::{EXIT_FAILURE, EXIT_SUCCESS};
 use context::{
@@ -225,6 +225,16 @@ pub async fn gather_quarantine_context(
                 },
                 failure.id
             );
+            if quarantine_failure {
+                if let Ok(url) = url_for_test_case(
+                    &api_client.host,
+                    &request.org_url_slug,
+                    &request.repo,
+                    &failure,
+                ) {
+                    tracing::info!("Test page: {}", url);
+                }
+            }
             if quarantine_failure {
                 Some(failure)
             } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,7 +67,11 @@ fn main() -> anyhow::Result<()> {
             let cli = Cli::parse();
             let log_level_filter = cli.verbose.log_level_filter();
             setup_logger(log_level_filter)?;
-            tracing::info!(command = cli.debug_props(), "Running command");
+            tracing::info!("{}", TITLE_CARD);
+            tracing::info!(
+                command = cli.debug_props(),
+                "Trunk Flaky Test running command"
+            );
             match run(cli).await {
                 Ok(exit_code) => std::process::exit(exit_code),
                 Err(e) => match (*(e.root_cause())).downcast_ref::<std::io::Error>() {
@@ -121,9 +125,28 @@ fn to_trace_filter(filter: log::LevelFilter) -> tracing::level_filters::LevelFil
 
 fn setup_logger(log_level_filter: LevelFilter) -> anyhow::Result<()> {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_target(false))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(false)
+                .without_time(),
+        )
         .with(sentry_tracing::layer())
         .with(to_trace_filter(log_level_filter))
         .init();
     Ok(())
 }
+
+// Uses a raw string to avoid needing to escape quotes in the title card. This is mostly just so you can see
+// what it looks like in code rather than needing to print.
+const TITLE_CARD: &str = r#"
+88888888888  88              88                        888888888888                                        
+88           88              88                             88                           ,d                
+88           88              88                             88                           88                
+88aaaaa      88  ,adPPYYba,  88   ,d8  8b       d8          88   ,adPPYba,  ,adPPYba,  MM88MMM  ,adPPYba,  
+88"""""      88  ""     `Y8  88 ,a8"   `8b     d8'          88  a8P_____88  I8[    ""    88     I8[    ""  
+88           88  ,adPPPPP88  8888[      `8b   d8'           88  8PP"""""""   `"Y8ba,     88      `"Y8ba,   
+88           88  88,    ,88  88`"Yba,    `8b,d8'            88  "8b,   ,aa  aa    ]8I    88,    aa    ]8I  
+88           88  `"8bbdP"Y8  88   `Y8a     Y88'             88   `"Ybbd8"'  `"YbbdP"'    "Y888  `"YbbdP"'  
+                                           d8'                                                             
+                                          d8'                                                              
+"#;

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -106,7 +106,11 @@ impl MutTestReport {
 
     fn setup_logger() -> anyhow::Result<()> {
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_target(false))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(false)
+                    .without_time(),
+            )
             .with(sentry_tracing::layer())
             .with(tracing::level_filters::LevelFilter::INFO)
             .init();


### PR DESCRIPTION
Adds the logic requested by BB-340, with the exception of showing status since logs, as we can get all of those without needing to modify the flaky tests server.

Added logs outlined in red:
![command_screenshot](https://github.com/user-attachments/assets/6a7ca77c-0fe2-4889-b49b-eec5fba3196c)