### PR TITLE
Get event type

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -45,7 +45,7 @@ jobs:
           cli-binary-location: trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
-          environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
+          environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.action == 'staging-release' && 'staging') || 'both' }}
   slack-workflow-status:
     if: always() && needs.build_cli.result != 'success'
     name: Post Smoke Test Failure

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -45,7 +45,7 @@ jobs:
           cli-binary-location: trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
-          environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
+          environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
   slack-workflow-status:
     if: always() && needs.build_cli.result != 'success'
     name: Post Smoke Test Failure

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -49,7 +49,7 @@ jobs:
           cli-binary-location: target/${{matrix.platform.target}}/release/trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
-          environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
+          environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.action == 'staging-release' && 'staging') || 'both' }}
   slack-workflow-status:
     if: always() && needs.build_cli.result != 'success'
     name: Post Smoke Test Failure

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -49,7 +49,7 @@ jobs:
           cli-binary-location: target/${{matrix.platform.target}}/release/trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
-          environment-type: ${{ (github.event.event_type == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
+          environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.event_type == 'staging-release' && 'staging') || 'both' }}
   slack-workflow-status:
     if: always() && needs.build_cli.result != 'success'
     name: Post Smoke Test Failure


### PR DESCRIPTION
Smoke tests were falling back to testing everything for release. GH docs indicate that we were using the wrong field to fetch the repository dispatch event type, so updating to the correct value.