### PR TITLE
Remove tag flag

### DIFF
--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -64,13 +64,6 @@ pub struct UploadArgs {
     pub repo_head_branch: Option<String>,
     #[arg(long, help = "Value to override commit epoch of repository head.")]
     pub repo_head_commit_epoch: Option<String>,
-    #[arg(
-        long,
-        value_delimiter = ',',
-        help = "Comma separated list of custom tag=value pairs.",
-        hide = true
-    )]
-    pub tags: Vec<String>,
     #[arg(long, help = "Print files which will be uploaded to stdout.")]
     pub print_files: bool,
     #[arg(
@@ -171,11 +164,6 @@ pub async fn run_upload(
     pre_test_context: Option<PreTestContext>,
     test_run_result: Option<TestRunResult>,
 ) -> anyhow::Result<UploadRunResult> {
-    if !upload_args.tags.is_empty() {
-        tracing::error!(
-            "Tags are deprecated and ignored. They will be removed in a future release."
-        );
-    }
     // grab the exec start if provided (`test` subcommand) or use the current time
     let cli_started_at = if let Some(test_run_result) = test_run_result.as_ref() {
         test_run_result


### PR DESCRIPTION
We don't have any reports of users using this, so we can remove it. Next step is to remove it from the ETL parser.