### PR TITLE
Show debug statements in sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "lazy_static",
  "log",
  "reqwest",
- "sentry 0.36.0",
+ "sentry",
  "serde",
  "serde_json",
  "tempfile",
@@ -3975,25 +3975,6 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
-dependencies = [
- "httpdate",
- "native-tls",
- "reqwest",
- "sentry-backtrace 0.34.0",
- "sentry-contexts 0.34.0",
- "sentry-core 0.34.0",
- "sentry-debug-images 0.34.0",
- "sentry-panic 0.34.0",
- "sentry-tracing 0.34.0",
- "tokio",
- "ureq",
-]
-
-[[package]]
-name = "sentry"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
@@ -4001,26 +3982,14 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
- "sentry-backtrace 0.36.0",
- "sentry-contexts 0.36.0",
- "sentry-core 0.36.0",
- "sentry-debug-images 0.36.0",
- "sentry-panic 0.36.0",
- "sentry-tracing 0.36.0",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
  "tokio",
  "ureq",
-]
-
-[[package]]
-name = "sentry-backtrace"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
-dependencies = [
- "backtrace",
- "once_cell",
- "regex",
- "sentry-core 0.34.0",
 ]
 
 [[package]]
@@ -4032,21 +4001,7 @@ dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core 0.36.0",
-]
-
-[[package]]
-name = "sentry-contexts"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
-dependencies = [
- "hostname",
- "libc",
- "os_info",
- "rustc_version",
- "sentry-core 0.34.0",
- "uname",
+ "sentry-core",
 ]
 
 [[package]]
