### PR TITLE
Allow defining fallback exit code

### DIFF
--- a/cli-tests/src/command_builder.rs
+++ b/cli-tests/src/command_builder.rs
@@ -22,7 +22,7 @@ pub struct UploadArgs {
     disable_quarantining: Option<bool>,
     allow_empty_test_results: Option<bool>,
     variant: Option<String>,
-    previous_exit_code: Option<i32>,
+    test_process_exit_code: Option<i32>,
 }
 
 impl UploadArgs {
@@ -42,7 +42,7 @@ impl UploadArgs {
             disable_quarantining: None,
             allow_empty_test_results: None,
             variant: None,
-            previous_exit_code: None,
+            test_process_exit_code: None,
         }
     }
 
@@ -165,12 +165,12 @@ impl UploadArgs {
                 .flat_map(|variant: String| vec![String::from("--variant"), variant]),
         )
         .chain(
-            self.previous_exit_code
+            self.test_process_exit_code
                 .into_iter()
-                .flat_map(|previous_exit_code: i32| {
+                .flat_map(|test_process_exit_code: i32| {
                     vec![
-                        String::from("--previous-exit-code"),
-                        previous_exit_code.to_string(),
+                        String::from("--test-process-exit-code"),
+                        test_process_exit_code.to_string(),
                     ]
                 }),
         )
@@ -427,16 +427,16 @@ impl<'b> CommandBuilder<'b> {
         self
     }
 
-    pub fn previous_exit_code(&mut self, new_value: i32) -> &mut Self {
+    pub fn test_process_exit_code(&mut self, new_value: i32) -> &mut Self {
         match &mut self.command_type {
             CommandType::Upload { upload_args, .. } => {
-                upload_args.previous_exit_code = Some(new_value);
+                upload_args.test_process_exit_code = Some(new_value);
             }
             CommandType::Quarantine { upload_args, .. } => {
-                upload_args.previous_exit_code = Some(new_value);
+                upload_args.test_process_exit_code = Some(new_value);
             }
             CommandType::Test { upload_args, .. } => {
-                upload_args.previous_exit_code = Some(new_value);
+                upload_args.test_process_exit_code = Some(new_value);
             }
             CommandType::Validate { .. } => {}
         }

--- a/cli-tests/src/command_builder.rs
+++ b/cli-tests/src/command_builder.rs
@@ -22,6 +22,7 @@ pub struct UploadArgs {
     disable_quarantining: Option<bool>,
     allow_empty_test_results: Option<bool>,
     variant: Option<String>,
+    previous_exit_code: Option<i32>,
 }
 
 impl UploadArgs {
@@ -41,6 +42,7 @@ impl UploadArgs {
             disable_quarantining: None,
             allow_empty_test_results: None,
             variant: None,
+            previous_exit_code: None,
         }
     }
 
@@ -161,6 +163,16 @@ impl UploadArgs {
                 .clone()
                 .into_iter()
                 .flat_map(|variant: String| vec![String::from("--variant"), variant]),
+        )
+        .chain(
+            self.previous_exit_code
+                .into_iter()
+                .flat_map(|previous_exit_code: i32| {
+                    vec![
+                        String::from("--previous-exit-code"),
+                        previous_exit_code.to_string(),
+                    ]
+                }),
         )
         .collect()
     }
@@ -409,6 +421,22 @@ impl<'b> CommandBuilder<'b> {
             }
             CommandType::Test { upload_args, .. } => {
                 upload_args.variant = Some(new_value.to_string());
+            }
+            CommandType::Validate { .. } => {}
+        }
+        self
+    }
+
+    pub fn previous_exit_code(&mut self, new_value: i32) -> &mut Self {
+        match &mut self.command_type {
+            CommandType::Upload { upload_args, .. } => {
+                upload_args.previous_exit_code = Some(new_value);
+            }
+            CommandType::Quarantine { upload_args, .. } => {
+                upload_args.previous_exit_code = Some(new_value);
+            }
+            CommandType::Test { upload_args, .. } => {
+                upload_args.previous_exit_code = Some(new_value);
             }
             CommandType::Validate { .. } => {}
         }

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -301,15 +301,15 @@ async fn upload_bundle_success_preceding_failure() {
     fs::write(&bep_path, bep_content).unwrap();
 
     let state = MockServerBuilder::new().spawn_mock_server().await;
-    let previous_exit_code = 127;
+    let test_process_exit_code = 127;
 
     // Even though the junits contain failures, they contain retries that succeeded,
     // so the upload command should have a successful exit code
     let assert = CommandBuilder::upload(temp_dir.path(), state.host.clone())
-        .previous_exit_code(previous_exit_code)
+        .test_process_exit_code(test_process_exit_code)
         .command()
         .assert()
-        .code(previous_exit_code)
+        .code(test_process_exit_code)
         .failure();
 
     // No quarantine request

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -315,7 +315,7 @@ pub async fn gather_exit_code_and_quarantined_tests_context(
     disable_quarantining: bool,
     api_client: &ApiClient,
     file_set_builder: &FileSetBuilder,
-    test_run_result: &Option<TestRunResult>,
+    default_exit_code: Option<i32>,
 ) -> i32 {
     // Run the quarantine step and update the exit code.
     let failed_tests_extractor = FailedTestsExtractor::new(
@@ -332,9 +332,9 @@ pub async fn gather_exit_code_and_quarantined_tests_context(
             },
     } = if disable_quarantining {
         // use the exit code of the test run result if exists
-        if let Some(test_run_result) = test_run_result {
+        if let Some(exit_code) = default_exit_code {
             QuarantineContext {
-                exit_code: test_run_result.exit_code,
+                exit_code,
                 quarantine_status: QuarantineBulkTestStatus {
                     quarantine_results: failed_tests_extractor
                         .failed_tests()
@@ -366,7 +366,7 @@ pub async fn gather_exit_code_and_quarantined_tests_context(
             },
             file_set_builder,
             Some(failed_tests_extractor),
-            test_run_result.as_ref().map(|t| t.exit_code),
+            default_exit_code,
         )
         .await
     };

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -137,7 +137,7 @@ pub struct UploadArgs {
         num_args = 1,
         hide = true
     )]
-    pub default_quarantine_exit_code: Option<i32>,
+    pub previous_exit_code: Option<i32>,
 }
 
 impl UploadArgs {
@@ -227,10 +227,10 @@ pub async fn run_upload(
             }
         }
     }
-    let default_exit_code = if let Some(exit_code) = upload_args.default_quarantine_exit_code {
+    let default_exit_code = if let Some(exit_code) = upload_args.previous_exit_code {
         Some(exit_code)
     } else {
-        test_run_result.as_ref().and_then(|r| Some(r.exit_code))
+        test_run_result.as_ref().map(|r| r.exit_code)
     };
     let exit_code = gather_exit_code_and_quarantined_tests_context(
         &mut meta,

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -130,6 +130,14 @@ pub struct UploadArgs {
         hide = true
     )]
     pub variant: Option<String>,
+    #[arg(
+        long,
+        help = "The exit code to use when not all tests are quarantined.",
+        required = false,
+        num_args = 1,
+        hide = true
+    )]
+    pub default_quarantine_exit_code: Option<i32>,
 }
 
 impl UploadArgs {
@@ -172,6 +180,7 @@ pub async fn run_upload(
     } else {
         chrono::Utc::now().into()
     };
+
     let api_client = ApiClient::new(&upload_args.token, &upload_args.org_url_slug)?;
 
     let PreTestContext {
@@ -218,13 +227,17 @@ pub async fn run_upload(
             }
         }
     }
-
+    let default_exit_code = if let Some(exit_code) = upload_args.default_quarantine_exit_code {
+        Some(exit_code)
+    } else {
+        test_run_result.as_ref().and_then(|r| Some(r.exit_code))
+    };
     let exit_code = gather_exit_code_and_quarantined_tests_context(
         &mut meta,
         upload_args.disable_quarantining || !upload_args.use_quarantining,
         &api_client,
         &file_set_builder,
-        &test_run_result,
+        default_exit_code,
     )
     .await;
 

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -137,7 +137,7 @@ pub struct UploadArgs {
         num_args = 1,
         hide = true
     )]
-    pub previous_exit_code: Option<i32>,
+    pub test_process_exit_code: Option<i32>,
 }
 
 impl UploadArgs {
@@ -227,7 +227,7 @@ pub async fn run_upload(
             }
         }
     }
-    let default_exit_code = if let Some(exit_code) = upload_args.previous_exit_code {
+    let default_exit_code = if let Some(exit_code) = upload_args.test_process_exit_code {
         Some(exit_code)
     } else {
         test_run_result.as_ref().map(|r| r.exit_code)


### PR DESCRIPTION
This mimics the behavior of `test` in `upload` by allowing users to set the exit code of the previous result.