### PR TITLE
Revert "Remove tags from being set"

### DIFF
--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -17,7 +17,7 @@ use tsify_next::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::{files::FileSet, Test};
+use crate::{files::FileSet, CustomTag, Test};
 
 pub const META_VERSION: &str = "1";
 // 0.5.29 was first version to include bundle_upload_id and serves as the base
@@ -30,6 +30,7 @@ pub struct BundleMetaBaseProps {
     pub org: String,
     pub repo: BundleRepo,
     pub bundle_upload_id: String,
+    pub tags: Vec<CustomTag>,
     pub file_sets: Vec<FileSet>,
     pub envs: HashMap<String, String>,
     pub upload_time_epoch: u64,

--- a/bundle/src/custom_tag.rs
+++ b/bundle/src/custom_tag.rs
@@ -1,0 +1,43 @@
+use crate::types::CustomTag;
+
+pub const MAX_KEY_LEN: usize = 32;
+pub const MAX_VAL_LEN: usize = 1024 * 8;
+
+pub fn parse_custom_tags(tags: &[String]) -> anyhow::Result<Vec<CustomTag>> {
+    let parsed = tags.iter()
+        .filter(|tag_str| !tag_str.trim().is_empty())
+        .map(|tag_str| {
+            let parts = tag_str.split('=').collect::<Vec<&str>>();
+            if parts.len() != 2 {
+                return Err(anyhow::anyhow!(
+                    "Invalid custom tag format. Expected exactly 2 parts: {:?} (tags: {:?})",
+                    parts,
+                    tags
+                ));
+            }
+
+            let key = parts[0].trim().to_owned();
+            let value = parts[1].trim().to_owned();
+
+            if key.is_empty() || value.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Invalid custom tag format. Key/Value is empty: {:?}",
+                    tags
+                ));
+            }
+
+            if key.len() > MAX_KEY_LEN || value.len() > MAX_VAL_LEN {
+                return Err(anyhow::anyhow!(
+                    "Invalid custom tag format. Key/Value is too long: {:?}. Max key len: {}, max value len: {}",
+                    tags,
+                    MAX_KEY_LEN,
+                    MAX_VAL_LEN
+                ));
+            }
+
+            Ok(CustomTag { key, value })
+        })
+        .collect::<anyhow::Result<Vec<CustomTag>>>()?;
+
+    Ok(parsed)
+}

--- a/bundle/src/lib.rs
+++ b/bundle/src/lib.rs
@@ -1,9 +1,11 @@
 mod bundle_meta;
 mod bundler;
+mod custom_tag;
 mod files;
 mod types;
 
 pub use bundle_meta::*;
 pub use bundler::*;
+pub use custom_tag::*;
 pub use files::*;
 pub use types::*;

--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -103,11 +103,106 @@ pub struct BundleUploader {
     pub org_slug: String,
 }
 
