### PR TITLE
part 1 update validation to mark timestamps as old when older than 24 hours

### DIFF
--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -1195,7 +1195,7 @@ mod tests {
                     assert_eq!(issue.1.error_type, JunitValidationType::Report);
                     assert_eq!(
                         issue.1.error_message,
-                        "report has old (> 30 day(s)) timestamps"
+                        "report has old (> 24 hour(s)) timestamps"
                     );
                 } else {
                     assert_eq!(issue.1.error_type, JunitValidationType::TestCase);

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -15,7 +15,7 @@ use crate::string_safety::{validate_field_len, FieldLen};
 
 pub const MAX_FIELD_LEN: usize = 1_000;
 
-const TIMESTAMP_OLD_DAYS: u32 = 30;
+const TIMESTAMP_OLD_HOURS: u32 = 24;
 const TIMESTAMP_STALE_HOURS: u32 = 1;
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
@@ -161,7 +161,7 @@ pub fn validate(report: &Report) -> JunitReportValidation {
                     test_case_validation.add_issue(JunitValidationIssue::SubOptimal(
                         JunitTestCaseValidationIssueSubOptimal::TestCaseFutureTimestamp(timestamp),
                     ));
-                } else if time_since_timestamp.num_days() > i64::from(TIMESTAMP_OLD_DAYS) {
+                } else if time_since_timestamp.num_hours() > i64::from(TIMESTAMP_OLD_HOURS) {
                     test_case_validation.add_issue(JunitValidationIssue::SubOptimal(
                         JunitTestCaseValidationIssueSubOptimal::TestCaseOldTimestamp(timestamp),
                     ));
@@ -406,7 +406,7 @@ pub enum JunitReportValidationIssueSubOptimal {
     MissingTimestamps,
     #[error("report has test cases with future timestamp")]
     FutureTimestamps,
-    #[error("report has old (> {} day(s)) timestamps", TIMESTAMP_OLD_DAYS)]
+    #[error("report has old (> {} hour(s)) timestamps", TIMESTAMP_OLD_HOURS)]
     OldTimestamps,
     #[error("report has stale (> {} hour(s)) timestamps", TIMESTAMP_STALE_HOURS)]
     StaleTimestamps,
@@ -574,8 +574,8 @@ pub enum JunitTestCaseValidationIssueSubOptimal {
     #[error("test case or parent has future timestamp")]
     TestCaseFutureTimestamp(DateTime<FixedOffset>),
     #[error(
-        "test case or parent has old (> {} day(s)) timestamp",
-        TIMESTAMP_OLD_DAYS
+        "test case or parent has old (> {} hour(s)) timestamp",
+        TIMESTAMP_OLD_HOURS
     )]
     TestCaseOldTimestamp(DateTime<FixedOffset>),
     #[error(

--- a/context/src/repo/validator.rs
+++ b/context/src/repo/validator.rs
@@ -15,7 +15,7 @@ pub const MAX_EMAIL_LEN: usize = 254;
 pub const MAX_FIELD_LEN: usize = 1000;
 pub const MAX_SHA_FIELD_LEN: usize = 40;
 
-const TIMESTAMP_OLD_DAYS: u32 = 30;
+const TIMESTAMP_OLD_HOURS: u32 = 24;
 const TIMESTAMP_STALE_HOURS: u32 = 1;
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass_enum, pyclass(eq, eq_int))]
@@ -84,7 +84,10 @@ pub enum RepoValidationIssueSubOptimal {
     RepoCommitMessageTooLong(String),
     #[error("repo head commit has future timestamp")]
     RepoCommitFutureTimestamp(DateTime<Utc>),
-    #[error("repo head commit has old (> {} day(s)) timestamp", TIMESTAMP_OLD_DAYS)]
+    #[error(
+        "repo head commit has old (> {} hour(s)) timestamp",
+        TIMESTAMP_OLD_HOURS
+    )]
     RepoCommitOldTimestamp(DateTime<Utc>),
     #[error(
         "repo head commit has stale (> {} hour(s)) timestamp",
