### PR TITLE
Parse internal bin from tarball

### DIFF
--- a/context-js/src/lib.rs
+++ b/context-js/src/lib.rs
@@ -1,17 +1,21 @@
 use std::{collections::HashMap, io::BufReader};
 
-use bundle::{parse_meta_from_tarball as parse_tarball, VersionedBundle};
+use bundle::{
+    parse_internal_bin_from_tarball as parse_bin, parse_meta_from_tarball as parse_tarball,
+    VersionedBundle,
+};
 use context::{env, junit, repo};
 use futures::{future::Either, io::BufReader as BufReaderAsync, stream::TryStreamExt};
 use js_sys::Uint8Array;
 use prost::Message;
+use proto::test_context::test_run::TestResult;
 use wasm_bindgen::prelude::*;
 use wasm_streams::{readable::sys, readable::ReadableStream};
 
 #[wasm_bindgen]
 pub fn bin_parse(bin: Vec<u8>) -> Result<Vec<junit::bindings::BindingsReport>, JsError> {
-    let test_result = proto::test_context::test_run::TestResult::decode(bin.as_slice())
-        .map_err(|err| JsError::new(&err.to_string()))?;
+    let test_result =
+        TestResult::decode(bin.as_slice()).map_err(|err| JsError::new(&err.to_string()))?;
     Ok(vec![junit::bindings::BindingsReport::from(test_result)])
 }
 
@@ -133,4 +137,33 @@ pub async fn parse_meta_from_tarball(
     parse_tarball(buf_reader)
         .await
         .map_err(|err| JsError::new(&err.to_string()))
+}
+
+#[wasm_bindgen()]
+pub async fn parse_internal_bin_from_tarball(
+    input: sys::ReadableStream,
+) -> Result<Vec<junit::bindings::BindingsReport>, JsError> {
+    let readable_stream = ReadableStream::from_raw(input);
+
+    // Many platforms do not support readable byte streams
+    // https://github.com/MattiasBuelens/wasm-streams/issues/19#issuecomment-1447294077
+    let async_read = match readable_stream.try_into_async_read() {
+        Ok(async_read) => Either::Left(async_read),
+        Err((_err, body)) => Either::Right(
+            body.into_stream()
+                .map_ok(|js_value| js_value.dyn_into::<Uint8Array>().unwrap_throw().to_vec())
+                .map_err(|_js_error| {
+                    std::io::Error::new(std::io::ErrorKind::Other, "failed to read")
+                })
+                .into_async_read(),
+        ),
+    };
+
+    let buf_reader = BufReaderAsync::new(async_read);
+
+    let test_result = parse_bin(buf_reader)
+        .await
+        .map_err(|err| JsError::new(&err.to_string()))?;
+
+    Ok(vec![junit::bindings::BindingsReport::from(test_result)])
 }

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, io::BufReader, sync::Arc};
 
 use bundle::{
+    parse_internal_bin_from_tarball as parse_internal_bin_from_tarball_impl,
     parse_meta as parse_meta_impl, parse_meta_from_tarball as parse_meta_from_tarball_impl,
     BindingsVersionedBundle,
 };
@@ -166,6 +167,23 @@ pub fn parse_meta_from_tarball(
         .block_on(parse_meta_from_tarball_impl(py_bytes_reader))
         .map_err(|err| PyTypeError::new_err(err.to_string()))?;
     Ok(BindingsVersionedBundle(versioned_bundle))
+}
+
+#[gen_stub_pyfunction]
+#[pyfunction]
+pub fn parse_internal_bin_from_tarball(
+    py: Python<'_>,
+    reader: PyObject,
+) -> PyResult<Vec<junit::bindings::BindingsReport>> {
+    let py_bytes_reader = PyBytesReader::new(reader.into_bound(py))?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let internal_bin = rt
+        .block_on(parse_internal_bin_from_tarball_impl(py_bytes_reader))
+        .map_err(|err| PyTypeError::new_err(err.to_string()))?;
+
+    Ok(vec![junit::bindings::BindingsReport::from(internal_bin)])
 }
 
 #[gen_stub_pyfunction]


### PR DESCRIPTION
Similar to `parse_metadata_from_tarball`, this PR aims to introduce a rust method that can be used to extract and parse the internal.bin file from an upload (as opposed to having consumers extract the tarball from the S3 stream themselves)