### PR TITLE
fix sentry release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
 
   tag_and_release:
     name: Tag and Release [ ${{ github.event.inputs.release_tag }} ]
-    runs-on: public-amd64-small
+    runs-on: ubuntu-latest
     needs: [build_release, perform_smoke_test]
     # only empty during testing
     if: needs.perform_smoke_test.result == 'success' && github.event.inputs.release_tag != ''


### PR DESCRIPTION
Internal runners are introducing issues with docker in docker that caused this step to fail. Opting to use GitHub runners instead. 