### PR TITLE
Specify remote urls in getQuarantineConfig

### DIFF
--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -362,6 +362,7 @@ mod tests {
                 },
                 org_url_slug: String::from("org_url_slug"),
                 test_identifiers: vec![],
+                remote_urls: vec![],
             })
             .await
             .unwrap_err()
@@ -402,6 +403,7 @@ mod tests {
                     owner: String::from("owner"),
                     name: String::from("name"),
                 },
+                remote_urls: vec![],
                 org_url_slug: String::from("org_url_slug"),
                 test_identifiers: vec![],
             })
@@ -439,6 +441,7 @@ mod tests {
                     owner: String::from("owner"),
                     name: String::from("name"),
                 },
+                remote_urls: vec![],
                 org_url_slug: String::from("org_url_slug"),
                 test_identifiers: vec![],
             })

--- a/api/src/message.rs
+++ b/api/src/message.rs
@@ -33,6 +33,8 @@ pub struct GetQuarantineConfigResponse {
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
 pub struct GetQuarantineConfigRequest {
     pub repo: RepoUrlParts,
+    #[serde(rename = "remoteUrls")]
+    pub remote_urls: Vec<String>,
     #[serde(rename = "orgUrlSlug")]
     pub org_url_slug: String,
     #[serde(rename = "testIdentifiers")]

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -270,6 +270,7 @@ pub async fn gather_exit_code_and_quarantined_tests_context(
                 repo: meta.base_props.repo.repo.clone(),
                 org_url_slug: meta.base_props.org.clone(),
                 test_identifiers: failed_tests_extractor.failed_tests().to_vec(),
+                remote_urls: vec![meta.base_props.repo.repo_url.clone()],
             },
             file_set_builder,
             Some(failed_tests_extractor),


### PR DESCRIPTION
That endpoint is being updated to handle creating a repo if one doesn't exist, so we need to add this data.