### PR TITLE
[TRUNK-14326] Remove JUnit from file messages

### DIFF
--- a/cli-tests/src/test.rs
+++ b/cli-tests/src/test.rs
@@ -93,7 +93,7 @@ async fn test_command_fails_with_no_junit_files_no_quarantine_successful_upload(
     .failure()
     .code(128)
     .stdout(predicate::str::contains(
-        "No JUnit files found, not quarantining any tests",
+        "No test output files found, not quarantining any tests",
     ));
 
     println!("{assert}");

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -492,7 +492,7 @@ async fn upload_bundle_with_no_junit_files_no_quarantine_successful_upload() {
         .code(0)
         .success()
         .stdout(predicate::str::contains(
-            "No JUnit files found, not quarantining any tests",
+            "No test output files found, not quarantining any tests",
         ));
 
     // HINT: View CLI output with `cargo test -- --nocapture`

--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -52,7 +52,9 @@ fn validate_no_junits() {
         .command()
         .assert()
         .failure()
-        .stdout(predicate::str::contains("No JUnit files found to validate"));
+        .stdout(predicate::str::contains(
+            "No test output files found to validate",
+        ));
 
     println!("{assert}");
 }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -156,13 +156,13 @@ pub fn gather_post_test_context<U: AsRef<Path>>(
     )?;
 
     if !allow_empty_test_results && file_set_builder.no_files_found() {
-        return Err(anyhow::anyhow!("No JUnit files found to upload."));
+        return Err(anyhow::anyhow!("No test output files found to upload."));
     }
 
     tracing::info!("Total files pack and upload: {}", file_set_builder.count());
     if file_set_builder.no_files_found() {
         tracing::warn!(
-            "No JUnit files found to pack and upload using globs: {:?}",
+            "No test output files found to pack and upload using globs: {:?}",
             junit_path_wrappers
                 .iter()
                 .map(|j| &j.junit_path)

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -172,7 +172,7 @@ pub async fn gather_quarantine_context(
     let mut exit_code = test_run_exit_code.unwrap_or(EXIT_SUCCESS);
 
     if file_set_builder.no_files_found() {
-        tracing::info!("No JUnit files found, not quarantining any tests");
+        tracing::info!("No test output files found, not quarantining any tests.");
         return QuarantineContext {
             exit_code,
             ..Default::default()

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -91,7 +91,7 @@ async fn validate(
         None,
     )?;
     if file_set_builder.no_files_found() {
-        return Err(anyhow::anyhow!("No JUnit files found to validate."));
+        return Err(anyhow::anyhow!("No test output files found to validate."));
     }
     print_matched_files(&file_set_builder);
 


### PR DESCRIPTION
Users aren't always using JUnit files, but our messages always referenced JUnit. Switched to 'test output' to avoid confusing references to JUnit.