### PR TITLE
Print checksum and file size in smoke tests

### DIFF
--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -17,6 +17,8 @@ runs:
       shell: bash
       run: |
         chmod +x ${{ inputs.cli-binary-location }}
+        sha256sum ${{ inputs.cli-binary-location }}
+        ls -l ${{ inputs.cli-binary-location }}
 
     - name: Run tests on staging
       env:


### PR DESCRIPTION
Two smoke tests failed with a mysterious exit code of 127 this year:

[Jan 1](https://github.com/trunk-io/analytics-cli/actions/runs/12573101685/job/35045772864)
[Feb 15](https://github.com/trunk-io/analytics-cli/actions/runs/13346579624/job/37277741684)

Hopefully with this output we can verify that the binary is on disk, and that it hasn't been corrupted.