### PR TITLE
Move away from using quick_junit directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,6 +4957,7 @@ dependencies = [
  "log",
  "openssl",
  "openssl-src",
+ "prost",
  "proto",
  "quick-junit",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ bundle = { path = "../bundle" }
 constants = { path = "../constants" }
 chrono = { version = "0.4.33", default-features = false, features = ["clock"] }
 clap = { version = "4.4.18", features = ["derive", "env"] }
-context = { path = "../context" }
+context = { path = "../context", features = ["bindings"] }
 third-party = { path = "../third-party" }
 env_logger = { version = "0.11.0", default-features = false }
 log = "0.4.14"
@@ -54,6 +54,7 @@ proto = { path = "../proto" }
 regex = "1.11.1"
 lazy_static = "1.5.0"
 url = "2.5.4"
+prost = "0.12.6"
 
 [dev-dependencies]
 test_utils = { version = "0.1.0", path = "../test_utils" }

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -1,13 +1,22 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    io::{BufReader, Read},
+};
 
 use api::{client::ApiClient, urls::url_for_test_case};
-use bundle::{FileSet, FileSetBuilder, QuarantineBulkTestStatus, Test};
+use bundle::{FileSet, FileSetBuilder, FileSetType, QuarantineBulkTestStatus, Test};
 use constants::{EXIT_FAILURE, EXIT_SUCCESS};
 use context::{
-    junit::{junit_path::JunitReportStatus, parser::JunitParser},
+    junit::{
+        bindings::{
+            BindingsReport, BindingsTestCase, BindingsTestCaseStatusStatus, BindingsTestSuite,
+        },
+        junit_path::JunitReportStatus,
+        parser::JunitParser,
+    },
     repo::RepoUrlParts,
 };
-use quick_junit::TestCaseStatus;
+use prost::Message;
 
 use crate::error_report::{log_error, Context};
 