@@ -191,7 +194,7 @@ pub fn validate(bundle_repo: &BundleRepo) -> RepoValidation {
             repo_validation.add_issue(RepoValidationIssue::SubOptimal(
                 RepoValidationIssueSubOptimal::RepoCommitFutureTimestamp(timestamp),
             ));
-        } else if time_since_timestamp.num_days() > i64::from(TIMESTAMP_OLD_DAYS) {
+        } else if time_since_timestamp.num_hours() > i64::from(TIMESTAMP_OLD_HOURS) {
             repo_validation.add_issue(RepoValidationIssue::SubOptimal(
                 RepoValidationIssueSubOptimal::RepoCommitOldTimestamp(timestamp),
             ));

--- a/context/tests/junit.rs
+++ b/context/tests/junit.rs
@@ -5,10 +5,11 @@ use context::junit::{
     self,
     parser::JunitParser,
     validator::{
+        JunitReportValidationIssue, JunitReportValidationIssueSubOptimal,
         JunitTestCaseValidationIssue, JunitTestCaseValidationIssueInvalid,
         JunitTestCaseValidationIssueSubOptimal, JunitTestSuiteValidationIssue,
         JunitTestSuiteValidationIssueInvalid, JunitTestSuiteValidationIssueSubOptimal,
-        JunitValidationIssue, JunitValidationLevel,
+        JunitValidationIssue, JunitValidationIssueType, JunitValidationLevel,
     },
 };
 use junit_mock::JunitMock;
@@ -264,6 +265,65 @@ fn validate_max_level() {
         vec![JunitValidationIssue::Invalid(
             JunitTestCaseValidationIssueInvalid::TestCaseNameTooShort(String::new()),
         )],
+        "failed to validate with seed `{}`",
+        seed,
+    );
+}
+
+#[test]
+fn validate_timestamps() {
+    let (seed, mut generated_reports) = generate_mock_junit_reports(1, Some(1), Some(4));
+    let mut generated_report = generated_reports.pop().unwrap();
+    let generated_report_timestamp = generated_report.timestamp.unwrap();
+
+    for test_suite in &mut generated_report.test_suites {
+        for (index, test_case) in &mut test_suite.test_cases.iter_mut().enumerate() {
+            match index {
+                0 => {
+                    // future timestamp
+                    test_case.timestamp = Utc::now()
+                        .fixed_offset()
+                        .checked_add_signed(TimeDelta::hours(1));
+                }
+                1 => {
+                    // stale timestamp
+                    test_case.timestamp =
+                        generated_report_timestamp.checked_sub_signed(TimeDelta::hours(1))
+                }
+                2 => {
+                    // old timestamp
+                    test_case.timestamp =
+                        generated_report_timestamp.checked_sub_signed(TimeDelta::hours(24))
+                }
+                _ => {
+                    // valid timestamp
+                }
+            };
+        }
+    }
+
+    let report_validation = junit::validator::validate(&generated_report);
+
+    assert_eq!(
+        report_validation.max_level(),
+        JunitValidationLevel::SubOptimal,
+        "failed to validate with seed `{}`",
+        seed,
+    );
+
+    pretty_assertions::assert_eq!(
+        report_validation.all_issues(),
+        vec![
+            JunitValidationIssueType::Report(JunitReportValidationIssue::SubOptimal(
+                JunitReportValidationIssueSubOptimal::OldTimestamps,
+            )),
+            JunitValidationIssueType::Report(JunitReportValidationIssue::SubOptimal(
+                JunitReportValidationIssueSubOptimal::StaleTimestamps,
+            )),
+            JunitValidationIssueType::Report(JunitReportValidationIssue::SubOptimal(
+                JunitReportValidationIssueSubOptimal::FutureTimestamps,
+            )),
+        ],
         "failed to validate with seed `{}`",
         seed,
     );


### PR DESCRIPTION
First of a couple of PRs to update how we validate timestamps. The threshold has been reduced to 24 hours.