### PR TITLE
[RSpec] Drop external `colorize` package

### DIFF
--- a/context-ruby/Gemfile.lock
+++ b/context-ruby/Gemfile.lock
@@ -2,14 +2,12 @@ PATH
   remote: .
   specs:
     rspec_trunk_flaky_tests (0.0.0)
-      colorize (= 1.1.0)
       rb_sys (= 0.9.103)
       rspec-core (> 3.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    colorize (1.1.0)
     diff-lcs (1.5.1)
     rake (13.2.1)
     rake-compiler (1.2.0)

--- a/context-ruby/context_ruby.gemspec
+++ b/context-ruby/context_ruby.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.email       = 'support@trunk.io'
   s.files       = Dir['lib/**/*.rb', 'ext/**/*.{rs,rb}', '**/Cargo.*']
   s.add_runtime_dependency('rspec-core', '>3.3')
-  s.add_dependency('colorize', '=1.1.0')
   s.add_dependency('rb_sys', '=0.9.103')
   s.add_development_dependency('rspec')
   s.homepage    = 'https://trunk.io'

--- a/context-ruby/lib/trunk_spec_helper.rb
+++ b/context-ruby/lib/trunk_spec_helper.rb
@@ -3,7 +3,24 @@
 require 'rspec/core'
 require 'time'
 require 'context_ruby'
-require 'colorize'
+
+class String
+  def colorize(color_code)
+    "\e[#{color_code}m#{self}\e[0m"
+  end
+
+  def red
+    colorize(31)
+  end
+
+  def green
+    colorize(32)
+  end
+
+  def yellow
+    colorize(33)
+  end
+end
 
 def escape(str)
   str.dump[1..-2]
@@ -47,14 +64,14 @@ module RSpec
         parent_name = parent_name.empty? ? 'rspec' : parent_name
         file = escape(metadata[:file_path])
         classname = file.sub(%r{\.[^/.]+\Z}, '').gsub('/', '.').gsub(/\A\.+|\.+\Z/, '')
-        puts "Test failed, checking if it can be quarantined: `#{location}`".colorize(:yellow)
+        puts "Test failed, checking if it can be quarantined: `#{location}`".yellow
         if $test_report.is_quarantined(id, name, parent_name, classname, file)
           # monitor the override in the metadata
           metadata[:quarantined_exception] = exception
-          puts "Test is quarantined, overriding exception: #{exception}".colorize(:green)
+          puts "Test is quarantined, overriding exception: #{exception}".green
           nil
         else
-          puts 'Test is not quarantined, continuing'.colorize(:red)
+          puts 'Test is not quarantined, continuing'.red
           set_exception_core(exception)
         end
       end
@@ -117,9 +134,9 @@ class TrunkAnalyticsListener
   def close(_notification)
     res = @testreport.publish
     if res
-      puts 'Flaky tests report upload complete'.colorize(:green)
+      puts 'Flaky tests report upload complete'.green
     else
-      puts 'Failed to publish flaky tests report'.colorize(:red)
+      puts 'Failed to publish flaky tests report'.red
     end
   end
 

--- a/context-ruby/lib/trunk_spec_helper.rb
+++ b/context-ruby/lib/trunk_spec_helper.rb
@@ -4,6 +4,8 @@ require 'rspec/core'
 require 'time'
 require 'context_ruby'
 
+# String is an override to the main String class that is used to colorize the output
+# it is used to make the output more readable
 class String
   def colorize(color_code)
     "\e[#{color_code}m#{self}\e[0m"


### PR DESCRIPTION
We don't really need it and it's causing issues with our packaging. 