### PR TITLE
[TRUNK-14363] Add settings to auth messages

### DIFF
--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -345,6 +345,8 @@ mod tests {
                     CheckUnauthorized::DoNotCheck,
                     CheckNotFound::Check,
                     |_e| String::from("Test message"),
+                    &String::from("mock_host"),
+                    &String::from("mock_url_slug"),
                 )
             },
             log_progress_message: |_, _| String::new(),

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -377,7 +377,7 @@ fn adds_settings_if_domain_present() {
         add_settings_url_to_context("base_context", domain, &String::from("fake-org-slug"));
     assert_eq!(
         final_context,
-        "base_context\nYour settings page can be found at: https://app.fake-trunk.io/fake-org-slug/settings",
+        "base_context\nHint - Your settings page can be found at: https://app.fake-trunk.io/fake-org-slug/settings",
     )
 }
 

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -16,13 +16,15 @@ pub struct ApiClient {
     trunk_api_client: Client,
     telemetry_client: Client,
     version_path_prefix: String,
+    org_url_slug: String,
 }
 
 impl ApiClient {
     const TRUNK_API_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
     const TRUNK_API_TOKEN_HEADER: &'static str = "x-api-token";
 
-    pub fn new<T: AsRef<str>>(api_token: T) -> anyhow::Result<Self> {
+    pub fn new<T: AsRef<str>>(api_token: T, org_url_slug: T) -> anyhow::Result<Self> {
+        let org_url_slug = String::from(org_url_slug.as_ref());
         let api_token = api_token.as_ref();
         if api_token.trim().is_empty() {
             return Err(anyhow::anyhow!("Trunk API token is required."));
@@ -96,6 +98,7 @@ impl ApiClient {
             trunk_api_client,
             telemetry_client,
             version_path_prefix,
+            org_url_slug,
         })
     }
 
@@ -117,6 +120,8 @@ impl ApiClient {
                     CheckUnauthorized::Check,
                     CheckNotFound::Check,
                     |_| String::from("Failed to create bundle upload."),
+                    &self.api_host,
+                    &self.org_url_slug,
                 )?;
 
                 response
@@ -159,6 +164,8 @@ impl ApiClient {
                             String::from("Failed to get quarantine bulk test.")
                         }
                     },
+                    &self.api_host,
+                    &self.org_url_slug,
                 )?;
 
                 response
