### PR TITLE
Don't show errors in console

### DIFF
--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -375,7 +375,7 @@ mod tests {
             .await
             .unwrap_err()
             .to_string()
-            .contains("Failed to get quarantine bulk test."));
+            .contains("501 Not Implemented"));
         assert_eq!(CALL_COUNT.load(Ordering::Relaxed), 1);
     }
 
@@ -417,7 +417,7 @@ mod tests {
             .await
             .unwrap_err()
             .to_string()
-            .contains("Failed to get quarantine bulk test."));
+            .contains("500 Internal Server Error"));
         assert_eq!(CALL_COUNT.load(Ordering::Relaxed), 6);
     }
 
@@ -454,6 +454,6 @@ mod tests {
             .await
             .unwrap_err()
             .to_string()
-            .contains("Quarantining config not found"));
+            .contains("404 Not Found"));
     }
 }

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use anyhow::Context;
 use constants::{DEFAULT_ORIGIN, TRUNK_PUBLIC_API_ADDRESS_ENV};
 use http::{header::HeaderMap, HeaderValue};
 use reqwest::{header, Client, Response, StatusCode};
+use serde::de::DeserializeOwned;
 use tokio::fs;
 
 use crate::call_api::CallApi;
@@ -119,10 +119,7 @@ impl ApiClient {
                     |_| String::from("Failed to create bundle upload."),
                 )?;
 
-                response
-                    .json::<message::CreateBundleUploadResponse>()
-                    .await
-                    .context("Failed to get response body as json.")
+                self.deserialize_response::<message::CreateBundleUploadResponse>(response).await
             },
             log_progress_message: |time_elapsed, _| {
                 format!("Reporting bundle upload initiation to Trunk services is taking longer than expected. It has taken {} seconds so far.", time_elapsed.as_secs())
@@ -161,10 +158,7 @@ impl ApiClient {
                     },
                 )?;
 
-                response
-                    .json::<message::GetQuarantineConfigResponse>()
-                    .await
-                    .context("Failed to get response body as json.")
+                self.deserialize_response::<message::GetQuarantineConfigResponse>(response).await
             },
             log_progress_message: |time_elapsed, _| {
                 format!("Getting quarantine configuration from Trunk services is taking longer than expected. It has taken {} seconds so far.", time_elapsed.as_secs())
@@ -235,12 +229,14 @@ impl ApiClient {
                 let error_message = "Failed to send telemetry metrics.";
                 if !response.status().is_client_error() {
                     response.error_for_status().map_err(|reqwest_error| {
-                        anyhow::Error::from(reqwest_error).context(error_message)
+                        tracing::warn!("{}", error_message);
+                        anyhow::Error::from(reqwest_error)
                     }).map(|_| ())
                 } else {
+                    tracing::warn!("{}", error_message);
                     match response.error_for_status() {
                         Ok(..) => Err(anyhow::Error::msg(error_message)),
-                        Err(error) => Err(anyhow::Error::from(error).context(error_message)),
+                        Err(error) => Err(anyhow::Error::from(error)),
                     }
                 }
             },
@@ -257,6 +253,17 @@ impl ApiClient {
         }
         .call_api()
         .await
+    }
+
+    async fn deserialize_response<MessageType: DeserializeOwned>(
+        &self,
+        response: Response,
+    ) -> Result<MessageType, anyhow::Error> {
+        let deserialized: reqwest::Result<MessageType> = response.json::<MessageType>().await;
+        if deserialized.is_err() {
+            tracing::warn!("Failed to get response body as json.");
+        }
+        deserialized.map_err(anyhow::Error::from)
     }
 }
 
