### PR TITLE
Remove sha256sum check from smoke tests

### DIFF
--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -17,7 +17,6 @@ runs:
       shell: bash
       run: |
         chmod +x ${{ inputs.cli-binary-location }}
-        sha256sum ${{ inputs.cli-binary-location }}
         ls -l ${{ inputs.cli-binary-location }}
 
     - name: Run tests on staging


### PR DESCRIPTION
This doesn't work on Mac