@@ -4059,21 +4014,8 @@ dependencies = [
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core 0.36.0",
+ "sentry-core",
  "uname",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
-dependencies = [
- "once_cell",
- "rand",
- "sentry-types 0.34.0",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4084,20 +4026,9 @@ checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
 dependencies = [
  "once_cell",
  "rand",
- "sentry-types 0.36.0",
+ "sentry-types",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "sentry-debug-images"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
-dependencies = [
- "findshlibs",
- "once_cell",
- "sentry-core 0.34.0",
 ]
 
 [[package]]
@@ -4108,7 +4039,7 @@ checksum = "2a60bc2154e6df59beed0ac13d58f8dfaf5ad20a88548a53e29e4d92e8e835c2"
 dependencies = [
  "findshlibs",
  "once_cell",
- "sentry-core 0.36.0",
+ "sentry-core",
 ]
 
 [[package]]
@@ -4118,17 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c96d796cba1b3a0793e7f53edc420c61f9419fba8fb34ad5519f5c7d01af6b2"
 dependencies = [
  "log",
- "sentry-core 0.36.0",
-]
-
-[[package]]
-name = "sentry-panic"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
-dependencies = [
- "sentry-backtrace 0.34.0",
- "sentry-core 0.34.0",
+ "sentry-core",
 ]
 
 [[package]]
@@ -4137,20 +4058,8 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "105e3a956c8aa9dab1e4087b1657b03271bfc49d838c6ae9bfc7c58c802fd0ef"
 dependencies = [
- "sentry-backtrace 0.36.0",
- "sentry-core 0.36.0",
-]
-
-[[package]]
-name = "sentry-tracing"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
-dependencies = [
- "sentry-backtrace 0.34.0",
- "sentry-core 0.34.0",
- "tracing-core",
- "tracing-subscriber",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
@@ -4159,27 +4068,10 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e75c831b4d8b34a5aec1f65f67c5d46a26c7c5d3c7abd8b5ef430796900cf8"
 dependencies = [
- "sentry-backtrace 0.36.0",
- "sentry-core 0.36.0",
+ "sentry-backtrace",
+ "sentry-core",
  "tracing-core",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
-dependencies = [
- "debugid",
- "hex",
- "rand",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -4529,7 +4421,7 @@ dependencies = [
  "prost",
  "prost-wkt-types",
  "proto",
- "sentry-tracing 0.36.0",
+ "sentry-tracing",
  "serde_json",
  "tempfile",
  "test_utils",
@@ -4552,7 +4444,7 @@ dependencies = [
  "junit-mock",
  "lazy_static",
  "log",
- "sentry 0.36.0",
+ "sentry",
  "tar",
  "tempfile",
  "tokio",
@@ -4567,7 +4459,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "log",
- "sentry 0.36.0",
+ "sentry",
  "sentry-log",
 ]
 
@@ -4975,8 +4867,7 @@ dependencies = [
  "openssl-src",
  "quick-junit",
  "reqwest",
- "sentry 0.34.0",
- "sentry-tracing 0.36.0",
+ "sentry-tracing",
  "serde_json",
  "tempfile",
  "test_utils",

--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -63,6 +63,11 @@ impl AbortableRetry for reqwest::Error {
         !(self.is_decode()
             || self.status().map_or(false, |status: StatusCode| {
                 // List of codes for which we do not retry
+                if let Some(url) = self.url() {
+                    tracing::debug!("Received status code {:?} for {:?}", status, url.as_str());
+                } else {
+                    tracing::debug!("Received status code {:?}", status);
+                }
                 match status {
                     // 400
                     StatusCode::BAD_REQUEST => true,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,6 @@ reqwest = { version = "0.12.5", default-features = false, features = [
 ] }
 codeowners = { path = "../codeowners" }
 xcresult = { path = "../xcresult" }
-sentry = { version = "0.34.0", features = ["debug-images"] }
 sentry-tracing = "0.36.0"
 openssl = { version = "0.10.70", features = ["vendored"] }
 openssl-src = { version = "=300.3.1", optional = true }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -80,6 +80,7 @@ pub fn gather_pre_test_context(
         repo_head_branch,
         repo_head_commit_epoch,
     )?;
+    tracing::debug!("Found repo state: {:?}", repo);
 
     let (junit_path_wrappers, bep_result, junit_path_wrappers_temp_dir) =
         coalesce_junit_path_wrappers(

--- a/third-party/src/sentry.rs
+++ b/third-party/src/sentry.rs
@@ -35,10 +35,3 @@ pub fn init(
 
     sentry::init(opts)
 }
-
-pub fn logger(mut builder: env_logger::Builder, log_level: log::LevelFilter) -> anyhow::Result<()> {
-    let logger = sentry_log::SentryLogger::with_dest(builder.build());
-    log::set_boxed_logger(Box::new(logger))?;
-    log::set_max_level(log_level);
-    Ok(())
-}


### PR DESCRIPTION
Adds support for sending debug to sentry while hiding it from the UI.

Terminal:
```
   Compiling trunk-analytics-cli v0.0.0 (/Users/work/src/analytics-cli/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `/Users/work/src/analytics-cli/target/debug/trunk-analytics-cli upload --org-url-slug=test --token=1234 --junit-paths=.`
 INFO 
88888888888  88              88                        888888888888                                        
88           88              88                             88                           ,d                
88           88              88                             88                           88                
88aaaaa      88  ,adPPYYba,  88   ,d8  8b       d8          88   ,adPPYba,  ,adPPYba,  MM88MMM  ,adPPYba,  
88"""""      88  ""     `Y8  88 ,a8"   `8b     d8'          88  a8P_____88  I8[    ""    88     I8[    ""  
88           88  ,adPPPPP88  8888[      `8b   d8'           88  8PP"""""""   `"Y8ba,     88      `"Y8ba,   
88           88  88,    ,88  88`"Yba,    `8b,d8'            88  "8b,   ,aa  aa    ]8I    88,    aa    ]8I  
88           88  `"8bbdP"Y8  88   `Y8a     Y88'             88   `"Ybbd8"'  `"YbbdP"'    "Y888  `"YbbdP"'  
                                           d8'                                                             
                                          d8'                                                              

 INFO Trunk Flaky Test running command command="/Users/work/src/analytics-cli/target/debug/trunk-analytics-cli upload --org-url-slug=test *** --junit-paths=."
ERROR is this error captured
 INFO Starting trunk flakytests 0.0.0 (git=173e4f2fe35792080e8b746f2c2de6e30a2f908a) rustc=1.80.0-nightly
 INFO Using public api address https://api.trunk-staging.io
 INFO Using repo root at "/Users/work/src/analytics-cli/.git"
 INFO Total files pack and upload: 6
 INFO Checking if failed tests can be quarantined
ERROR Failed to get quarantine bulk test.

For more help, contact us at https://slack.trunk.io/
 INFO GoodbyeTest -> Goodbye  Learn more > https://app.trunk-staging.io/test/flaky-tests/test/29154112-2e52-5159-bfd7-0c35ae149b6b?repo=trunk-io%2Fanalytics-cli
 INFO Not all test failures were quarantined, returning exit code from command.
ERROR Error: Failed to create repo.

For more help, contact us at https://slack.trunk.io/

Caused by:
    HTTP status client error (404 Not Found) for url (https://api.trunk-staging.io/v1/repo/create)
```

Sentry event:
https://trunkio.sentry.io/issues/6293568279/events/7f1c362257d24043a2102414af182551/

Note that debug logs for connections are there.