### PR TITLE
deprecate `team` flag

### DIFF
--- a/bundle/src/files.rs
+++ b/bundle/src/files.rs
@@ -31,7 +31,6 @@ impl FileSetBuilder {
     pub fn build_file_sets<T: AsRef<str>, U: AsRef<Path>>(
         repo_root: T,
         junit_paths: &[JunitReportFileWithStatus],
-        team: &Option<String>,
         codeowners_path: &Option<U>,
         exec_start: Option<SystemTime>,
     ) -> anyhow::Result<Self> {
@@ -40,7 +39,7 @@ impl FileSetBuilder {
         let codeowners = CodeOwners::find_file(repo_root, codeowners_path);
 
         let file_set_builder =
-            Self::file_sets_from_glob(repo_root, junit_paths, team, codeowners, exec_start)?;
+            Self::file_sets_from_glob(repo_root, junit_paths, codeowners, exec_start)?;
 
         // Handle case when paths are not globs.
         if file_set_builder.count == 0 {
@@ -66,7 +65,6 @@ impl FileSetBuilder {
             return Self::file_sets_from_glob(
                 repo_root,
                 junit_paths_with_glob.as_slice(),
-                team,
                 file_set_builder.codeowners,
                 exec_start,
             );
@@ -78,7 +76,6 @@ impl FileSetBuilder {
     fn file_sets_from_glob(
         repo_root: &str,
         junit_paths: &[JunitReportFileWithStatus],
-        team: &Option<String>,
         codeowners: Option<CodeOwners>,
         exec_start: Option<SystemTime>,
     ) -> anyhow::Result<Self> {
@@ -98,7 +95,6 @@ impl FileSetBuilder {
                             acc.0,
                             repo_root,
                             &junit_wrapper.junit_path,
-                            team.clone(),
                             codeowners,
                             exec_start,
                         )? {
@@ -241,7 +237,6 @@ impl BundledFile {
         file_index: usize,
         repo_root: T,
         glob_path: U,
-        team: Option<String>,
         codeowners: &Option<CodeOwners>,
         start: Option<SystemTime>,
     ) -> anyhow::Result<Option<Self>> {
@@ -314,7 +309,9 @@ impl BundledFile {
                 .duration_since(std::time::UNIX_EPOCH)?
                 .as_nanos(),
             owners,
-            team,
+            // Added in v0.5.33 but unused
+            // We are unable to remove for the time being
+            team: None,
         }))
     }
 

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -167,7 +167,6 @@ pub fn gather_initial_test_context(
 pub fn gather_post_test_context<U: AsRef<Path>>(
     meta: &mut BundleMeta,
     junit_path_wrappers: Vec<JunitReportFileWithStatus>,
-    team: &Option<String>,
     codeowners_path: &Option<U>,
     allow_empty_test_results: bool,
     test_run_result: &Option<TestRunResult>,
@@ -175,7 +174,6 @@ pub fn gather_post_test_context<U: AsRef<Path>>(
     let mut file_set_builder = FileSetBuilder::build_file_sets(
         &meta.base_props.repo.repo_root,
         &junit_path_wrappers,
-        team,
         codeowners_path,
         test_run_result.as_ref().and_then(|r| r.exec_start),
     )?;
@@ -255,7 +253,6 @@ pub fn generate_internal_file(
         original_path_rel: None,
         owners: vec![],
         path: filename.to_string(),
-        team: None,
         // last_modified_epoch_ns does not serialize so the compiler complains it does not exist
         ..Default::default()
     })

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -206,6 +206,14 @@ pub async fn run_upload(
         chrono::Utc::now().into()
     };
 
+    if let Some(team) = &upload_args.team {
+        if !team.is_empty() {
+            tracing::error!(
+                "The --team flag is deprecated and will be removed in a future version."
+            );
+        }
+    }
+
     let api_client = ApiClient::new(&upload_args.token, &upload_args.org_url_slug)?;
 
     let PreTestContext {
@@ -226,7 +234,6 @@ pub async fn run_upload(
     let file_set_builder = gather_post_test_context(
         &mut meta,
         junit_path_wrappers,
-        &upload_args.team,
         &upload_args.codeowners_path,
         upload_args.allow_empty_test_results,
         &test_run_result,

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -101,13 +101,8 @@ async fn validate(
         .ok()
         .and_then(|p| p.to_str().map(String::from))
         .unwrap_or_default();
-    let file_set_builder = FileSetBuilder::build_file_sets(
-        &current_dir,
-        &junit_paths,
-        &None,
-        &Option::<&str>::None,
-        None,
-    )?;
+    let file_set_builder =
+        FileSetBuilder::build_file_sets(&current_dir, &junit_paths, &Option::<&str>::None, None)?;
     if file_set_builder.no_files_found() {
         let msg = "No test output files found to validate.";
         tracing::warn!(msg);


### PR DESCRIPTION
To my knowledge this was never broadcast out to be used and has never been used by customers. Instead of removing it, we'll track its usage and delete it in a future version.