@@ -200,6 +207,8 @@ impl ApiClient {
                     CheckUnauthorized::DoNotCheck,
                     CheckNotFound::DoNotCheck,
                     |_| String::from("Failed to upload bundle to S3."),
+                    &self.api_host,
+                    &self.org_url_slug
                 )
             },
             log_progress_message: |time_elapsed, _| {
@@ -289,8 +298,10 @@ pub(crate) fn status_code_help<T: FnMut(&Response) -> String>(
     check_unauthorized: CheckUnauthorized,
     check_not_found: CheckNotFound,
     mut create_error_message: T,
+    api_host: &String,
+    org_url_slug: &String,
 ) -> anyhow::Result<Response> {
-    let base_error_message = &create_error_message(&response);
+    let base_error_message = create_error_message(&response);
 
     if !response.status().is_client_error() {
         response.error_for_status().map_err(|reqwest_error| {
@@ -298,9 +309,17 @@ pub(crate) fn status_code_help<T: FnMut(&Response) -> String>(
             anyhow::Error::from(reqwest_error).context(error_message)
         })
     } else {
+        let domain: Option<String> = url::Url::parse(api_host)
+            .ok()
+            .map(|url| url.domain().map(|domain| String::from(domain)))
+            .flatten();
         let error_message = match (response.status(), check_unauthorized, check_not_found) {
-            (StatusCode::UNAUTHORIZED, CheckUnauthorized::Check, _) => UNAUTHORIZED_CONTEXT,
-            (StatusCode::NOT_FOUND, _, CheckNotFound::Check) => NOT_FOUND_CONTEXT,
+            (StatusCode::UNAUTHORIZED, CheckUnauthorized::Check, _) => {
+                add_settings_url_to_context(UNAUTHORIZED_CONTEXT, domain, org_url_slug)
+            }
+            (StatusCode::NOT_FOUND, _, CheckNotFound::Check) => {
+                add_settings_url_to_context(NOT_FOUND_CONTEXT, domain, org_url_slug)
+            }
             _ => base_error_message,
         };
 
@@ -311,6 +330,48 @@ pub(crate) fn status_code_help<T: FnMut(&Response) -> String>(
             Err(error) => Err(anyhow::Error::from(error).context(error_message_with_help)),
         }
     }
+}
+
+fn add_settings_url_to_context(
+    context: &str,
+    domain: Option<String>,
+    org_url_slug: &String,
+) -> String {
+    match domain {
+        Some(present_domain) => {
+            let settings_url = format!(
+                "https://{}/{}/settings",
+                present_domain.replace("api", "app"),
+                org_url_slug
+            );
+            format!(
+                "{} Your settings page can be found at: {}",
+                context, settings_url
+            )
+        }
+        None => String::from(context),
+    }
+}
+
+#[test]
+fn adds_settings_if_domain_present() {
+    let domain = url::Url::parse("https://api.fake-trunk.io/")
+        .ok()
+        .map(|url| url.domain().map(|domain| String::from(domain)))
+        .flatten();
+    let final_context =
+        add_settings_url_to_context("base_context", domain, &String::from("fake-org-slug"));
+    assert_eq!(
+        final_context,
+        "base_context Your settings page can be found at: https://app.fake-trunk.io/fake-org-slug/settings",
+    )
+}
+
+#[test]
+fn does_not_add_settings_if_domain_absent() {
+    let final_context =
+        add_settings_url_to_context("base_context", None, &String::from("fake-org-slug"));
+    assert_eq!(final_context, "base_context",)
 }
 
 #[cfg(test)]
@@ -350,7 +411,8 @@ mod tests {
 
         let state = mock_server_builder.spawn_mock_server().await;
 
-        let mut api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        let mut api_client =
+            ApiClient::new(String::from("mock-token"), String::from("mock-org")).unwrap();
         api_client.api_host.clone_from(&state.host);
 
         assert!(api_client
@@ -392,7 +454,8 @@ mod tests {
 
         let state = mock_server_builder.spawn_mock_server().await;
 
-        let mut api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        let mut api_client =
+            ApiClient::new(String::from("mock-token"), String::from("mock-org")).unwrap();
         api_client.api_host.clone_from(&state.host);
 
         assert!(api_client
@@ -429,7 +492,8 @@ mod tests {
 
         let state = mock_server_builder.spawn_mock_server().await;
 
-        let mut api_client = ApiClient::new(String::from("mock-token")).unwrap();
+        let mut api_client =
+            ApiClient::new(String::from("mock-token"), String::from("mock-org")).unwrap();
         api_client.api_host.clone_from(&state.host);
 
         assert!(api_client

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -353,7 +353,7 @@ fn add_settings_url_to_context(
                 org_url_slug
             );
             format!(
-                "{}\nYour settings page can be found at: {}",
+                "{}\nHint - Your settings page can be found at: {}",
                 context, settings_url
             )
         }

--- a/cli-tests/src/test.rs
+++ b/cli-tests/src/test.rs
@@ -254,7 +254,7 @@ async fn quarantining_resets_fail_code() {
         vec![
             String::from("bash"),
             String::from("-c"),
-            String::from("touch ./*; exit 1"),
+            String::from("sleep 1; touch ./*; exit 1"),
         ],
     )
     .command()

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -156,7 +156,7 @@ pub async fn run_upload(
     } else {
         chrono::Utc::now().into()
     };
-    let api_client = ApiClient::new(&upload_args.token)?;
+    let api_client = ApiClient::new(&upload_args.token, &upload_args.org_url_slug)?;
 
     let PreTestContext {
         mut meta,


### PR DESCRIPTION
Adds the settings page link to auth error messages.
![2025-03-05-142300_2449x611_scrot](https://github.com/user-attachments/assets/2be42f5c-a6cb-40af-b022-51e4a2b39189)
