### PR TITLE
[TRUNK-15139] Validation report argument for upload/test

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod context_quarantine;
 pub mod error_report;
 pub mod print;
+mod report_limiting;
 pub mod test_command;
 pub mod upload_command;
 pub mod validate_command;

--- a/cli/src/report_limiting.rs
+++ b/cli/src/report_limiting.rs
@@ -1,0 +1,56 @@
+use clap::ValueEnum;
+
+#[derive(ValueEnum, Debug, Clone, PartialEq, Default)]
+pub enum ValidationReport {
+    None,
+    #[default]
+    Limited,
+    Full,
+}
+
+impl ValidationReport {
+    const LIMITED_FILE_ISSUES_TO_SHOW: usize = 8;
+    const LIMITED_FILES_TO_SHOW: usize = 8;
+
+    pub fn limit_issues<I, T>(&self, issues: I) -> impl Iterator<Item = T>
+    where
+        I: Iterator<Item = T>,
+    {
+        match &self {
+            ValidationReport::None => issues.take(0).collect::<Vec<T>>().into_iter(),
+            ValidationReport::Limited => issues
+                .take(Self::LIMITED_FILE_ISSUES_TO_SHOW)
+                .collect::<Vec<T>>()
+                .into_iter(),
+            ValidationReport::Full => issues.collect::<Vec<T>>().into_iter(),
+        }
+    }
+
+    pub fn limit_files<I, T>(&self, files: I) -> impl Iterator<Item = T>
+    where
+        I: Iterator<Item = T>,
+    {
+        match &self {
+            ValidationReport::None => files.take(0).collect::<Vec<T>>().into_iter(),
+            ValidationReport::Limited => files
+                .take(Self::LIMITED_FILES_TO_SHOW)
+                .collect::<Vec<T>>()
+                .into_iter(),
+            ValidationReport::Full => files.collect::<Vec<T>>().into_iter(),
+        }
+    }
+
+    pub fn num_exceeding_files_limit(&self, num_files: usize) -> Option<usize> {
+        match &self {
+            ValidationReport::None => Some(num_files),
+            ValidationReport::Limited => {
+                if num_files > Self::LIMITED_FILES_TO_SHOW {
+                    Some(num_files - Self::LIMITED_FILES_TO_SHOW)
+                } else {
+                    None
+                }
+            }
+            ValidationReport::Full => None,
+        }
+    }
+}


### PR DESCRIPTION
Adds a validation-report argument for the upload and test subcommands. The argument can be set to none (show literally no validation reports at all), limited (the current behaviour, which caps at 8 files and 8 of each type of issue per file), and full (literally all issues in all files). It defaults to limited, to preserve existing behaviour.

Helptext including the arg:
![Screenshot from 2025-06-18 10-57-38](https://github.com/user-attachments/assets/2c77eab9-094f-4981-8862-69bc0568081c)

Result of using none:
![Screenshot from 2025-06-18 10-58-49](https://github.com/user-attachments/assets/0baade78-b39b-46a2-a792-59438f12343a)

Result of using limited:
![Screenshot from 2025-06-18 10-59-17](https://github.com/user-attachments/assets/7f566e28-cdbf-40f4-9237-72cd6d4f347d)


Result of using full:
![Screenshot from 2025-06-18 10-59-52](https://github.com/user-attachments/assets/c7d562fa-cf58-4ec0-bf27-96be6ea43a49)
