### PR TITLE
calculate num_tests in cli context

### DIFF
--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -49,7 +49,6 @@ pub struct TestRunResult {
     pub command: String,
     pub exec_start: Option<SystemTime>,
     pub exit_code: i32,
-    pub num_tests: Option<usize>,
 }
 
 pub async fn run_test(
@@ -128,7 +127,6 @@ pub async fn run_test_command<T: AsRef<str>>(command: &[T]) -> anyhow::Result<Te
     Ok(TestRunResult {
         exit_code,
         exec_start: Some(exec_start),
-        num_tests: None,
         command: command
             .iter()
             .map(|s| s.as_ref())

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -230,9 +230,6 @@ pub async fn run_upload(
         upload_args.allow_empty_test_results,
         &test_run_result,
     )?;
-    if let Some(num_tests) = test_run_result.clone().and_then(|r| r.num_tests) {
-        meta.junit_props.num_tests = num_tests;
-    }
     let temp_dir = tempfile::tempdir()?;
     let internal_bundled_file = generate_internal_file(&meta.base_props.file_sets, &temp_dir);
     if let Ok(internal_bundled_file) = internal_bundled_file {

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -316,7 +316,6 @@ impl MutTestReport {
             command: self.0.borrow().command.clone(),
             exec_start: Some(self.0.borrow().started_at),
             exit_code: 0,
-            num_tests: Some(self.0.borrow().test_result.test_case_runs.len()),
         };
         let result = match gather_initial_test_context(upload_args.clone(), debug_props) {
             Ok(pre_test_context) => {


### PR DESCRIPTION
For rspec this was being passed through explicitly, but it should instead be calculated in the shared context. This code is already tested in the `test_report` crate.