### PR TITLE
Add smoke test workflow dispatch

### DIFF
--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -22,7 +22,7 @@ runs:
         ls -l ${{ inputs.cli-binary-location }}
 
     - name: Run tests on staging
-      if: inputs.environment-type == "staging" || inputs.environment-type == "both"
+      if: inputs.environment-type == 'staging' || inputs.environment-type == 'both'
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         FAIL_TEST: true
@@ -35,7 +35,7 @@ runs:
         cargo nextest run -p smoke-test --profile ci
 
     - name: Run tests on production
-      if: inputs.environment-type == "production" || inputs.environment-type == "both"
+      if: inputs.environment-type == 'production' || inputs.environment-type == 'both'
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
         FAIL_TEST: true
@@ -48,7 +48,7 @@ runs:
         cargo nextest run -p smoke-test --profile ci
 
     - name: Upload to staging
-      if: inputs.environment-type == "staging" || inputs.environment-type == "both"
+      if: inputs.environment-type == 'staging' || inputs.environment-type == 'both'
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
@@ -59,7 +59,7 @@ runs:
         --token ${{ inputs.staging-api-token }}
 
     - name: Upload to production
-      if: inputs.environment-type == "production" || inputs.environment-type == "both"
+      if: inputs.environment-type == 'production' || inputs.environment-type == 'both'
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -9,6 +9,8 @@ inputs:
     description: Api token for the trunk-staging-org org on trunk-staging (should be available in secrets)
   production-api-token:
     description: Api token for the trunk org on trunk (should be available in secrets)
+  environment-type:
+    description: staging if you only want to run for staging, production if you only want production, both for both
 
 runs:
   using: composite
@@ -20,6 +22,7 @@ runs:
         ls -l ${{ inputs.cli-binary-location }}
 
     - name: Run tests on staging
+      if: inputs.environment-type == "staging" || inputs.environment-type == "both"
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         FAIL_TEST: true
@@ -32,6 +35,7 @@ runs:
         cargo nextest run -p smoke-test --profile ci
 
     - name: Run tests on production
+      if: inputs.environment-type == "production" || inputs.environment-type == "both"
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
         FAIL_TEST: true
@@ -44,6 +48,7 @@ runs:
         cargo nextest run -p smoke-test --profile ci
 
     - name: Upload to staging
+      if: inputs.environment-type == "staging" || inputs.environment-type == "both"
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
@@ -54,6 +59,7 @@ runs:
         --token ${{ inputs.staging-api-token }}
 
     - name: Upload to production
+      if: inputs.environment-type == "production" || inputs.environment-type == "both"
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -46,30 +46,30 @@ jobs:
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
-  slack-workflow-status:
-    if: always() && needs.build_cli.result != 'success'
-    name: Post Smoke Test Failure
-    needs:
-      - build_cli
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    env:
-      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-    steps:
-      - name: Analytics Cli Smoke Test Failure
-        uses: slackapi/slack-github-action@v1
-        with:
-          channel-id: production-notifications
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
-                  }
-                }
-              ]
-            }
+#  slack-workflow-status:
+#    if: always() && needs.build_cli.result != 'success'
+#    name: Post Smoke Test Failure
+#    needs:
+#      - build_cli
+#    runs-on: ubuntu-latest
+#    permissions:
+#      actions: read
+#    env:
+#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+#    steps:
+#      - name: Analytics Cli Smoke Test Failure
+#        uses: slackapi/slack-github-action@v1
+#        with:
+#          channel-id: production-notifications
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
+#                  }
+#                }
+#              ]
+#            }

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: 0 0/2 * * *
+  repository_dispatch:
+    types:
+      - staging-release
+      - production-release
 env:
   RELEASE: 0.6.18
 jobs:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -45,6 +45,7 @@ jobs:
           cli-binary-location: trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
+          environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
   slack-workflow-status:
     if: always() && needs.build_cli.result != 'success'
     name: Post Smoke Test Failure

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -46,30 +46,30 @@ jobs:
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
-#  slack-workflow-status:
-#    if: always() && needs.build_cli.result != 'success'
-#    name: Post Smoke Test Failure
-#    needs:
-#      - build_cli
-#    runs-on: ubuntu-latest
-#    permissions:
-#      actions: read
-#    env:
-#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-#    steps:
-#      - name: Analytics Cli Smoke Test Failure
-#        uses: slackapi/slack-github-action@v1
-#        with:
-#          channel-id: production-notifications
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
-#                  }
-#                }
-#              ]
-#            }
+  slack-workflow-status:
+    if: always() && needs.build_cli.result != 'success'
+    name: Post Smoke Test Failure
+    needs:
+      - build_cli
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+    steps:
+      - name: Analytics Cli Smoke Test Failure
+        uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: production-notifications
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -50,30 +50,30 @@ jobs:
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
-#  slack-workflow-status:
-#    if: always() && needs.build_cli.result != 'success'
-#    name: Post Smoke Test Failure
-#    needs:
-#      - build_cli
-#    runs-on: public-amd64-small
-#    permissions:
-#      actions: read
-#    env:
-#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-#    steps:
-#      - name: Analytics Cli Smoke Test Failure
-#        uses: slackapi/slack-github-action@v1
-#        with:
-#          channel-id: staging-notifications
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "The main branch of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test_main.yml"
-#                  }
-#                }
-#              ]
-#            }
+  slack-workflow-status:
+    if: always() && needs.build_cli.result != 'success'
+    name: Post Smoke Test Failure
+    needs:
+      - build_cli
+    runs-on: public-amd64-small
+    permissions:
+      actions: read
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+    steps:
+      - name: Analytics Cli Smoke Test Failure
+        uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: staging-notifications
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The main branch of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test_main.yml"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -49,6 +49,7 @@ jobs:
           cli-binary-location: target/${{matrix.platform.target}}/release/trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
+          environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
 
   slack-workflow-status:
     if: always() && needs.build_cli.result != 'success'

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: 0 0/2 * * *
+  repository_dispatch:
+    types:
+      - staging-release
+      - production-release
 jobs:
   build_cli:
     name: Smoke test ${{ matrix.platform.name }} cli from release

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -50,31 +50,30 @@ jobs:
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
-
-  slack-workflow-status:
-    if: always() && needs.build_cli.result != 'success'
-    name: Post Smoke Test Failure
-    needs:
-      - build_cli
-    runs-on: public-amd64-small
-    permissions:
-      actions: read
-    env:
-      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-    steps:
-      - name: Analytics Cli Smoke Test Failure
-        uses: slackapi/slack-github-action@v1
-        with:
-          channel-id: staging-notifications
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "The main branch of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test_main.yml"
-                  }
-                }
-              ]
-            }
+#  slack-workflow-status:
+#    if: always() && needs.build_cli.result != 'success'
+#    name: Post Smoke Test Failure
+#    needs:
+#      - build_cli
+#    runs-on: public-amd64-small
+#    permissions:
+#      actions: read
+#    env:
+#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+#    steps:
+#      - name: Analytics Cli Smoke Test Failure
+#        uses: slackapi/slack-github-action@v1
+#        with:
+#          channel-id: staging-notifications
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "The main branch of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test_main.yml"
+#                  }
+#                }
+#              ]
+#            }


### PR DESCRIPTION
Adds the workflow dispatch trigger to the smoke test workflows, so we can trigger this from the trunk repo on release.