### PR TITLE
Support all versions in bindings to parse `meta.json`

### DIFF
--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -174,6 +174,14 @@ pub async fn extract_files_from_tarball<R: AsyncBufRead>(
 
 pub fn parse_meta(meta_bytes: Vec<u8>) -> anyhow::Result<VersionedBundle> {
     if let Ok(message) = serde_json::from_slice(&meta_bytes) {
+        return Ok(VersionedBundle::V0_7_7(message));
+    }
+
+    if let Ok(message) = serde_json::from_slice(&meta_bytes) {
+        return Ok(VersionedBundle::V0_7_6(message));
+    }
+
+    if let Ok(message) = serde_json::from_slice(&meta_bytes) {
         return Ok(VersionedBundle::V0_6_3(message));
     }
 

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -173,12 +173,14 @@ describe("context-js", () => {
       },
     ],
     [
-      "V0_6_3",
+      "V0_7_7",
       {
         num_tests: faker.number.int(100),
         num_files: faker.number.int(100),
         command_line: "trunk-analytics-cli upload --token=***",
         bundle_upload_id_v2: "SOME ID",
+        variant: null,
+        internal_bundled_file: null,
       },
     ],
   ];

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -328,6 +328,8 @@ describe("context-js", () => {
         num_files: faker.number.int(100),
         command_line: "trunk-analytics-cli upload --token=***",
         bundle_upload_id_v2: "SOME ID",
+        variant: "some-variant",
+        internal_bundled_file: null,
       },
     };
     const metaInfoJson = JSON.stringify(
@@ -343,7 +345,7 @@ describe("context-js", () => {
     const { bindings_report, versioned_bundle } =
       await parse_internal_bin_and_meta_from_tarball(readableStream);
 
-    const expectedMeta = createExpectedVersionedBundle("V0_6_3", uploadMeta);
+    const expectedMeta = createExpectedVersionedBundle("V0_7_7", uploadMeta);
 
     expect(versioned_bundle).toStrictEqual(expectedMeta);
 


### PR DESCRIPTION
The bindings explicitly only parse up to version 0.6.3 - I made it so we now parse up to version 0.7.7