### PR TITLE
Deprecate hide_banner flag

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,14 +57,6 @@ impl Cli {
         }
     }
 
-    pub fn hide_banner(&self) -> bool {
-        match &self.command {
-            Commands::Test(args) => args.hide_banner(),
-            Commands::Upload(args) => args.hide_banner,
-            Commands::Validate(args) => args.hide_banner(),
-        }
-    }
-
     pub fn repo_root(&self) -> String {
         let explicit_root = match &self.command {
             Commands::Test(args) => args.repo_root(),

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -37,10 +37,6 @@ impl TestArgs {
     pub fn repo_root(&self) -> Option<String> {
         self.upload_args.repo_root.clone()
     }
-
-    pub fn hide_banner(&self) -> bool {
-        self.upload_args.hide_banner
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -122,13 +122,14 @@ pub struct UploadArgs {
     pub allow_empty_test_results: bool,
     #[arg(
         long,
-        help = "Hide the top-level flaky tests banner",
+        help = "Deprecated (does nothing, left in to avoid breaking existing flows)",
         action = ArgAction::Set,
         required = false,
         require_equals = true,
         num_args = 0..=1,
         default_value = "false",
         default_missing_value = "true",
+        hide = true,
     )]
     pub hide_banner: bool,
     #[arg(

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -45,21 +45,16 @@ pub struct ValidateArgs {
     pub codeowners_path: Option<String>,
     #[arg(
         long,
-        help = "Hide the top-level flaky tests banner",
+        help = "Deprecated (does nothing, left in to avoid breaking existing flows)",
         action = ArgAction::Set,
         required = false,
         require_equals = true,
         num_args = 0..=1,
         default_value = "false",
         default_missing_value = "true",
+        hide = true,
     )]
     pub hide_banner: bool,
-}
-
-impl ValidateArgs {
-    pub fn hide_banner(&self) -> bool {
-        self.hide_banner
-    }
 }
 
 pub async fn run_validate(validate_args: ValidateArgs) -> anyhow::Result<i32> {
@@ -68,7 +63,7 @@ pub async fn run_validate(validate_args: ValidateArgs) -> anyhow::Result<i32> {
         bazel_bep_path,
         show_warnings: _,
         codeowners_path,
-        hide_banner: _,
+        ..
     } = validate_args;
 
     let junit_file_paths = match bazel_bep_path {


### PR DESCRIPTION
The hide_banner flag does nothing in the superconsole world, so it can be deprecated and have its logic removed.