### PR TITLE
[rspec] Improve integration with rspec/retry

### DIFF
--- a/context-ruby/lib/trunk_spec_helper.rb
+++ b/context-ruby/lib/trunk_spec_helper.rb
@@ -48,7 +48,7 @@ module RSpec
       # trunk-ignore(rubocop/Naming/AccessorMethodName,rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)
       def set_exception(exception)
         return set_exception_core(exception) if trunk_disabled
-        return set_exception_core(exception) if metadata[:retry_attempts] && metadata[:retry_attempts] > 0
+        return set_exception_core(exception) if metadata[:retry_attempts]&.positive?
 
         id = generate_trunk_id
         name = full_description

--- a/context-ruby/lib/trunk_spec_helper.rb
+++ b/context-ruby/lib/trunk_spec_helper.rb
@@ -48,6 +48,7 @@ module RSpec
       # trunk-ignore(rubocop/Naming/AccessorMethodName,rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)
       def set_exception(exception)
         return set_exception_core(exception) if trunk_disabled
+        return set_exception_core(exception) if metadata[:retry_attempts] && metadata[:retry_attempts] > 0
 
         id = generate_trunk_id
         name = full_description
@@ -158,7 +159,7 @@ class TrunkAnalyticsListener
     finished_at = example.execution_result.finished_at.to_i
     id = example.generate_trunk_id
 
-    attempt_number = example.metadata[:attempt_number] || 0
+    attempt_number = example.metadata[:retry_attempts] || example.metadata[:attempt_number] || 0
     status = example.execution_result.status.to_s
     # set the status to failure, but mark it as quarantined
     is_quarantined = example.metadata[:quarantined_exception] ? true : false


### PR DESCRIPTION
Right now we check quarantining each time which is spammy when you have retries enabled. Instead we should only check once and try to use the retry attempts from that plugin (when it is there).