### PR TITLE
Address flag issue in debug mode

### DIFF
--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -167,7 +167,7 @@ pub struct UploadArgs {
         long,
         help = "Flag to enable populating file paths from xcresult stack traces",
         required = false,
-        num_args = 1,
+        num_args = 0,
         hide = true
     )]
     pub use_experimental_failure_summary: bool,


### PR DESCRIPTION
Seeing the following for local debug builds 
```
thread 'main' panicked at /Users/work/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.23/src/builder/debug_asserts.rs:694:9:
Argument `use_experimental_failure_summary`'s selected action SetTrue contradicts `takes_value`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Updates the num args to 0 to resolve.