### PR TITLE
[TRUNK-14422] Don't say VALID when codeowners path exists

### DIFF
--- a/cli-tests/src/validate.rs
+++ b/cli-tests/src/validate.rs
@@ -23,7 +23,7 @@ fn validate_success() {
         .stdout(predicate::str::contains("0 validation errors"))
         .stdout(predicate::str::contains("All 1 files are valid"))
         .stdout(predicate::str::contains("Checking for codeowners file..."))
-        .stdout(predicate::str::contains("VALID - Found codeowners:"));
+        .stdout(predicate::str::contains("Found codeowners:"));
 
     println!("{assert}");
 }

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -443,10 +443,7 @@ fn print_codeowners_validation(
     println!("\nChecking for codeowners file...");
     match codeowners {
         Some(owners) => {
-            println!(
-                "  {} - Found codeowners:",
-                print_validation_level(JunitValidationLevel::Valid)
-            );
+            println!("  Found codeowners:");
             println!("    Path: {:?}", owners.path);
 
             let has_test_cases_without_matching_codeowners_paths = report_validations


### PR DESCRIPTION
Printing VALID when we have a codeowners path can contradict earlier output that the codeowners file could not be parsed or has other issues, so we shouldn't print it at all.