### PR TITLE
part 4 use test runner report for junit report validation

### DIFF
--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -245,8 +245,13 @@ pub fn generate_internal_file(
                     }
                     let reports = junit_parser.reports();
                     if reports.len() == 1 {
-                        junit_validations
-                            .insert(file.original_path.clone(), Ok(validate(&reports[0])));
+                        junit_validations.insert(
+                            file.original_path.clone(),
+                            Ok(validate(
+                                &reports[0],
+                                file_set.test_runner_report.map(|t| t.into()),
+                            )),
+                        );
                     }
                     test_case_runs.extend(junit_parser.into_test_case_runs(codeowners));
                 }

--- a/context-js/src/lib.rs
+++ b/context-js/src/lib.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, io::BufReader};
 
 use bundle::{
     parse_internal_bin_from_tarball as parse_internal_bin,
-    parse_meta_from_tarball as parse_tarball, VersionedBundle,
+    parse_meta_from_tarball as parse_tarball, FileSetTestRunnerReport, VersionedBundle,
 };
 use context::{env, junit, repo};
 use futures::{future::Either, io::BufReader as BufReaderAsync, stream::TryStreamExt};
@@ -100,9 +100,11 @@ pub fn junit_parse(xml: Vec<u8>) -> Result<junit::bindings::BindingsParseResult,
 #[wasm_bindgen]
 pub fn junit_validate(
     report: &junit::bindings::BindingsReport,
+    test_runner_report: Option<FileSetTestRunnerReport>,
 ) -> junit::bindings::BindingsJunitReportValidation {
     junit::bindings::BindingsJunitReportValidation::from(junit::validator::validate(
         &report.clone().into(),
+        test_runner_report.map(junit::junit_path::TestRunnerReport::from),
     ))
 }
 

