### PR TITLE
Cleanup lingering `print-files` in test

### DIFF
--- a/cli-tests/src/command_builder.rs
+++ b/cli-tests/src/command_builder.rs
@@ -14,7 +14,6 @@ pub struct UploadArgs {
     repo_head_branch: Option<String>,
     repo_head_commit_epoch: Option<String>,
     tags: Option<Vec<String>>,
-    print_files: Option<bool>,
     no_upload: Option<bool>,
     team: Option<String>,
     codeowners_path: Option<String>,
@@ -36,7 +35,6 @@ impl UploadArgs {
             repo_head_branch: None,
             repo_head_commit_epoch: None,
             tags: None,
-            print_files: None,
             no_upload: None,
             team: None,
             codeowners_path: None,
@@ -101,13 +99,6 @@ impl UploadArgs {
                 let mut args = vec![String::from("--tags")];
                 args.extend(tags);
                 args
-            }
-        }))
-        .chain(self.print_files.into_iter().flat_map(|print_files: bool| {
-            if print_files {
-                vec![String::from("--print-files")]
-            } else {
-                vec![]
             }
         }))
         .chain(self.no_upload.into_iter().flat_map(|no_upload: bool| {
@@ -310,16 +301,6 @@ impl CommandType {
         self
     }
 
-    pub fn print_files(&mut self, new_flag: bool) -> &mut Self {
-        match self {
-            CommandType::Upload { upload_args, .. } => upload_args.print_files = Some(new_flag),
-            CommandType::Quarantine { upload_args, .. } => upload_args.print_files = Some(new_flag),
-            CommandType::Test { upload_args, .. } => upload_args.print_files = Some(new_flag),
-            CommandType::Validate { .. } => (),
-        }
-        self
-    }
-
     pub fn repo_root(&mut self, new_value: &str) -> &mut Self {
         match self {
             CommandType::Upload { upload_args, .. } => {
@@ -515,11 +496,6 @@ impl<'b> CommandBuilder<'b> {
 
     pub fn disable_quarantining(&mut self, new_flag: bool) -> &mut Self {
         self.command_type.disable_quarantining(new_flag);
-        self
-    }
-
-    pub fn print_files(&mut self, new_flag: bool) -> &mut Self {
-        self.command_type.print_files(new_flag);
         self
     }
 

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -433,9 +433,7 @@ async fn upload_bundle_no_files_allow_missing_junit_files() {
 
         let state = MockServerBuilder::new().spawn_mock_server().await;
 
-        let mut command = CommandBuilder::upload(temp_dir.path(), state.host.clone())
-            .print_files(true)
-            .command();
+        let mut command = CommandBuilder::upload(temp_dir.path(), state.host.clone()).command();
 
         match flag {
             Flag::Long => {


### PR DESCRIPTION
Missed this when I dropped the parameter. The test was quarantined, so it slipped through.