### PR TITLE
Specify job_id in buildkite url

### DIFF
--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -333,7 +333,7 @@ impl<'a> CIInfoParser<'a> {
     fn parse_buildkite(&mut self) {
         if let (Some(url), Some(id)) = (
             self.get_env_var("BUILDKITE_BUILD_URL"),
-            self.get_env_var("BUILDKITE_STEP_ID"),
+            self.get_env_var("BUILDKITE_JOB_ID"),
         ) {
             self.ci_info.job_url = Some(format!("{}#{}", url, id));
         }

--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -8,8 +8,8 @@ use context::env::{
 #[test]
 fn test_simple_buildkite() {
     let job_url = String::from("https://buildkite.com/test/builds/123");
-    let step_id = String::from("step-id");
-    let full_job_url = format!("{}#{}", job_url, step_id);
+    let job_id = String::from("job-id");
+    let full_job_url = format!("{}#{}", job_url, job_id);
     let branch = String::from("some-branch-name");
     let env_vars = EnvVars::from_iter(vec![
         (
@@ -23,7 +23,7 @@ fn test_simple_buildkite() {
             String::from(""),
         ),
         (String::from("BUILDKITE"), String::from("true")),
-        (String::from("BUILDKITE_STEP_ID"), String::from("step-id")),
+        (String::from("BUILDKITE_JOB_ID"), String::from("job-id")),
     ]);
 
     let mut env_parser = EnvParser::new();

--- a/context/tests/meta.rs
+++ b/context/tests/meta.rs
@@ -68,7 +68,7 @@ fn valid_ci_info_and_bundle_repo() -> (CIInfo, BundleRepo) {
             String::from(""),
         ),
         (String::from("BUILDKITE"), String::from("true")),
-        (String::from("BUILDKITE_STEP_ID"), String::from("step-id")),
+        (String::from("BUILDKITE_JOB_ID"), String::from("job-id")),
     ]);
 
     let mut env_parser = EnvParser::new();


### PR DESCRIPTION
BUILDKITE_BUILD_URL#BUILDKITE_JOB_ID works for both the old and new ui. The new UI will auto-redirect you to the job in question. 

This is a bindings only change, so we do not need a CLI release to get this out.