@@ -21,17 +30,14 @@ fn convert_case_to_test<T: AsRef<str>>(
     repo: &RepoUrlParts,
     org_slug: T,
     parent_name: String,
-    case: &quick_junit::TestCase,
-    suite: &quick_junit::TestSuite,
+    case: &BindingsTestCase,
+    suite: &BindingsTestSuite,
 ) -> Test {
     let name = String::from(case.name.as_str());
-    let xml_string_to_string = |s: &quick_junit::XmlString| String::from(s.as_str());
-    let class_name = case.classname.as_ref().map(xml_string_to_string);
-    let file = case.extra.get("file").map(xml_string_to_string);
-    let timestamp_millis = case
-        .timestamp
-        .or(suite.timestamp)
-        .map(|t| t.timestamp_millis());
+    let class_name = case.classname.clone();
+    let file = case.extra().get("file").cloned();
+    let timestamp_millis = case.timestamp_micros.or(suite.timestamp_micros).map(|ts| ts / 1000);
+    println!("timestamp_millis: {:?}", timestamp_millis);
     let mut test = Test {
         name,
         parent_name,
@@ -40,8 +46,13 @@ fn convert_case_to_test<T: AsRef<str>>(
         id: String::with_capacity(0),
         timestamp_millis,
     };
-    if let Some(id) = case.extra.get("id").map(xml_string_to_string) {
-        test.id = id;
+    if let Some(id) = case.extra().get("id") {
+        if id.is_empty() {
+            test.set_id(org_slug, repo);
+        } else {
+            // trunk-ignore(clippy/assigning_clones)
+            test.id = id.clone();
+        }
     } else {
         test.set_id(org_slug, repo);
     }
@@ -65,25 +76,58 @@ impl FailedTestsExtractor {
                     continue;
                 }
             }
-            for file in &file_set.files {
-                let file = match std::fs::File::open(&file.original_path) {
+            for base_file in &file_set.files {
+                let file = match std::fs::File::open(&base_file.original_path) {
                     Ok(file) => file,
-                    Err(e) => {
-                        tracing::warn!("Error opening file: {}", e);
+                    Err(err) => {
+                        tracing::warn!(
+                            "Failed to open file {:?} for reading: {}",
+                            base_file.original_path,
+                            err
+                        );
                         continue;
                     }
                 };
-                let reader = std::io::BufReader::new(file);
-                let mut junitxml = JunitParser::new();
-                match junitxml.parse(reader) {
-                    Ok(junitxml) => junitxml,
-                    Err(e) => {
-                        tracing::warn!("Error parsing junitxml: {}", e);
-                        continue;
+                let mut reader = BufReader::new(file);
+                let bindings_reports = match file_set.file_set_type {
+                    FileSetType::Junit => {
+                        let mut junitxml = JunitParser::new();
+                        match junitxml.parse(reader) {
+                            Ok(junitxml) => junitxml,
+                            Err(err) => {
+                                tracing::warn!(
+                                    "Failed to parse junit xml file {:?}: {}",
+                                    base_file.original_path,
+                                    err
+                                );
+                                continue;
+                            }
+                        };
+                        junitxml
+                            .into_reports()
+                            .iter()
+                            .map(|report| BindingsReport::from(report.clone()))
+                            .collect::<Vec<BindingsReport>>()
+                    }
+                    _ => {
+                        let mut buffer = Vec::new();
+                        let result = reader.read_to_end(&mut buffer);
+                        if let Err(err) = result {
+                            tracing::warn!(
+                                "Failed to read file {:?} for reading: {}",
+                                base_file.original_path,
+                                err
+                            );
+                            continue;
+                        }
+                        let test_result =
+                            proto::test_context::test_run::TestResult::decode(buffer.as_slice())
+                                .unwrap();
+                        vec![BindingsReport::from(test_result)]
                     }
                 };
-                for report in junitxml.reports() {
-                    for suite in &report.test_suites {
+                for report in bindings_reports {
+                    for suite in report.test_suites {
                         let parent_name = String::from(suite.name.as_str());
                         for case in &suite.test_cases {
                             let test = convert_case_to_test(
@@ -91,13 +135,14 @@ impl FailedTestsExtractor {
                                 org_slug.as_ref(),
                                 parent_name.clone(),
                                 case,
-                                suite,
+                                &suite,
                             );
-                            match &case.status {
-                                TestCaseStatus::Skipped { .. } => {
+                            match &case.status.status {
+                                BindingsTestCaseStatusStatus::Unspecified
+                                | BindingsTestCaseStatusStatus::Skipped { .. } => {
                                     continue;
                                 }
-                                TestCaseStatus::Success { .. } => {
+                                BindingsTestCaseStatusStatus::Success { .. } => {
                                     if let Some(existing_timestamp) = successes.get(&test.id) {
                                         if *existing_timestamp > test.timestamp_millis.unwrap_or(0)
                                         {
@@ -109,7 +154,7 @@ impl FailedTestsExtractor {
                                         test.timestamp_millis.unwrap_or(0),
                                     );
                                 }
-                                TestCaseStatus::NonSuccess { .. } => {
+                                BindingsTestCaseStatusStatus::NonSuccess { .. } => {
                                     // Only store the most recent failure of a given test run ID
                                     if let Some(existing_test) = failures.get(&test.id) {
                                         if existing_test.timestamp_millis > test.timestamp_millis {
@@ -179,7 +224,13 @@ pub async fn gather_quarantine_context(
         };
     }
 
-    let quarantine_config = if !failed_tests_extractor.failed_tests().is_empty() {
+    let quarantine_config = if !failed_tests_extractor.failed_tests().is_empty()
+        && file_set_builder
+            .file_sets()
+            .iter()
+            // internal files track quarantine status directly, so we don't need to check them
+            .any(|file_set| file_set.file_set_type == FileSetType::Junit)
+    {
         tracing::info!("Checking if failed tests can be quarantined");
         let result = api_client.get_quarantining_config(request).await;
 
@@ -195,7 +246,7 @@ pub async fn gather_quarantine_context(
 
         result.unwrap_or_default()
     } else {
-        tracing::debug!("No failed tests to quarantine");
+        tracing::debug!("Skipping quarantine check.");
         api::message::GetQuarantineConfigResponse::default()
     };
 

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -5,6 +5,7 @@ use std::{
 
 use api::{client::ApiClient, urls::url_for_test_case};
 use bundle::{FileSet, FileSetBuilder, FileSetType, QuarantineBulkTestStatus, Test};
+use chrono::TimeDelta;
 use constants::{EXIT_FAILURE, EXIT_SUCCESS};
 use context::{
     junit::{
@@ -36,8 +37,12 @@ fn convert_case_to_test<T: AsRef<str>>(
     let name = String::from(case.name.as_str());
     let class_name = case.classname.clone();
     let file = case.extra().get("file").cloned();
-    let timestamp_millis = case.timestamp_micros.or(suite.timestamp_micros).map(|ts| ts / 1000);
-    println!("timestamp_millis: {:?}", timestamp_millis);
+    // convert timestamp_micros to millis using chrono
+    let timestamp_millis = Some(TimeDelta::num_milliseconds(&TimeDelta::microseconds(
+        case.timestamp_micros
+            .or(suite.timestamp_micros)
+            .unwrap_or(0),
+    )));
     let mut test = Test {
         name,
         parent_name,

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -323,6 +323,12 @@ impl BindingsTestSuite {
     }
 }
 
+impl BindingsTestSuite {
+    pub fn extra(&self) -> HashMap<String, String> {
+        self.extra.clone()
+    }
+}
+
 #[cfg(feature = "wasm")]
 #[wasm_bindgen]
 impl BindingsTestSuite {
@@ -528,6 +534,12 @@ impl BindingsTestCase {
                 acc
             });
         js_sys::Object::from_entries(&entries)
+    }
+}
+
+impl BindingsTestCase {
+    pub fn extra(&self) -> HashMap<String, String> {
+        self.extra.clone()
     }
 }
 


### PR DESCRIPTION
Not everything the CLI uses will be directly supported by `quick_junit`. We should move away from assuming the incoming failures are stored in junit and move towards the shared bindings type. This is already how we process this data within our services and this makes the CLI more aligned with it. This is required to support quarantining with rspec and reporting what has been quarantined.