### PR TITLE
[TRUNK-14377] Tags for sentry uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,17 +4920,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "nu-ansi-term",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ tempfile = "3.2.0"
 tokio-retry = { version = "0.3", default-features = false }
 tracing = "0.1.41"
 tracing-log = "0.2.0"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["json"] }
 glob = "0.3.0"
 reqwest = { version = "0.12.5", default-features = false, features = [
   "rustls-tls-native-roots",

--- a/cli/src/quarantine_command.rs
+++ b/cli/src/quarantine_command.rs
@@ -15,6 +15,14 @@ impl QuarantineArgs {
     pub fn token(&self) -> String {
         self.upload_args.token.clone()
     }
+
+    pub fn org_url_slug(&self) -> String {
+        self.upload_args.org_url_slug.clone()
+    }
+
+    pub fn repo_root(&self) -> Option<String> {
+        self.upload_args.repo_root.clone()
+    }
 }
 
 // This is an alias to `run_upload`, but does not exit on upload failure

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -29,6 +29,14 @@ impl TestArgs {
     pub fn token(&self) -> String {
         self.upload_args.token.clone()
     }
+
+    pub fn org_url_slug(&self) -> String {
+        self.upload_args.org_url_slug.clone()
+    }
+
+    pub fn repo_root(&self) -> Option<String> {
+        self.upload_args.repo_root.clone()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Uses spans to add tags to sentry uploads. Also removes logging levels since it's a one-liner.