### PR TITLE
Small sentry fixes

### DIFF
--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -190,6 +190,7 @@ async fn upload_bundle() {
             .build_args()
             .join(" ")
             .replace("test-token", "***")
+            .replace("--token", "")
     ));
 
     // HINT: View CLI output with `cargo test -- --nocapture`

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -46,7 +46,9 @@ pub fn gather_debug_props(token: String) -> BundleMetaDebugProps {
         command_line: env::args()
             .collect::<Vec<String>>()
             .join(" ")
-            .replace(&token, "***"),
+            .replace(&token, "***")
+            .replace("--token=", "")
+            .replace("--token", ""),
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,7 +57,7 @@ enum Commands {
 // "the Sentry client must be initialized before starting an async runtime or spawning threads"
 // https://docs.sentry.io/platforms/rust/#async-main-function
 fn main() -> anyhow::Result<()> {
-    let release_name = env!("CARGO_PKG_VERSION");
+    let release_name = format!("analytics-cli@{}", env!("CARGO_PKG_VERSION"));
     let _guard = sentry::init(release_name.into(), None);
 
     tokio::runtime::Builder::new_multi_thread()

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -115,7 +115,7 @@ impl MutTestReport {
 
     // sends out to the trunk api
     pub fn publish(&self) -> bool {
-        let release_name = env!("CARGO_PKG_VERSION");
+        let release_name = format!("rspec-flaky-tests@{}", env!("CARGO_PKG_VERSION"));
         let _guard = sentry::init(release_name.into(), None);
         let _logger_setup_res = MutTestReport::setup_logger();
         let resolved_path = if let Ok(path) = self.save() {


### PR DESCRIPTION
Addresses the following issues:
* The command is being filtered because `token` exists in the string
* sentry isn't treating out release as semver compatible