--- a/context-js/tests/parse_and_validate.test.ts
+++ b/context-js/tests/parse_and_validate.test.ts
@@ -109,6 +109,14 @@ describe("context-js", () => {
         .filter((issue) => issue.error_type === JunitValidationType.Report),
     ).toHaveLength(1);
 
+    junitReportValidation = junit_validate(parse_result.report, {
+      resolved_status: "Passed",
+      resolved_start_time_epoch_ms: dayjs.utc().subtract(5, "minute").valueOf(),
+      resolved_end_time_epoch_ms: dayjs.utc().subtract(2, "minute").valueOf(),
+    });
+
+    expect(junitReportValidation.max_level()).toBe(JunitValidationLevel.Valid);
+
     const nestedJunitXml = `<?xml version="1.0" encoding="UTF-8"?>
       <testsuites>
           <testsuite name="/home/runner/work/flake-farm/flake-farm/php/phpunit/phpunit.xml" tests="2" assertions="2" errors="0" failures="0" skipped="0" timestamp="${validTimestamp}" time="0.001161">

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -7,7 +7,11 @@ use bundle::{
 use codeowners::{
     associate_codeowners_multithreaded as associate_codeowners, BindingsOwners, CodeOwners, Owners,
 };
-use context::{env, junit, meta, repo};
+use context::{
+    env,
+    junit::{self, junit_path::TestRunnerReport},
+    meta, repo,
+};
 use prost::Message;
 use pyo3::{exceptions::PyTypeError, prelude::*};
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyfunction};
@@ -106,12 +110,21 @@ fn bin_parse(bin: Vec<u8>) -> PyResult<Vec<junit::bindings::BindingsReport>> {
     Ok(vec![junit::bindings::BindingsReport::from(test_result)])
 }
 
+// NOTE: This complains about the deprecation of using `Option<T>` as an auto-variadic
+// function signature, but because we use `gen_stub_pyfunction` it always requires the second
+// argument to be passed. And if you try to implement the suggested fix of using
+// `#[pyo3(signature = (report, test_runner_report=None))]`, `gen_stub_pyfunction` does not work
+// correctly, so it's best to just leave this the way it is.
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn junit_validate(
     report: junit::bindings::BindingsReport,
+    test_runner_report: Option<bundle::FileSetTestRunnerReport>,
 ) -> junit::bindings::BindingsJunitReportValidation {
-    junit::bindings::BindingsJunitReportValidation::from(junit::validator::validate(&report.into()))
+    junit::bindings::BindingsJunitReportValidation::from(junit::validator::validate(
+        &report.into(),
+        test_runner_report.map(TestRunnerReport::from),
+    ))
 }
 
 #[gen_stub_pyfunction]
@@ -133,6 +146,7 @@ fn junit_validation_type_to_string(
 ) -> String {
     match junit_validation_type {
         junit::validator::JunitValidationType::Report => "Report".to_string(),
+        junit::validator::JunitValidationType::TestRunnerReport => "TestRunnerReport".to_string(),
         junit::validator::JunitValidationType::TestSuite => "TestSuite".to_string(),
         junit::validator::JunitValidationType::TestCase => "TestCase".to_string(),
     }

--- a/context-py/tests/test_junit_validate.py
+++ b/context-py/tests/test_junit_validate.py
@@ -29,7 +29,7 @@ def test_junit_validate_valid():
     report = parse_result.report
     assert report is not None
 
-    junit_report_validation = junit_validate(report)
+    junit_report_validation = junit_validate(report, None)
 
     assert (
         junit_report_validation.max_level() == JunitValidationLevel.Valid
@@ -74,7 +74,7 @@ def test_junit_validate_suboptimal():
     report = parse_result.report
     assert report is not None
 
-    junit_report_validation = junit_validate(report)
+    junit_report_validation = junit_validate(report, None)
 
     assert (
         junit_report_validation.max_level() == JunitValidationLevel.SubOptimal
@@ -98,4 +98,65 @@ def test_junit_validate_suboptimal():
     )
     assert (
         junit_validation_level_to_string(report_level_issues[0].level) == "SUBOPTIMAL"
+    )
+
+
+def test_junit_validate_with_test_runner_report():
+    from datetime import datetime, timedelta, timezone
+
+    from context_py import (
+        BindingsParseResult,
+        FileSetTestRunnerReport,
+        JunitValidationLevel,
+        TestRunnerReportStatus,
+        junit_parse,
+        junit_validate,
+    )
+
+    stale_timestamp = (
+        (datetime.now() - timedelta(hours=30)).astimezone(timezone.utc).isoformat()
+    )
+    suboptimal_junit_xml = f"""
+    <testsuites name="my-test-run" tests="1" failures="1" errors="0">
+      <testsuite name="my-test-suite" tests="1" disabled="0" errors="0" failures="1" timestamp="{stale_timestamp}">
+        <testcase name="failure-case" file="test.py" classname="MyClass" timestamp="{stale_timestamp}" time="1">
+          <failure/>
+        </testcase>
+      </testsuite>
+    </testsuites>
+   """
+
+    parse_result: BindingsParseResult = junit_parse(str.encode(suboptimal_junit_xml))
+    report = parse_result.report
+    assert report is not None
+
+    junit_report_validation = junit_validate(report, None)
+
+    assert (
+        junit_report_validation.max_level() == JunitValidationLevel.SubOptimal
+    ), "\n" + "\n".join(
+        [
+            issue.error_message
+            for test_suite in junit_report_validation.test_suites
+            for test_case in test_suite.test_cases_owned()
+            for issue in test_case.issues_flat()
+        ]
+    )
+
+    test_runner_report = FileSetTestRunnerReport(
+        TestRunnerReportStatus.Passed,
+        datetime.now().astimezone(timezone.utc),
+        datetime.now().astimezone(timezone.utc),
+    )
+    junit_report_validation = junit_validate(report, test_runner_report)
+
+    assert (
+        junit_report_validation.max_level() == JunitValidationLevel.Valid
+    ), "\n" + "\n".join(
+        [
+            issue.error_message
+            for test_suite in junit_report_validation.test_suites
+            for test_case in test_suite.test_cases_owned()
+            for issue in test_case.issues_flat()
+        ]
     )

--- a/context-py/tests/test_parse_compressed_bundle.py
+++ b/context-py/tests/test_parse_compressed_bundle.py
@@ -3,13 +3,13 @@ def test_parse_meta_from_tarball():
     import json
     import tarfile
     import tempfile
+    import typing
 
     import zstandard as zstd
     from botocore.response import StreamingBody
     from context_py import parse_meta_from_tarball
 
-    # trunk-ignore(pyright/reportUnknownVariableType)
-    expected_meta = {
+    expected_meta: typing.Any = {
         "version": "1",
         "bundle_upload_id": "59c8ddd9-0a00-4b56-9eea-ef0d60ebcb79",
         "cli_version": "cargo=0.5.11 git=7e5824fa365c63a2d4b38020762be17f4edd6425 rustc=1.80.0-nightly",

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -19,7 +19,7 @@ use super::{
         JunitValidationLevel, JunitValidationType,
     },
 };
-use crate::junit::parser::extra_attrs;
+use crate::junit::{parser::extra_attrs, validator::TestRunnerReportValidation};
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
@@ -921,6 +921,7 @@ impl From<BindingsNonSuccessKind> for NonSuccessKind {
 pub struct BindingsJunitReportValidation {
     all_issues: Vec<JunitReportValidationFlatIssue>,
     level: JunitValidationLevel,
+    test_runner_report: TestRunnerReportValidation,
     test_suites: Vec<JunitTestSuiteValidation>,
     valid_test_suites: Vec<BindingsTestSuite>,
 }
@@ -932,6 +933,7 @@ impl From<JunitReportValidation> for BindingsJunitReportValidation {
             level,
             test_suites,
             valid_test_suites,
+            test_runner_report,
         }: JunitReportValidation,
     ) -> Self {
         Self {
@@ -949,6 +951,7 @@ impl From<JunitReportValidation> for BindingsJunitReportValidation {
                 .into_iter()
                 .map(BindingsTestSuite::from)
                 .collect(),
+            test_runner_report,
         }
     }
 }
@@ -1180,7 +1183,7 @@ mod tests {
         assert_eq!(test_case2.codeowners.clone().unwrap().len(), 0);
 
         // verify that the test report is valid
-        let results = validate(&converted_bindings.clone().into());
+        let results = validate(&converted_bindings.clone().into(), None);
         assert_eq!(results.all_issues_flat().len(), 1);
         results
             .all_issues_flat()

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -1,6 +1,6 @@
-use std::{cmp::Ordering, collections::HashSet};
+use std::{cmp::Ordering, collections::HashSet, fmt};
 
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, FixedOffset, TimeDelta, Utc};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
@@ -11,7 +11,10 @@ use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 use super::parser::extra_attrs;
-use crate::string_safety::{validate_field_len, FieldLen};
+use crate::{
+    junit::junit_path::TestRunnerReport,
+    string_safety::{validate_field_len, FieldLen},
+};
 
 pub const MAX_FIELD_LEN: usize = 1_000;
 
@@ -39,6 +42,15 @@ pub enum JunitValidationIssue<SO, I> {
     Invalid(I),
 }
 
+impl<SO: fmt::Display, I: fmt::Display> fmt::Display for JunitValidationIssue<SO, I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SubOptimal(i) => write!(f, "{i}"),
+            Self::Invalid(i) => write!(f, "{i}"),
+        }
+    }
+}
+
 impl<SO, I> From<&JunitValidationIssue<SO, I>> for JunitValidationLevel {
     fn from(value: &JunitValidationIssue<SO, I>) -> Self {
         match value {
@@ -53,8 +65,9 @@ impl<SO, I> From<&JunitValidationIssue<SO, I>> for JunitValidationLevel {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum JunitValidationType {
     Report = 0,
-    TestSuite = 1,
-    TestCase = 2,
+    TestRunnerReport = 1,
+    TestSuite = 2,
+    TestCase = 3,
 }
 
 impl Default for JunitValidationType {
@@ -63,8 +76,20 @@ impl Default for JunitValidationType {
     }
 }
 
-pub fn validate(report: &Report) -> JunitReportValidation {
+pub fn validate(
+    report: &Report,
+    test_runner_report: Option<TestRunnerReport>,
+) -> JunitReportValidation {
     let mut report_validation = JunitReportValidation::default();
+
+    let now = Utc::now().fixed_offset();
+    validate_test_runner_report(test_runner_report, now)
+        .into_iter()
+        .for_each(|i| {
+            report_validation
+                .test_runner_report
+                .add_issue(TestRunnerReportValidationIssue::SubOptimal(i))
+        });
 
     for test_suite in report.test_suites.iter() {
         let mut test_suite_validation = JunitTestSuiteValidation::default();
@@ -149,32 +174,15 @@ pub fn validate(report: &Report) -> JunitReportValidation {
                 ));
             }
 
-            if let Some(timestamp) = test_case
-                .timestamp
-                .or(test_suite.timestamp)
-                .or(report.timestamp)
-            {
-                let now = Utc::now().fixed_offset();
-                let time_since_timestamp = now - timestamp;
-
-                if timestamp > now {
-                    test_case_validation.add_issue(JunitValidationIssue::SubOptimal(
-                        JunitTestCaseValidationIssueSubOptimal::TestCaseFutureTimestamp(timestamp),
-                    ));
-                } else if time_since_timestamp.num_hours() > i64::from(TIMESTAMP_OLD_HOURS) {
-                    test_case_validation.add_issue(JunitValidationIssue::SubOptimal(
-                        JunitTestCaseValidationIssueSubOptimal::TestCaseOldTimestamp(timestamp),
-                    ));
-                } else if time_since_timestamp.num_hours() > i64::from(TIMESTAMP_STALE_HOURS) {
-                    test_case_validation.add_issue(JunitValidationIssue::SubOptimal(
-                        JunitTestCaseValidationIssueSubOptimal::TestCaseStaleTimestamp(timestamp),
-                    ));
-                }
-            } else {
-                test_case_validation.add_issue(JunitValidationIssue::SubOptimal(
-                    JunitTestCaseValidationIssueSubOptimal::TestCaseNoTimestamp,
-                ));
-            }
+            validate_test_case_timestamp(
+                test_case.timestamp,
+                test_suite.timestamp,
+                report.timestamp,
+                test_runner_report,
+                now,
+            )
+            .into_iter()
+            .for_each(|i| test_case_validation.add_issue(JunitValidationIssue::SubOptimal(i)));
 
             if test_case_validation.level != JunitValidationLevel::Invalid {
                 valid_test_cases.push(test_case.clone());
@@ -201,6 +209,7 @@ pub fn validate(report: &Report) -> JunitReportValidation {
 pub struct JunitReportValidation {
     pub all_issues: Vec<JunitValidationIssueType>,
     pub level: JunitValidationLevel,
+    pub test_runner_report: TestRunnerReportValidation,
     pub test_suites: Vec<JunitTestSuiteValidation>,
     pub valid_test_suites: Vec<TestSuite>,
 }
@@ -208,16 +217,18 @@ pub struct JunitReportValidation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JunitValidationIssueType {
     Report(JunitReportValidationIssue),
+    TestRunnerReport(TestRunnerReportValidationIssue),
     TestSuite(JunitTestSuiteValidationIssue),
     TestCase(JunitTestCaseValidationIssue),
 }
 
-impl ToString for JunitValidationIssueType {
-    fn to_string(&self) -> String {
+impl fmt::Display for JunitValidationIssueType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            JunitValidationIssueType::Report(i) => i.to_string(),
-            JunitValidationIssueType::TestSuite(i) => i.to_string(),
-            JunitValidationIssueType::TestCase(i) => i.to_string(),
+            JunitValidationIssueType::Report(i) => write!(f, "{i}"),
+            JunitValidationIssueType::TestRunnerReport(i) => write!(f, "{i}"),
+            JunitValidationIssueType::TestSuite(i) => write!(f, "{i}"),
+            JunitValidationIssueType::TestCase(i) => write!(f, "{i}"),
         }
     }
 }
@@ -226,6 +237,7 @@ impl From<&JunitValidationIssueType> for JunitValidationType {
     fn from(value: &JunitValidationIssueType) -> Self {
         match value {
             JunitValidationIssueType::Report(..) => JunitValidationType::Report,
+            JunitValidationIssueType::TestRunnerReport(..) => JunitValidationType::TestRunnerReport,
             JunitValidationIssueType::TestSuite(..) => JunitValidationType::TestSuite,
             JunitValidationIssueType::TestCase(..) => JunitValidationType::TestCase,
         }
@@ -236,6 +248,7 @@ impl From<&JunitValidationIssueType> for JunitValidationLevel {
     fn from(value: &JunitValidationIssueType) -> Self {
         match value {
             JunitValidationIssueType::Report(i) => JunitValidationLevel::from(i),
+            JunitValidationIssueType::TestRunnerReport(i) => JunitValidationLevel::from(i),
             JunitValidationIssueType::TestSuite(i) => JunitValidationLevel::from(i),
             JunitValidationIssueType::TestCase(i) => JunitValidationLevel::from(i),
         }
@@ -310,6 +323,10 @@ impl JunitReportValidation {
     fn derive_all_issues(&mut self) {
         let mut report_level_issues: HashSet<JunitReportValidationIssue> = HashSet::new();
         let mut other_issues: Vec<JunitValidationIssueType> = Vec::new();
+
+        for issue in &self.test_runner_report.issues {
+            other_issues.push(JunitValidationIssueType::TestRunnerReport(issue.clone()));
+        }
 
         for test_suite in &self.test_suites {
             for issue in &test_suite.issues {
@@ -389,14 +406,43 @@ impl JunitReportValidation {
 pub type JunitReportValidationIssue =
     JunitValidationIssue<JunitReportValidationIssueSubOptimal, JunitReportValidationIssueInvalid>;
 
-impl ToString for JunitReportValidationIssue {
-    fn to_string(&self) -> String {
-        match self {
-            Self::SubOptimal(i) => i.to_string(),
-            Self::Invalid(i) => i.to_string(),
-        }
-    }
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TestRunnerReportValidationIssueSubOptimal {
+    #[error("test runner report start time has future timestamp")]
+    StartTimeFutureTimestamp(DateTime<FixedOffset>),
+    #[error(
+        "test runner report start time has old (> {} hour(s)) timestamp",
+        TIMESTAMP_OLD_HOURS
+    )]
+    StartTimeOldTimestamp(DateTime<FixedOffset>),
+    #[error(
+        "test runner report start time has stale (> {} hour(s)) timestamp",
+        TIMESTAMP_STALE_HOURS
+    )]
+    StartTimeStaleTimestamp(DateTime<FixedOffset>),
+    #[error("test runner report end time has future timestamp")]
+    EndTimeFutureTimestamp(DateTime<FixedOffset>),
+    #[error(
+        "test runner report end time has old (> {} hour(s)) timestamp",
+        TIMESTAMP_OLD_HOURS
+    )]
+    EndTimeOldTimestamp(DateTime<FixedOffset>),
+    #[error(
+        "test runner report end time has stale (> {} hour(s)) timestamp",
+        TIMESTAMP_STALE_HOURS
+    )]
+    EndTimeStaleTimestamp(DateTime<FixedOffset>),
+    #[error("test runner report end time is before start time")]
+    EndTimeBeforeStartTime(TestRunnerReport),
 }
+
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TestRunnerReportValidationIssueInvalid {}
+
+pub type TestRunnerReportValidationIssue = JunitValidationIssue<
+    TestRunnerReportValidationIssueSubOptimal,
+    TestRunnerReportValidationIssueInvalid,
+>;
 
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JunitReportValidationIssueSubOptimal {
@@ -420,12 +466,22 @@ pub type JunitTestSuiteValidationIssue = JunitValidationIssue<
     JunitTestSuiteValidationIssueInvalid,
 >;
 
-impl ToString for JunitTestSuiteValidationIssue {
-    fn to_string(&self) -> String {
-        match self {
-            Self::SubOptimal(i) => i.to_string(),
-            Self::Invalid(i) => i.to_string(),
-        }
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TestRunnerReportValidation {
+    level: JunitValidationLevel,
+    issues: Vec<TestRunnerReportValidationIssue>,
+}
+
+impl TestRunnerReportValidation {
+    pub fn issues(&self) -> &[TestRunnerReportValidationIssue] {
+        &self.issues
+    }
+
+    pub fn add_issue(&mut self, issue: TestRunnerReportValidationIssue) {
+        self.level = self.level.max(JunitValidationLevel::from(&issue));
+        self.issues.push(issue);
     }
 }
 
@@ -508,15 +564,6 @@ pub type JunitTestCaseValidationIssue = JunitValidationIssue<
     JunitTestCaseValidationIssueInvalid,
 >;
 
-impl ToString for JunitTestCaseValidationIssue {
-    fn to_string(&self) -> String {
-        match self {
-            Self::SubOptimal(i) => i.to_string(),
-            Self::Invalid(i) => i.to_string(),
-        }
-    }
-}
-
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(eq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -583,10 +630,157 @@ pub enum JunitTestCaseValidationIssueSubOptimal {
         TIMESTAMP_STALE_HOURS
     )]
     TestCaseStaleTimestamp(DateTime<FixedOffset>),
+    #[error("test case timestamp is after test runner report end time")]
+    TestCaseTimestampIsAfterTestReportEndTime(DateTime<FixedOffset>),
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum JunitTestCaseValidationIssueInvalid {
     #[error("test case name too short")]
     TestCaseNameTooShort(String),
+}
+
+fn validate_test_runner_report(
+    test_runner_report: Option<TestRunnerReport>,
+    now: DateTime<FixedOffset>,
+) -> Vec<TestRunnerReportValidationIssueSubOptimal> {
+    let mut issues: Vec<TestRunnerReportValidationIssueSubOptimal> = Vec::new();
+
+    if let Some(test_runner_report) = test_runner_report {
+        let TestRunnerReport {
+            start_time,
+            end_time,
+            ..
+        } = test_runner_report;
+        if let TimestampValidation::Future(_) = validate_timestamp(start_time, end_time) {
+            issues.push(
+                TestRunnerReportValidationIssueSubOptimal::EndTimeBeforeStartTime(
+                    test_runner_report,
+                ),
+            );
+        }
+        match validate_timestamp(start_time, now) {
+            TimestampValidation::Future(timestamp) => {
+                issues.push(
+                    TestRunnerReportValidationIssueSubOptimal::StartTimeFutureTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Old(timestamp) => {
+                issues.push(
+                    TestRunnerReportValidationIssueSubOptimal::StartTimeOldTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Stale(timestamp) => {
+                issues.push(
+                    TestRunnerReportValidationIssueSubOptimal::StartTimeStaleTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Valid => {}
+        };
+        match validate_timestamp(end_time, now) {
+            TimestampValidation::Future(timestamp) => {
+                issues.push(
+                    TestRunnerReportValidationIssueSubOptimal::EndTimeFutureTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Old(timestamp) => {
+                issues.push(
+                    TestRunnerReportValidationIssueSubOptimal::EndTimeOldTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Stale(timestamp) => {
+                issues.push(
+                    TestRunnerReportValidationIssueSubOptimal::EndTimeStaleTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Valid => {}
+        };
+    }
+
+    issues
+}
+
+fn validate_test_case_timestamp(
+    test_case_timestamp: Option<DateTime<FixedOffset>>,
+    test_suite_timestamp: Option<DateTime<FixedOffset>>,
+    report_timestamp: Option<DateTime<FixedOffset>>,
+    test_runner_report: Option<TestRunnerReport>,
+    now: DateTime<FixedOffset>,
+) -> Vec<JunitTestCaseValidationIssueSubOptimal> {
+    let mut issues: Vec<JunitTestCaseValidationIssueSubOptimal> = Vec::new();
+
+    if let Some(timestamp) = test_case_timestamp
+        .or(test_suite_timestamp)
+        .or(report_timestamp)
+    {
+        let test_runner_report_start_time_override_timestamp_diff =
+            if let Some(test_runner_report) = test_runner_report {
+                let ts_diff_from = report_timestamp
+                    .or(test_suite_timestamp)
+                    .unwrap_or(timestamp);
+                test_runner_report
+                    .start_time
+                    .signed_duration_since(ts_diff_from)
+            } else {
+                TimeDelta::zero()
+            };
+        let timestamp = timestamp
+            .checked_add_signed(test_runner_report_start_time_override_timestamp_diff)
+            .unwrap_or(timestamp);
+
+        match validate_timestamp(timestamp, now) {
+            TimestampValidation::Future(timestamp) => {
+                issues.push(
+                    JunitTestCaseValidationIssueSubOptimal::TestCaseFutureTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Old(timestamp) => {
+                issues
+                    .push(JunitTestCaseValidationIssueSubOptimal::TestCaseOldTimestamp(timestamp));
+            }
+            TimestampValidation::Stale(timestamp) => {
+                issues.push(
+                    JunitTestCaseValidationIssueSubOptimal::TestCaseStaleTimestamp(timestamp),
+                );
+            }
+            TimestampValidation::Valid => {}
+        };
+
+        if let Some(test_runner_report) = test_runner_report {
+            if let TimestampValidation::Future(timestamp) =
+                validate_timestamp(timestamp, test_runner_report.start_time)
+            {
+                issues.push(JunitTestCaseValidationIssueSubOptimal::TestCaseTimestampIsAfterTestReportEndTime(timestamp));
+            }
+        }
+    } else {
+        issues.push(JunitTestCaseValidationIssueSubOptimal::TestCaseNoTimestamp);
+    }
+
+    issues
+}
+
+#[derive(Debug, Clone)]
+enum TimestampValidation {
+    Valid,
+    Future(DateTime<FixedOffset>),
+    Old(DateTime<FixedOffset>),
+    Stale(DateTime<FixedOffset>),
+}
+
+fn validate_timestamp<T: Into<DateTime<FixedOffset>>, U: Into<DateTime<FixedOffset>>>(
+    timestamp: T,
+    other_timestamp: U,
+) -> TimestampValidation {
+    let timestamp = timestamp.into();
+    let time_since_other_timestamp = other_timestamp.into() - timestamp;
+    if time_since_other_timestamp < TimeDelta::zero() {
+        TimestampValidation::Future(timestamp)
+    } else if time_since_other_timestamp.num_hours() > i64::from(TIMESTAMP_OLD_HOURS) {
+        TimestampValidation::Old(timestamp)
+    } else if time_since_other_timestamp.num_hours() > i64::from(TIMESTAMP_STALE_HOURS) {
+        TimestampValidation::Stale(timestamp)
+    } else {
+        TimestampValidation::Valid
+    }
 }


### PR DESCRIPTION
TRUNK-15041

Split from #634

follow up to #651

Uses the test runner report to override the timestamps that are found in JUnits. Additionally, this will validate the test runner report for various possible glitches (the test runner report comes from Bazel, so it should hopefully be completely valid, but you never know 🤷).