### PR TITLE
[TRUNK-15076] Support unlimited rows for end output

### DIFF
--- a/cli/src/end_output.rs
+++ b/cli/src/end_output.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use superconsole::{Component, Dimensions, DrawMode, Line, Lines, SuperConsole};
+
+pub trait EndOutput {
+    fn output(&self) -> Result<Vec<Line>>;
+}
+
+enum EmptyComponent {
+    Base,
+}
+impl Component for EmptyComponent {
+    fn draw_unchecked(&self, _dimensions: Dimensions, _mode: DrawMode) -> Result<Lines> {
+        Ok(Lines(vec![]))
+    }
+}
+
+// Clears out any renders, and outputs the entire output of result, scrolling the terminal and wrapping long lines (you know, normal terminal output)
+pub fn display_end(superconsole: &mut SuperConsole, result: &impl EndOutput) -> Result<()> {
+    let lines = result.output()?;
+    // Superconsole truncates line emission if you emit more lines than the console has rows in a single render loop.
+    // We could batch these based on tty rows, but the performance is fine without doing so, and we're not exactly running
+    // a reactive ui here.
+    for line in lines {
+        superconsole.emit_now(Lines(vec![line]), &EmptyComponent::Base)?;
+    }
+    Ok(())
+}

--- a/cli/src/error_report.rs
+++ b/cli/src/error_report.rs
@@ -2,8 +2,10 @@ use api::client::get_api_host;
 use http::StatusCode;
 use superconsole::{
     style::{style, Attribute, Stylize},
-    Component, Dimensions, DrawMode, Line, Lines, Span,
+    Line, Span,
 };
+
+use crate::end_output::EndOutput;
 
 const HELP_TEXT: &str = "For more help, contact us at https://slack.trunk.io/";
 const CONNECTION_REFUSED_CONTEXT: &str = concat!("Unable to connect to trunk's server",);
@@ -81,8 +83,8 @@ fn is_unauthorized(error: &anyhow::Error) -> bool {
     }
 }
 
-impl Component for ErrorReport {
-    fn draw_unchecked(&self, _dimensions: Dimensions, _mode: DrawMode) -> anyhow::Result<Lines> {
+impl EndOutput for ErrorReport {
+    fn output(&self) -> anyhow::Result<Vec<Line>> {
         let Context {
             base_message,
             org_url_slug,
@@ -100,7 +102,7 @@ impl Component for ErrorReport {
             lines.push(Line::from_iter([Span::new_unstyled(
                 CONNECTION_REFUSED_CONTEXT,
             )?]));
-            return Ok(Lines(lines));
+            return Ok(lines);
         }
         let api_host = get_api_host();
         if is_unauthorized(&self.error) {
@@ -119,7 +121,7 @@ impl Component for ErrorReport {
                 if let Some(line) = lines.last_mut() {
                     line.pad_left(2);
                 }
-                return Ok(Lines(lines));
+                return Ok(lines);
             }
         }
         if base_message.is_some() {
@@ -152,7 +154,7 @@ impl Component for ErrorReport {
                 Span::new_styled(style(exit_code.to_string()).attribute(Attribute::Bold))?,
             ]));
         }
-        Ok(Lines(lines))
+        Ok(lines)
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod context_quarantine;
+pub mod end_output;
 pub mod error_report;
 pub mod print;
 pub mod test_command;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ use third_party::sentry;
 use tracing_subscriber::{filter::FilterFn, prelude::*};
 use trunk_analytics_cli::{
     context::gather_debug_props,
+    end_output::display_end,
     error_report::ErrorReport,
     test_command::{run_test, TestArgs},
     upload_command::{run_upload, UploadArgs, UploadRunResult},
@@ -118,7 +119,7 @@ fn main() -> anyhow::Result<()> {
             };
             match run(cli).await {
                 Ok(RunResult::Upload(run_result)) => {
-                    let render_result = superconsole.render(&run_result);
+                    let render_result = display_end(&mut superconsole, &run_result);
                     if let Err(e) = render_result {
                         tracing::error!("Failed to render upload display: {}", e);
                     }
@@ -130,7 +131,7 @@ fn main() -> anyhow::Result<()> {
                     std::process::exit(exit_code)
                 }
                 Ok(RunResult::Test(run_result)) => {
-                    let render_result = superconsole.render(&run_result);
+                    let render_result = display_end(&mut superconsole, &run_result);
                     if let Err(e) = render_result {
                         tracing::error!("Failed to render test display: {}", e);
                     }
@@ -144,7 +145,7 @@ fn main() -> anyhow::Result<()> {
                 Err(error) => {
                     let error_report = ErrorReport::new(error, org_url_slug, None);
                     let exit_code = error_report.context.exit_code;
-                    let render_result = superconsole.render(&error_report);
+                    let render_result = display_end(&mut superconsole, &error_report);
                     if let Err(e) = render_result {
                         tracing::error!("Failed to render error display: {}", e);
                     }

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -14,12 +14,12 @@ use context::junit::validator::{
 use pluralizer::pluralize;
 use superconsole::{
     style::{style, Attribute, Color, Stylize},
-    Line, Span,
+    Line, Lines, Span,
 };
-use superconsole::{Component, Dimensions, DrawMode, Lines};
 use unicode_ellipsis::truncate_str_leading;
 
 use crate::context_quarantine::QuarantineContext;
+use crate::end_output::EndOutput;
 use crate::{
     context::{
         gather_debug_props, gather_exit_code_and_quarantined_tests_context,
@@ -418,14 +418,14 @@ async fn upload_bundle(
     Ok(())
 }
 
-impl Component for UploadRunResult {
-    fn draw_unchecked(&self, dimensions: Dimensions, mode: DrawMode) -> anyhow::Result<Lines> {
+impl EndOutput for UploadRunResult {
+    fn output(&self) -> anyhow::Result<Vec<Line>> {
         let mut output: Vec<Line> = Vec::new();
         // If there is an error report, we display it instead
         if let Some(error_report) = self.error_report.as_ref() {
             output.push(Line::default());
-            output.extend(error_report.draw_unchecked(dimensions, mode)?);
-            return Ok(Lines(output));
+            output.extend(error_report.output()?);
+            return Ok(output);
         }
 
         let mut perfect_files = 0;
@@ -680,6 +680,6 @@ impl Component for UploadRunResult {
                 )?,
             ]));
         }
-        Ok(Lines(output))
+        Ok(output)
     }
 }

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -20,16 +20,13 @@ use context::{
 };
 use pluralizer::pluralize;
 use quick_junit::Report;
+use superconsole::Lines;
 use superconsole::{
     style::{Attribute, Stylize},
     Line, Span,
 };
-use superconsole::Lines;
 
-use crate::{
-    print::print_bep_results,
-    end_output::EndOutput,
-};
+use crate::{end_output::EndOutput, print::print_bep_results};
 
 #[derive(Args, Clone, Debug)]
 pub struct ValidateArgs {


### PR DESCRIPTION
Superconsole lets you emit rows, in which case they get outputted as a normal bit of console output, which lets us bypass the issues we were seeing with long rows and more rows than the tty has visible. Creates an EndOutput trait we can use for these in order to nicely display the end reports.