### PR TITLE
[logging] Update user facing logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4971,6 +4971,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "url",
  "vergen",
  "xcresult",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ clap-verbosity-flag = "3.0.2"
 proto = { path = "../proto" }
 regex = "1.11.1"
 lazy_static = "1.5.0"
+url = "2.5.4"
 
 [dev-dependencies]
 test_utils = { version = "0.1.0", path = "../test_utils" }

--- a/cli/src/error_report.rs
+++ b/cli/src/error_report.rs
@@ -1,30 +1,79 @@
+use api::client::get_api_host;
 use http::StatusCode;
 
-pub fn log_error(error: &anyhow::Error, base_message: Option<&str>) -> i32 {
+pub(crate) const UNAUTHORIZED_CONTEXT: &str = concat!(
+    "Your Trunk organization URL slug or token may be incorrect - find it in the Trunk app",
+);
+
+fn add_settings_url_to_context(
+    base_message: String,
+    domain: Option<String>,
+    org_url_slug: &String,
+) -> String {
+    match domain {
+        Some(present_domain) => {
+            let settings_url = format!(
+                "{}/{}/settings",
+                present_domain.replace("api", "app"),
+                org_url_slug
+            );
+            format!(
+                "{}\n  Hint: Your settings page can be found at: {}",
+                base_message, settings_url
+            )
+        }
+        None => base_message,
+    }
+}
+
+const HELP_TEXT: &str = "\n\nFor more help, contact us at https://slack.trunk.io/";
+
+pub struct Context {
+    pub base_message: Option<String>,
+    pub org_url_slug: String,
+}
+
+pub fn log_error(error: &anyhow::Error, context: Context) -> i32 {
     let root_cause = error.root_cause();
+    let Context {
+        base_message,
+        org_url_slug,
+    } = context;
     if let Some(io_error) = root_cause.downcast_ref::<std::io::Error>() {
         if io_error.kind() == std::io::ErrorKind::ConnectionRefused {
             tracing::warn!(
                 "{}",
-                message(base_message, "could not connect to trunk's server")
+                message(base_message, "Unable to connect to trunk's server")
             );
             return exitcode::OK;
         }
     }
 
+    let api_host = get_api_host();
     if let Some(reqwest_error) = root_cause.downcast_ref::<reqwest::Error>() {
         if let Some(status) = reqwest_error.status() {
             if status == StatusCode::UNAUTHORIZED
                 || status == StatusCode::FORBIDDEN
                 || status == StatusCode::NOT_FOUND
             {
-                tracing::warn!("{}", message(base_message, "unauthorized to access trunk"),);
+                tracing::warn!(
+                    "{}",
+                    add_settings_url_to_context(
+                        message(base_message, UNAUTHORIZED_CONTEXT),
+                        Some(api_host),
+                        &org_url_slug
+                    )
+                );
                 return exitcode::SOFTWARE;
             }
         }
     }
 
-    tracing::error!("{}", message(base_message, "error"));
+    if let Some(base_message) = base_message {
+        tracing::error!("{}", message(Some(base_message), HELP_TEXT));
+    } else {
+        tracing::error!("{}", error);
+    }
     tracing::error!(hidden_in_console = true, "Caused by error: {:#?}", error);
     exitcode::SOFTWARE
 }
@@ -45,9 +94,30 @@ pub fn error_reason(error: &anyhow::Error) -> String {
     "unknown".into()
 }
 
-fn message(base_message: Option<&str>, hint: &str) -> String {
+fn message(base_message: Option<String>, hint: &str) -> String {
     match base_message {
-        Some(base_message) => format!("{} because {}", base_message, hint),
+        Some(base_message) => format!("{}\n\t{}", base_message, hint),
         None => String::from(hint),
     }
+}
+
+#[test]
+fn adds_settings_if_domain_present() {
+    let host = "https://api.fake-trunk.io";
+    let final_context = add_settings_url_to_context(
+        "base_context".into(),
+        Some(host.into()),
+        &String::from("fake-org-slug"),
+    );
+    assert_eq!(
+        final_context,
+        "base_context\n  Hint: Your settings page can be found at: https://app.fake-trunk.io/fake-org-slug/settings",
+    )
+}
+
+#[test]
+fn does_not_add_settings_if_domain_absent() {
+    let final_context =
+        add_settings_url_to_context("base_context".into(), None, &String::from("fake-org-slug"));
+    assert_eq!(final_context, "base_context",)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,15 +122,15 @@ fn main() -> anyhow::Result<()> {
                             org_url_slug,
                         },
                     );
-                    guard.flush(None);
                     if exit_code != exitcode::OK {
-                        tracing::error!("Unable to proceed, returning exit code: {}", exit_code);
+                        tracing::warn!("Unable to proceed, returning exit code: {}", exit_code);
                     } else {
-                        tracing::error!(
+                        tracing::warn!(
                             "Errors occurred during upload, returning default exit code: {}",
                             exit_code
                         );
                     }
+                    guard.flush(None);
                     std::process::exit(exit_code);
                 }
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use third_party::sentry;
 use tracing_subscriber::{filter::FilterFn, prelude::*};
 use trunk_analytics_cli::{
     context::gather_debug_props,
-    error_report::log_error,
+    error_report::{log_error, Context},
     quarantine_command::{run_quarantine, QuarantineArgs},
     test_command::{run_test, TestArgs},
     upload_command::{run_upload, UploadArgs, UploadRunResult},
@@ -99,6 +99,7 @@ fn main() -> anyhow::Result<()> {
         .build()?
         .block_on(async {
             let cli = Cli::parse();
+            let org_url_slug = cli.org_url_slug();
             let log_level_filter = cli.verbose.log_level_filter();
             setup_logger(
                 log_level_filter,
@@ -114,8 +115,22 @@ fn main() -> anyhow::Result<()> {
             match run(cli).await {
                 Ok(exit_code) => std::process::exit(exit_code),
                 Err(error) => {
-                    let exit_code = log_error(&error, None);
+                    let exit_code = log_error(
+                        &error,
+                        Context {
+                            base_message: None,
+                            org_url_slug,
+                        },
+                    );
                     guard.flush(None);
+                    if exit_code != exitcode::OK {
+                        tracing::error!("Unable to proceed, returning exit code: {}", exit_code);
+                    } else {
+                        tracing::error!(
+                            "Errors occurred during upload, returning default exit code: {}",
+                            exit_code
+                        );
+                    }
                     std::process::exit(exit_code);
                 }
             }

--- a/cli/src/quarantine_command.rs
+++ b/cli/src/quarantine_command.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
 use crate::{
-    error_report::log_error,
+    error_report::{log_error, Context},
     upload_command::{run_upload, UploadArgs, UploadRunResult},
 };
 
@@ -27,6 +27,7 @@ impl QuarantineArgs {
 
 // This is an alias to `run_upload`, but does not exit on upload failure
 pub async fn run_quarantine(QuarantineArgs { upload_args }: QuarantineArgs) -> anyhow::Result<i32> {
+    let org_url_slug = upload_args.org_url_slug.clone();
     let upload_run_result = run_upload(upload_args, None, None).await;
     upload_run_result.map(
         |UploadRunResult {
@@ -34,7 +35,13 @@ pub async fn run_quarantine(QuarantineArgs { upload_args }: QuarantineArgs) -> a
              upload_bundle_error,
          }| {
             if let Some(e) = upload_bundle_error {
-                log_error(&e, Some("Error uploading test results"));
+                log_error(
+                    &e,
+                    Context {
+                        base_message: Some("Error uploading test results".into()),
+                        org_url_slug,
+                    },
+                );
             }
             exit_code
         },

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -9,7 +9,7 @@ use constants::EXIT_FAILURE;
 
 use crate::{
     context::{gather_debug_props, gather_pre_test_context},
-    error_report::log_error,
+    error_report::{log_error, Context},
     upload_command::{run_upload, UploadArgs, UploadRunResult},
 };
 
@@ -69,6 +69,7 @@ pub async fn run_test(
         test_run_result.exec_start = None;
     }
 
+    let org_url_slug = upload_args.org_url_slug.clone();
     let upload_run_result =
         run_upload(upload_args, Some(pre_test_context), Some(test_run_result)).await;
 
@@ -85,7 +86,13 @@ pub async fn run_test(
             },
         )
         .or_else(|e| {
-            log_error(&e, Some("Error uploading test results"));
+            log_error(
+                &e,
+                Context {
+                    base_message: Some("Error uploading test results".into()),
+                    org_url_slug,
+                },
+            );
             Ok(test_run_result_exit_code)
         })
 }

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -211,6 +211,7 @@ pub async fn run_upload(
     .await;
 
     let upload_started_at = chrono::Utc::now();
+    tracing::info!("Uploading test results...");
     let upload_bundle_result = upload_bundle(
         meta.clone(),
         &api_client,
@@ -252,6 +253,9 @@ pub async fn run_upload(
         tracing::debug!("Failed to send telemetry: {:?}", e);
     }
 
+    if upload_bundle_result.is_err() {
+        tracing::error!("Failed to upload bundle");
+    }
     Ok(UploadRunResult {
         exit_code,
         upload_bundle_error: upload_bundle_result.err(),
@@ -281,7 +285,7 @@ async fn upload_bundle(
             .put_bundle_to_s3(&upload.url, &bundle_temp_file)
             .await?;
         if exit_code == EXIT_SUCCESS {
-            tracing::info!("Done");
+            tracing::info!("Upload successful");
         } else {
             tracing::info!(
                 "Upload successful; returning unsuccessful exit code of test run: {}",


### PR DESCRIPTION
We were previously hiding the underlying message for non request based errors.
```
work@mac cli % TRUNK_PUBLIC_API_ADDRESS=https://api.trunk-staging.io cargo run upload  --token=test --bazel-bep-path=123 --org-url-slug=test 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `/Users/work/src/analytics-cli/target/debug/trunk-analytics-cli upload --token=test --bazel-bep-path=123 --org-url-slug=test`

%%%%%%%%%%%  %%              %%                        %%%%%%%%%%%%                                        
%%           %%              %%                             %%                           ,d                
%%           %%              %%                             %%                           %%                
%%aaaaa      %%  ,adPPYYba,  %%   ,d%  %b       d%          %%   ,adPPYba,  ,adPPYba,  MM%%MMM  ,adPPYba,  
%%"""""      %%  ""     `Y%  %% ,a%"   `%b     d%'          %%  a%P_____%%  I%[    ""    %%     I%[    ""  
%%           %%  ,adPPPPP%%  %%%%[      `%b   d%'           %%  %PP"""""""   `"Y%ba,     %%      `"Y%ba,   
%%           %%  %%,    ,%%  %%`"Yba,    `%b,d%'            %%  "%b,   ,aa  aa    ]%I    %%,    aa    ]%I  
%%           %%  `"%bbdP"Y%  %%   `Y%a     Y%%'             %%   `"Ybbd%"'  `"YbbdP"'    "Y%%%  `"YbbdP"'  
                                           d%'                                                             
                                          d%'                                                              

Trunk Flaky Test running command command="/Users/work/src/analytics-cli/target/debug/trunk-analytics-cli upload  --bazel-bep-path=123 --org-url-slug="
Starting trunk flakytests 0.0.0 (git=eef31217f3d58dac5dd3feab620ee211299cce5d) rustc=1.80.0-nightly
Using repo root at "/Users/work/src/analytics-cli/.git"
No such file or directory (os error 2)
Unable to proceed, returning exit code: 70
```

Bad token:
```
work@mac cli % cargo run upload  --token=test --junit-paths=. --org-url-slug=test 
   Compiling trunk-analytics-cli v0.0.0 (/Users/work/src/analytics-cli/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.56s
     Running `/Users/work/src/analytics-cli/target/debug/trunk-analytics-cli upload --token=test --junit-paths=. --org-url-slug=test`

%%%%%%%%%%%  %%              %%                        %%%%%%%%%%%%                                        
%%           %%              %%                             %%                           ,d                
%%           %%              %%                             %%                           %%                
%%aaaaa      %%  ,adPPYYba,  %%   ,d%  %b       d%          %%   ,adPPYba,  ,adPPYba,  MM%%MMM  ,adPPYba,  
%%"""""      %%  ""     `Y%  %% ,a%"   `%b     d%'          %%  a%P_____%%  I%[    ""    %%     I%[    ""  
%%           %%  ,adPPPPP%%  %%%%[      `%b   d%'           %%  %PP"""""""   `"Y%ba,     %%      `"Y%ba,   
%%           %%  %%,    ,%%  %%`"Yba,    `%b,d%'            %%  "%b,   ,aa  aa    ]%I    %%,    aa    ]%I  
%%           %%  `"%bbdP"Y%  %%   `Y%a     Y%%'             %%   `"Ybbd%"'  `"YbbdP"'    "Y%%%  `"YbbdP"'  
                                           d%'                                                             
                                          d%'                                                              

Trunk Flaky Test running command command="/Users/work/src/analytics-cli/target/debug/trunk-analytics-cli upload  --junit-paths=. --org-url-slug="
Starting trunk flakytests 0.0.0 (git=2b3f7fedc12d9bfe369003f519ebb780d35ed75b) rustc=1.80.0-nightly
Using repo root at "/Users/work/src/analytics-cli/.git"
Total files pack and upload: 6
Checking if failed tests can be quarantined
Unable to find quarantine config
	Your Trunk organization URL slug or token may be incorrect - find it in the Trunk app
  Hint: Your settings page can be found at: https://app.trunk.io/test/settings
️❌ 1 test failure not quarantined:
	GoodbyeTest -> Goodbye Learn more > https://app.trunk.io/test/flaky-tests/test/29154112-2e52-5159-bfd7-0c35ae149b6b?repo=trunk-io%2Fanalytics-cli

Quarantined 0 out of 1 test failures
Not all test failures were quarantined, using exit code 1 from command

Uploading test results...
Failed to upload bundle
Your Trunk organization URL slug or token may be incorrect - find it in the Trunk app
  Hint: Your settings page can be found at: https://app.trunk.io/test/settings
Unable to proceed, returning exit code: 70
```