@@ -295,7 +302,8 @@ pub(crate) fn status_code_help<T: FnMut(&Response) -> String>(
     if !response.status().is_client_error() {
         response.error_for_status().map_err(|reqwest_error| {
             let error_message = format!("{base_error_message}{HELP_TEXT}");
-            anyhow::Error::from(reqwest_error).context(error_message)
+            tracing::warn!("{}", error_message);
+            anyhow::Error::from(reqwest_error)
         })
     } else {
         let error_message = match (response.status(), check_unauthorized, check_not_found) {
@@ -306,9 +314,10 @@ pub(crate) fn status_code_help<T: FnMut(&Response) -> String>(
 
         let error_message_with_help = format!("{error_message}{HELP_TEXT}");
 
+        tracing::warn!("{}", error_message_with_help);
         match response.error_for_status() {
             Ok(..) => Err(anyhow::Error::msg(error_message_with_help)),
-            Err(error) => Err(anyhow::Error::from(error).context(error_message_with_help)),
+            Err(error) => Err(anyhow::Error::from(error)),
         }
     }
 }

--- a/cli-tests/Cargo.toml
+++ b/cli-tests/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = "3.2.0"
 test_utils = { path = "../test_utils" }
 tokio = { version = "*" }
 trunk-analytics-cli = { path = "../cli", features = ["force-sentry-env-dev"] }
+pretty_assertions = "0.6"
 
 [features]
 default = []

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -413,7 +413,7 @@ async fn upload_bundle_invalid_repo_root() {
         .assert()
         .failure()
         .stdout(predicate::str::contains(
-            "error: Failed to open git repository at \"../\"",
+            "Could not open the repo_root specified",
         ));
     let requests = state.requests.lock().unwrap().clone();
     assert_eq!(requests.len(), 0);
@@ -438,7 +438,7 @@ async fn upload_bundle_invalid_repo_root_explicit() {
         .assert()
         .failure()
         .stdout(predicate::str::contains(
-            "error: Failed to open git repository at",
+            "Could not open the repo_root specified",
         ));
     let requests = state.requests.lock().unwrap().clone();
     assert_eq!(requests.len(), 0);
@@ -694,7 +694,7 @@ async fn is_not_ok_on_bad_request() {
     command
         .assert()
         .failure()
-        .stdout(predicate::str::contains("error: "));
+        .stdout(predicate::str::contains("error"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/cli/src/error_report.rs
+++ b/cli/src/error_report.rs
@@ -5,9 +5,8 @@ pub fn log_error(error: &anyhow::Error, base_message: Option<&str>) -> i32 {
     if let Some(io_error) = root_cause.downcast_ref::<std::io::Error>() {
         if io_error.kind() == std::io::ErrorKind::ConnectionRefused {
             tracing::warn!(
-                "{}: {:?}",
-                message(base_message, "could not connect to trunk's server"),
-                error
+                "{}",
+                message(base_message, "could not connect to trunk's server")
             );
             return exitcode::OK;
         }
@@ -19,17 +18,14 @@ pub fn log_error(error: &anyhow::Error, base_message: Option<&str>) -> i32 {
                 || status == StatusCode::FORBIDDEN
                 || status == StatusCode::NOT_FOUND
             {
-                tracing::warn!(
-                    "{}: {:?}",
-                    message(base_message, "unauthorized to access trunk"),
-                    error,
-                );
+                tracing::warn!("{}", message(base_message, "unauthorized to access trunk"),);
                 return exitcode::SOFTWARE;
             }
         }
     }
 
-    tracing::error!("{}: {:?}", message(base_message, "error"), error,);
+    tracing::error!("{}", message(base_message, "error"));
+    tracing::error!(hidden_in_console = true, "Caused by error: {:#?}", error);
     exitcode::SOFTWARE
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::{log::LevelFilter, InfoLevel, Verbosity};
 use third_party::sentry;
-use tracing_subscriber::prelude::*;
+use tracing_subscriber::{filter::FilterFn, prelude::*};
 use trunk_analytics_cli::{
     context::gather_debug_props,
     error_report::log_error,
@@ -128,13 +128,20 @@ fn setup_logger(log_level_filter: LevelFilter) -> anyhow::Result<()> {
         &tracing::Level::DEBUG => sentry_tracing::EventFilter::Breadcrumb,
         _ => sentry_tracing::EventFilter::Ignore,
     });
+
+    let console_layer = tracing_subscriber::fmt::Layer::new()
+        .without_time()
+        .with_target(false)
+        .with_writer(std::io::stdout.with_max_level(to_trace_filter(log_level_filter)))
+        .with_filter(FilterFn::new(|metadata| {
+            !metadata
+                .fields()
+                .iter()
+                .any(|field| field.name() == "hidden_in_console")
+        }));
+
     tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::Layer::new()
-                .without_time()
-                .with_target(false)
-                .with_writer(std::io::stdout.with_max_level(to_trace_filter(log_level_filter))),
-        )
+        .with(console_layer)
         .with(sentry_layer)
         .init();
     Ok(())

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -91,7 +91,9 @@ async fn validate(
         None,
     )?;
     if file_set_builder.no_files_found() {
-        return Err(anyhow::anyhow!("No JUnit files found to validate."));
+        let msg = "No JUnit files found to validate.";
+        tracing::warn!(msg);
+        return Err(anyhow::anyhow!(msg));
     }
     print_matched_files(&file_set_builder);
 

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -174,7 +174,7 @@ impl MutTestReport {
                 )) {
                 Ok(_) => true,
                 Err(e) => {
-                    tracing::error!("Error uploading: {:?}", e);
+                    tracing::error!(hidden_in_console = true, "Error uploading: {:?}", e);
                     false
                 }
             }


### PR DESCRIPTION
Changes our requests to simply log context, and adds a hidden_in_console field filter so that when we have logs that should go to sentry only, we can hide them from the user. Uses this to hide internal rust errors from our existing logging.

![2025-03-07-085547_1834x598_scrot](https://github.com/user-attachments/assets/1af017f0-75ef-4bea-9f5e-1f6fed8efc8f)