### PR TITLE
context-py: export bundle meta version classes and add json dumping

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: 3.13
       - uses: trunk-io/trunk-action/setup@v1
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: 3.13
       - uses: trunk-io/trunk-action/setup@v1
       - name: Setup Xcode 16
         uses: maxim-lobanov/setup-xcode@v1

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use codeowners::CodeOwners;
 use context::repo::BundleRepo;
 #[cfg(feature = "pyo3")]
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyTypeError, prelude::*};
 #[cfg(feature = "pyo3")]
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use serde::{Deserialize, Serialize};
@@ -227,6 +227,10 @@ pub struct BindingsVersionedBundle(pub VersionedBundle);
 #[gen_stub_pymethods]
 #[pymethods]
 impl BindingsVersionedBundle {
+    pub fn dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.0).map_err(|err| PyTypeError::new_err(err.to_string()))
+    }
+
     pub fn get_v0_5_29(&self) -> BundleMetaV0_5_29 {
         match &self.0 {
             VersionedBundle::V0_7_7(bundle_meta) => BundleMetaV0_5_29::from(

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -407,6 +407,13 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<meta::validator::MetaValidationLevel>()?;
     m.add_function(wrap_pyfunction!(parse_meta_from_tarball, m)?)?;
     m.add_function(wrap_pyfunction!(parse_meta, m)?)?;
+    m.add_class::<bundle::BindingsVersionedBundle>()?;
+    m.add_class::<bundle::BundleMetaV0_5_29>()?;
+    m.add_class::<bundle::BundleMetaV0_5_34>()?;
+    m.add_class::<bundle::BundleMetaV0_6_2>()?;
+    m.add_class::<bundle::BundleMetaV0_6_3>()?;
+    m.add_class::<bundle::BundleMetaV0_7_6>()?;
+    m.add_class::<bundle::BundleMetaV0_7_7>()?;
     m.add_function(wrap_pyfunction!(meta_validate, m)?)?;
     m.add_function(wrap_pyfunction!(meta_validation_level_to_string, m)?)?;
     m.add_function(wrap_pyfunction!(parse_internal_bin_from_tarball, m)?)?;

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -179,3 +179,97 @@ def test_parse_meta_invalid():
         _ = parse_meta(encoded_meta)
 
     assert "missing field `version` at" in str(excinfo.value)
+
+
+def test_parse_and_dump_meta_roundtrip():
+    import json
+    import typing as PT
+
+    from context_py import parse_meta
+
+    valid_meta: dict[str, PT.Any] = {
+        "bundle_upload_id": "59c8ddd9-0a00-4b56-9eea-ef0d60ebcb79",
+        "cli_version": "cargo=0.5.11 git=7e5824fa365c63a2d4b38020762be17f4edd6425 rustc=1.80.0-nightly",
+        "codeowners": None,
+        "envs": {},
+        "file_sets": [
+            {
+                "file_set_type": "Junit",
+                "files": [
+                    {
+                        # serde_json doesn't support u128 in #[serde(flatten)] yet
+                        "last_modified_epoch_ns": 0,
+                        "original_path": "/home/runner/work/trunk/test/file1.xml",
+                        "original_path_rel": None,
+                        "owners": [],
+                        "path": "junit/0",
+                        "team": "",
+                    },
+                    {
+                        # serde_json doesn't support u128 in #[serde(flatten)] yet
+                        "last_modified_epoch_ns": 0,
+                        "original_path": "/home/runner/work/trunk/test/file2.xml",
+                        "original_path_rel": None,
+                        "owners": [],
+                        "path": "junit/1",
+                        "team": "",
+                    },
+                ],
+                "glob": "junit.xml",
+            },
+            {
+                "file_set_type": "Junit",
+                "files": [
+                    {
+                        # serde_json doesn't support u128 in #[serde(flatten)] yet
+                        "last_modified_epoch_ns": 0,
+                        "original_path": "/home/runner/work/trunk/test/file1.xml",
+                        "original_path_rel": None,
+                        "owners": [],
+                        "path": "junit/0",
+                        "team": "",
+                    },
+                    {
+                        # serde_json doesn't support u128 in #[serde(flatten)] yet
+                        "last_modified_epoch_ns": 0,
+                        "original_path": "/home/runner/work/trunk/test/file2.xml",
+                        "original_path_rel": None,
+                        "owners": [],
+                        "path": "junit/1",
+                        "team": "",
+                    },
+                ],
+                "glob": "junit.xml",
+                "resolved_end_time_epoch_ms": 1749505703092,
+                "resolved_start_time_epoch_ms": 1749505703092,
+                "resolved_status": "Passed",
+            },
+        ],
+        "org": "trunk",
+        "os_info": "linux",
+        "quarantined_tests": [],
+        "repo": {
+            "repo": {"host": "github.com", "name": "test", "owner": "trunk"},
+            "repo_head_author_email": "42547082+deepsource-io[bot]@users.noreply.github.com",
+            "repo_head_author_name": "deepsource-io[bot]",
+            "repo_head_branch": "refs/heads/main",
+            "repo_head_commit_epoch": 1720652103,
+            "repo_head_commit_message": "ci: add .deepsource.toml",
+            "repo_head_sha": "74518d470d8cfeb41408a85cf6097bb7f09ad902",
+            "repo_head_sha_short": None,
+            "repo_root": "/home/runner/work/trunk/test",
+            "repo_url": "https://github.com/trunk/test",
+        },
+        "schema": "V0_5_29",
+        "tags": [],
+        "test_command": None,
+        "upload_time_epoch": 1721095230,
+        "version": "1",
+    }
+
+    valid_meta_str = json.dumps(valid_meta, sort_keys=True)
+    bundle_meta = parse_meta(valid_meta_str.encode())
+    assert (
+        json.dumps(json.loads(bundle_meta.dump_json()), sort_keys=True)
+        == valid_meta_str
+    )

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -273,3 +273,56 @@ def test_parse_and_dump_meta_roundtrip():
         json.dumps(json.loads(bundle_meta.dump_json()), sort_keys=True)
         == valid_meta_str
     )
+
+
+def test_parse_meta_version():
+    import json
+    import typing as PT
+
+    from context_py import (
+        BindingsVersionedBundle,
+        BundleMetaV0_5_29,
+        BundleMetaV0_5_34,
+        BundleMetaV0_6_2,
+        BundleMetaV0_6_3,
+        BundleMetaV0_7_6,
+        BundleMetaV0_7_7,
+        parse_meta,
+    )
+
+    valid_meta: dict[str, PT.Any] = {
+        "bundle_upload_id": "59c8ddd9-0a00-4b56-9eea-ef0d60ebcb79",
+        "cli_version": "cargo=0.5.11 git=7e5824fa365c63a2d4b38020762be17f4edd6425 rustc=1.80.0-nightly",
+        "codeowners": None,
+        "envs": {},
+        "file_sets": [],
+        "org": "trunk",
+        "os_info": "linux",
+        "quarantined_tests": [],
+        "repo": {
+            "repo": {"host": "github.com", "name": "test", "owner": "trunk"},
+            "repo_head_author_email": "42547082+deepsource-io[bot]@users.noreply.github.com",
+            "repo_head_author_name": "deepsource-io[bot]",
+            "repo_head_branch": "refs/heads/main",
+            "repo_head_commit_epoch": 1720652103,
+            "repo_head_commit_message": "ci: add .deepsource.toml",
+            "repo_head_sha": "74518d470d8cfeb41408a85cf6097bb7f09ad902",
+            "repo_head_sha_short": None,
+            "repo_root": "/home/runner/work/trunk/test",
+            "repo_url": "https://github.com/trunk/test",
+        },
+        "schema": "V0_5_29",
+        "tags": [],
+        "test_command": None,
+        "upload_time_epoch": 1721095230,
+        "version": "1",
+    }
+
+    bundle_meta = parse_meta(json.dumps(valid_meta).encode())
+    assert isinstance(bundle_meta, BindingsVersionedBundle)
+    assert isinstance(bundle_meta.get_v0_5_29(), BundleMetaV0_5_29 | None)
+    assert isinstance(bundle_meta.get_v0_5_34(), BundleMetaV0_5_34 | None)
+    assert isinstance(bundle_meta.get_v0_6_2(), BundleMetaV0_6_2 | None)
+    assert isinstance(bundle_meta.get_v0_6_3(), BundleMetaV0_6_3 | None)
+    assert isinstance(bundle_meta.get_v0_7_6(), BundleMetaV0_7_6 | None)
+    assert isinstance(bundle_meta.get_v0_7_7(), BundleMetaV0_7_7 | None)


### PR DESCRIPTION
useful for accessing properties on a specific version via `isinstance()` and dumping JSON for debugging