### PR TITLE
[RSpec] Address small bugs and improve logging

### DIFF
--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -1,5 +1,3 @@
-use std::hash::{Hash, Hasher};
-
 use context::repo::RepoUrlParts;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
@@ -25,12 +23,6 @@ pub struct Test {
     /// Added in v0.6.9
     pub timestamp_millis: Option<i64>,
     pub is_quarantined: bool,
-}
-
-impl Hash for Test {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-    }
 }
 
 impl Test {

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -20,7 +20,7 @@ pub struct TestReport {
     test_result: TestResult,
     command: String,
     started_at: SystemTime,
-    quarantined_tests: Option<HashMap<Test, bool>>,
+    quarantined_tests: Option<HashMap<String, Test>>,
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
@@ -157,7 +157,7 @@ impl MutTestReport {
                 );
                 self.populate_quarantined_tests(&api_client, &bundle_repo.repo, org_url_slug);
                 if let Some(quarantined_tests) = self.0.borrow().quarantined_tests.as_ref() {
-                    return *quarantined_tests.get(&test_identifier).unwrap_or(&false);
+                    return quarantined_tests.get(&test_identifier.id).is_some();
                 }
                 false
             }
@@ -207,7 +207,7 @@ impl MutTestReport {
                             None,
                         );
 
-                        quarantined_tests.insert(test, true);
+                        quarantined_tests.insert(test.id.clone(), test);
                     }
                     if response.page.next_page_token.is_empty() {
                         break;


### PR DESCRIPTION
* Hashing wasn't working as I'd expect (it was still taking the whole object). Instead of pulling in a separate library to exclude fields, we can just key on id directly. 
* We don't have access to the generated description during test execution, so the log of the name was empty. Point to the location instead.
* add a helper for detecting if trunk is enabled / disabled