### PR TITLE
Update minimum release version

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -10,7 +10,7 @@ on:
       - staging-release
       - production-release
 env:
-  RELEASE: 0.6.18
+  RELEASE: 0.7.6
 jobs:
   build_cli:
     name: Smoke test ${{ matrix.platform.name }} cli from release


### PR DESCRIPTION
0.7.6 is about a month old and all of our users are above this version, so let's make this the default