### PR TITLE
Loosen code owners parsing

### DIFF
--- a/codeowners/src/github.rs
+++ b/codeowners/src/github.rs
@@ -96,8 +96,9 @@ impl OwnersOfPath for GitHubOwners {
                 if pattern.matches_path_with(path.as_ref(), opts) {
                     Some(owners)
                 } else {
-                    // if the path is relative, we need to strip the leading dot
-                    // to match the pattern
+                    // NOTE: if the path is relative, we need to strip the leading dot
+                    // to match the pattern. We are doing this as a workaround for
+                    // cases where the provided path is relative, like `./foo/bar/baz.rs`
                     if let Ok(simplified_path) = path.as_ref().strip_prefix("./") {
                         if pattern.matches_path_with(simplified_path, opts) {
                             return Some(owners);
@@ -393,8 +394,8 @@ mod tests {
             owners.of("./foo/bar/baz.rs"),
             Some(vec![GitHubOwner::Username("@doug".into())])
         );
-        assert_eq!(owners.of(".foo/bar/baz.rs"), None,);
-        assert_eq!(owners.of("./"), None,);
+        assert_eq!(owners.of(".foo/bar/baz.rs"), None);
+        assert_eq!(owners.of("./"), None);
         assert_eq!(
             owners.of("./foo/bar/baz.rs"),
             Some(vec![GitHubOwner::Username("@doug".into())])

--- a/codeowners/src/github.rs
+++ b/codeowners/src/github.rs
@@ -96,6 +96,13 @@ impl OwnersOfPath for GitHubOwners {
                 if pattern.matches_path_with(path.as_ref(), opts) {
                     Some(owners)
                 } else {
+                    // if the path is relative, we need to strip the leading dot
+                    // to match the pattern
+                    if let Ok(simplified_path) = path.as_ref().strip_prefix("./") {
+                        if pattern.matches_path_with(simplified_path, opts) {
+                            return Some(owners);
+                        }
+                    }
                     // this pattern is only meant to match
                     // direct children
                     if pattern.as_str().ends_with("/*") {
@@ -349,6 +356,10 @@ mod tests {
         assert_eq!(
             owners.of("foo/apps/foo.js"),
             Some(vec![GitHubOwner::Username("@octocat".into())])
+        );
+        assert_eq!(
+            owners.of("./foo/apps/foo.js"),
+            Some(vec![GitHubOwner::Username("@octocat".into())])
         )
     }
 
@@ -359,6 +370,10 @@ mod tests {
         assert_eq!(
             owners.of("docs/foo.js"),
             Some(vec![GitHubOwner::Username("@doctocat".into())])
+        );
+        assert_eq!(
+            owners.of("./docs/foo.js"),
+            Some(vec![GitHubOwner::Username("@doctocat".into())])
         )
     }
 
@@ -367,6 +382,21 @@ mod tests {
         let owners = GitHubOwners::from_reader("foo/bar @doug".as_bytes()).unwrap();
         assert_eq!(
             owners.of("foo/bar/baz.rs"),
+            Some(vec![GitHubOwner::Username("@doug".into())])
+        );
+    }
+
+    #[test]
+    fn relative_path_owners() {
+        let owners = GitHubOwners::from_reader("foo/bar @doug".as_bytes()).unwrap();
+        assert_eq!(
+            owners.of("./foo/bar/baz.rs"),
+            Some(vec![GitHubOwner::Username("@doug".into())])
+        );
+        assert_eq!(owners.of(".foo/bar/baz.rs"), None,);
+        assert_eq!(owners.of("./"), None,);
+        assert_eq!(
+            owners.of("./foo/bar/baz.rs"),
             Some(vec![GitHubOwner::Username("@doug".into())])
         )
     }

--- a/codeowners/src/gitlab/file.rs
+++ b/codeowners/src/gitlab/file.rs
@@ -64,6 +64,9 @@ impl File {
     }
 
     pub fn entries_for_path(&self, path: String) -> Vec<Entry> {
+        // NOTE: if the path is relative, we need to strip the leading dot
+        // to match the pattern. We are doing this as a workaround for
+        // cases where the provided path is relative, like `./foo/bar/baz.rs`
         let stripped_path = path.strip_prefix("./");
         let path = if path.starts_with('/') {
             path

--- a/codeowners/src/gitlab/file.rs
+++ b/codeowners/src/gitlab/file.rs
@@ -64,8 +64,14 @@ impl File {
     }
 
     pub fn entries_for_path(&self, path: String) -> Vec<Entry> {
+        let stripped_path = path.strip_prefix("./");
         let path = if path.starts_with('/') {
             path
+        } else if stripped_path.is_some() {
+            format!(
+                "/{}",
+                stripped_path.map(|s| s.to_string()).unwrap_or_default()
+            )
         } else {
             format!("/{path}")
         };

--- a/codeowners/src/gitlab/mod.rs
+++ b/codeowners/src/gitlab/mod.rs
@@ -199,6 +199,10 @@ mod tests {
             owners.of("build/logs/foo/bar.go"),
             Some(vec![GitLabOwner::Name("@doctocat".into())])
         );
+        assert_eq!(
+            owners.of("./build/logs/foo/bar.go"),
+            Some(vec![GitLabOwner::Name("@doctocat".into())])
+        );
         // not relative to root
         assert_eq!(
             owners.of("foo/build/logs/foo.go"),
@@ -266,6 +270,26 @@ mod tests {
         assert_eq!(
             partial_missing_owner.of("foo/bar/baz2.rs"),
             Some(Vec::new())
+        );
+    }
+
+    #[test]
+    fn relative_path_is_parsable() {
+        let relative_path = GitLabOwners::from_reader(
+            "/ @doug\nfoo/bar @doug\nfoo/bar/baz.rs @bob\nfoo/bar/baz2.rs @alice".as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            relative_path.of("./foo/bar/baz.rs"),
+            Some(vec![GitLabOwner::Name("@bob".into())])
+        );
+        assert_eq!(
+            relative_path.of("./foo/bar/baz2.rs"),
+            Some(vec![GitLabOwner::Name("@alice".into())])
+        );
+        assert_eq!(
+            relative_path.of("./"),
+            Some(vec![GitLabOwner::Name("@doug".into())])
         );
     }
 }


### PR DESCRIPTION
If a relative path is provided, we should attempt to match it relative to the root of the repo. This will allow us to parse the corresponding code owner when a test reporter provides relative paths.