### PR TITLE
[codeowners] Update bindings to parse out codeowners

### DIFF
--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -8,6 +8,7 @@ pretty_assertions = "0.6"
 junit-mock = { path = "../junit-mock" }
 test_utils = { path = "../test_utils" }
 tempfile = "3.2.0"
+codeowners = { path = "../codeowners" }
 
 [dependencies]
 anyhow = "1.0.44"


### PR DESCRIPTION
This is part 2 of moving codeowners parsing. These will allow us to reference them directly.