### PR TITLE
Use pinned version of cross-rs

### DIFF
--- a/.github/actions/build_cli_target/action.yaml
+++ b/.github/actions/build_cli_target/action.yaml
@@ -25,7 +25,7 @@ runs:
       run: cargo install cross --git https://github.com/cross-rs/cross --force
 
     - name: Build CLI ${{ inputs.target }} target
-      uses: houseabsolute/actions-rust-cross@v1
+      uses: houseabsolute/actions-rust-cross@v1.0.1
       # Cross-rs does not directly support cross compilation with macOS targets
       if: ${{ !contains(inputs.target, 'darwin') }}
       with:


### PR DESCRIPTION
The update 2 days ago is breaking our builds for smoke tests.

Example: https://github.com/trunk-io/analytics-cli/actions/runs/14437217940

After pinned: https://github.com/trunk-io/analytics-cli/actions/runs/14438426738/job/40483418147