+/// Custom tags defined by the user.
+///
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+pub struct CustomTag {
+    pub key: String,
+    pub value: String,
+}
+
 #[cfg(test)]
 mod tests {
     use context::repo::RepoUrlParts as Repo;
 
     use super::*;
+
+    #[test]
+    pub fn test_parse_good_custom_tags() {
+        let good_tags = &[
+            (
+                vec!["a=b".to_owned(), "1=2".to_owned()],
+                vec![
+                    CustomTag {
+                        key: "a".to_string(),
+                        value: "b".to_string(),
+                    },
+                    CustomTag {
+                        key: "1".to_string(),
+                        value: "2".to_string(),
+                    },
+                ],
+            ),
+            (
+                vec![
+                    "key1=value1".to_owned(),
+                    "key2=value2".to_owned(),
+                    "key3=value3".to_owned(),
+                ],
+                vec![
+                    CustomTag {
+                        key: "key1".to_string(),
+                        value: "value1".to_string(),
+                    },
+                    CustomTag {
+                        key: "key2".to_string(),
+                        value: "value2".to_string(),
+                    },
+                    CustomTag {
+                        key: "key3".to_string(),
+                        value: "value3".to_string(),
+                    },
+                ],
+            ),
+            (
+                vec![
+                    "key1=value1".to_owned(),
+                    "key2=value2".to_owned(),
+                    "key3=value3".to_owned(),
+                    "key4=value4".to_owned(),
+                ],
+                vec![
+                    CustomTag {
+                        key: "key1".to_string(),
+                        value: "value1".to_string(),
+                    },
+                    CustomTag {
+                        key: "key2".to_string(),
+                        value: "value2".to_string(),
+                    },
+                    CustomTag {
+                        key: "key3".to_string(),
+                        value: "value3".to_string(),
+                    },
+                    CustomTag {
+                        key: "key4".to_string(),
+                        value: "value4".to_string(),
+                    },
+                ],
+            ),
+        ];
+
+        for (tags_str, expected) in good_tags {
+            let actual: Vec<CustomTag> = crate::custom_tag::parse_custom_tags(tags_str).unwrap();
+            assert_eq!(actual, *expected);
+        }
+    }
+
+    #[test]
+    pub fn test_parse_bad_custom_tags() {
+        let bad_tags = vec![
+            vec!["key1=".to_owned(), "key2=value2".to_owned()],
+            vec!["=value".to_owned(), "key2=value2".to_owned()],
+            vec!["  =  ".to_owned(), "key2=value2".to_owned()],
+        ];
+
+        for tags_str in bad_tags {
+            let actual = crate::custom_tag::parse_custom_tags(&tags_str);
+            assert!(actual.is_err());
+        }
+    }
 
     #[test]
     fn test_test_new() {

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -123,6 +123,7 @@ async fn upload_bundle() {
         "your.email@example.com"
     );
     assert_eq!(base_props.bundle_upload_id, "test-bundle-upload-id");
+    assert_eq!(base_props.tags, &[]);
     assert_eq!(base_props.file_sets.len(), 1);
     assert_eq!(junit_props.num_files, 1);
     assert_eq!(junit_props.num_tests, 500);

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -10,8 +10,8 @@ use std::{
 
 use api::{client::ApiClient, message::CreateBundleUploadResponse};
 use bundle::{
-    BundleMeta, BundleMetaBaseProps, BundleMetaDebugProps, BundleMetaJunitProps, FileSet,
-    FileSetBuilder, QuarantineBulkTestStatus, META_VERSION,
+    parse_custom_tags, BundleMeta, BundleMetaBaseProps, BundleMetaDebugProps, BundleMetaJunitProps,
+    FileSet, FileSetBuilder, QuarantineBulkTestStatus, META_VERSION,
 };
 use constants::ENVS_TO_GET;
 #[cfg(target_os = "macos")]
@@ -72,6 +72,7 @@ pub fn gather_initial_test_context(
         repo_head_sha,
         repo_head_branch,
         repo_head_commit_epoch,
+        tags,
         allow_empty_test_results,
         ..
     } = upload_args;
@@ -122,6 +123,7 @@ pub fn gather_initial_test_context(
                 env!("VERGEN_RUSTC_SEMVER")
             ),
             bundle_upload_id: String::with_capacity(0),
+            tags: parse_custom_tags(&tags)?,
             file_sets: Vec::with_capacity(0),
             envs,
             upload_time_epoch: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -67,8 +67,7 @@ pub struct UploadArgs {
     #[arg(
         long,
         value_delimiter = ',',
-        help = "Comma separated list of custom tag=value pairs.",
-        hide = true
+        help = "Comma separated list of custom tag=value pairs."
     )]
     pub tags: Vec<String>,
     #[arg(long, help = "Print files which will be uploaded to stdout.")]
@@ -163,11 +162,6 @@ pub async fn run_upload(
     pre_test_context: Option<PreTestContext>,
     test_run_result: Option<TestRunResult>,
 ) -> anyhow::Result<UploadRunResult> {
-    if !upload_args.tags.is_empty() {
-        tracing::error!(
-            "Tags are deprecated and ignored. They will be removed in a future release."
-        );
-    }
     // grab the exec start if provided (`test` subcommand) or use the current time
     let cli_started_at = if let Some(test_run_result) = test_run_result.as_ref() {
         test_run_result

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -61,6 +61,7 @@ const generateBundleMeta = (): TestBundleMeta => ({
     },
   },
   upload_time_epoch: faker.number.int(),
+  tags: [],
   test_command: faker.hacker.verb(),
 });
 

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -116,6 +116,7 @@ async fn publish_test_report() {
         "your.email@example.com"
     );
     assert_eq!(base_props.bundle_upload_id, "test-bundle-upload-id");
+    assert_eq!(base_props.tags, &[]);
     assert_eq!(base_props.file_sets.len(), 1);
     assert_eq!(base_props.envs.get("CI"), Some(&String::from("1")));
     assert_eq!(


### PR DESCRIPTION
Reverts trunk-io/analytics-cli#504

We're seeing the following error when parsing
```
missing field `tags` at line 1 column 2791
```