### PR TITLE
Add internal_bundled_file for test reports

### DIFF
--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -202,7 +202,18 @@ pub fn generate_internal_file(
 ) -> anyhow::Result<BundledFile> {
     let mut test_case_runs = Vec::new();
     for file_set in file_sets {
-        if file_set.file_set_type != FileSetType::Internal {
+        if file_set.file_set_type == FileSetType::Internal {
+            if file_set.files.is_empty() {
+                return Err(anyhow::anyhow!("Internal file set is empty"));
+            }
+            if file_set.files.len() > 1 {
+                return Err(anyhow::anyhow!(
+                    "Internal file set contains more than one file"
+                ));
+            }
+            // Internal file set, we should just use that directly
+            return Ok(file_set.files[0].clone());
+        } else {
             for file in &file_set.files {
                 let mut junit_parser = JunitParser::new();
                 if file.original_path.ends_with(".xml") {

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -145,6 +145,9 @@ async fn publish_test_report() {
     assert_eq!(bundled_file.owners.len(), 0);
     assert_eq!(bundled_file.team, None);
 
+    let internal_bundled_file = bundle_meta.internal_bundled_file.unwrap();
+    assert_eq!(internal_bundled_file.path, bundled_file.path);
+
     let bin = fs::read(tar_extract_directory.join(&bundled_file.path)).unwrap();
     let report = proto::test_context::test_run::TestResult::decode(&*bin).unwrap();
 


### PR DESCRIPTION
We need to point to the internal file generated by the test reports.