### PR TITLE
Add Code And Bindings For Generating Test Case CheckSums

### DIFF
--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 
 use codeowners::CodeOwners;
-use context::{junit::bindings, repo::BundleRepo};
 #[cfg(feature = "bindings")]
 use context::junit;
 use context::repo::BundleRepo;

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use codeowners::CodeOwners;
-use context::{junit, repo::BundleRepo};
+use context::{junit::bindings, repo::BundleRepo};
 #[cfg(feature = "pyo3")]
 use pyo3::{exceptions::PyTypeError, prelude::*};
 #[cfg(feature = "pyo3")]
@@ -221,7 +221,7 @@ pub enum VersionedBundle {
 #[derive(Debug, Clone)]
 pub struct VersionedBundleWithBindingsReport {
     pub versioned_bundle: VersionedBundle,
-    pub bindings_report: Vec<junit::bindings::BindingsReport>,
+    pub bindings_report: Vec<bindings::BindingsReport>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -1,4 +1,4 @@
-use context::repo::RepoUrlParts;
+use context::{meta::id::gen_info_id, repo::RepoUrlParts};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
@@ -57,17 +57,16 @@ impl Test {
     }
 
     pub fn set_id<T: AsRef<str>>(&mut self, org_slug: T, repo: &RepoUrlParts) {
-        let info_id_input = [
+        self.id = gen_info_id(
             org_slug.as_ref(),
             repo.repo_full_name().as_str(),
-            self.file.as_deref().unwrap_or(""),
-            self.class_name.as_deref().unwrap_or(""),
-            &self.parent_name,
-            &self.name,
-            "JUNIT_TESTCASE",
-        ]
-        .join("#");
-        self.id = Uuid::new_v5(&Uuid::NAMESPACE_URL, info_id_input.as_bytes()).to_string()
+            self.file.as_deref(),
+            self.class_name.as_deref(),
+            Some(self.parent_name.as_str()),
+            Some(self.name.as_str()),
+            None,
+            "",
+        );
     }
 
     pub fn generate_custom_uuid<T: AsRef<str>>(&mut self, org_slug: T, repo: &RepoUrlParts, id: T) {

--- a/context-js/src/lib.rs
+++ b/context-js/src/lib.rs
@@ -187,8 +187,8 @@ pub fn gen_info_id(
     name: Option<String>,
     info_id: Option<String>,
     variant: String,
-) -> Result<String, JsError> {
-    let info_id = gen_info_id_impl(
+) -> String {
+    gen_info_id_impl(
         &org_url_slug,
         &repo_full_name,
         file.as_deref(),
@@ -197,6 +197,5 @@ pub fn gen_info_id(
         name.as_deref(),
         info_id.as_deref(),
         &variant,
-    );
-    Ok(info_id)
+    )
 }

--- a/context-js/src/lib.rs
+++ b/context-js/src/lib.rs
@@ -6,7 +6,7 @@ use bundle::{
     parse_meta_from_tarball as parse_tarball_meta, FileSetTestRunnerReport, VersionedBundle,
     VersionedBundleWithBindingsReport,
 };
-use context::{env, junit, repo};
+use context::{env, junit, meta::id::gen_info_id as gen_info_id_impl, repo};
 use futures::{future::Either, io::BufReader as BufReaderAsync, stream::TryStreamExt};
 use js_sys::Uint8Array;
 use prost::Message;
@@ -174,4 +174,29 @@ pub async fn parse_internal_bin_and_meta_from_tarball(
         bindings_report: vec![junit::bindings::BindingsReport::from(test_result)],
         versioned_bundle,
     })
+}
+
+#[wasm_bindgen]
+// trunk-ignore(clippy/too_many_arguments)
+pub fn gen_info_id(
+    org_url_slug: String,
+    repo_full_name: String,
+    file: Option<String>,
+    classname: Option<String>,
+    parent_fact_path: Option<String>,
+    name: Option<String>,
+    info_id: Option<String>,
+    variant: String,
+) -> Result<String, JsError> {
+    let info_id = gen_info_id_impl(
+        &org_url_slug,
+        &repo_full_name,
+        file.as_deref(),
+        classname.as_deref(),
+        parent_fact_path.as_deref(),
+        name.as_deref(),
+        info_id.as_deref(),
+        &variant,
+    );
+    Ok(info_id)
 }

--- a/context-js/tests/meta.test.ts
+++ b/context-js/tests/meta.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { gen_info_id } from "../pkg/context_js";
 
 describe("context-js", () => {
-  // Tese tests match the tests in context/src/meta/id.rs.
+  // These tests match the tests in context/src/meta/id.rs.
   // While they don't need to match, it proves both the bindings and
   // rust code are generating the same IDs.
   describe("gen_info_id", () => {

--- a/context-js/tests/meta.test.ts
+++ b/context-js/tests/meta.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { gen_info_id } from "../pkg/context_js";
+
+describe("context-js", () => {
+  // Tese tests match the tests in context/src/meta/id.rs.
+  // While they don't need to match, it proves both the bindings and
+  // rust code are generating the same IDs.
+  describe("gen_info_id", () => {
+    it("generates ID properly for trunk", () => {
+      expect.hasAssertions();
+
+      const generateIdForTest = () =>
+        gen_info_id(
+          "example_org",
+          "example_repo",
+          "src/lib.rs",
+          "ExampleClass",
+          "parent/fact/path",
+          "example_name",
+          "trunk:12345",
+          "unix",
+        );
+
+      const result = generateIdForTest();
+
+      expect(result).toBe("4392f63c-8dc9-5cec-bbdc-e7b90c2e5a6b");
+
+      // Generate again to ensure it is consistent
+      const result2 = generateIdForTest();
+
+      expect(result2).toBe(result);
+    });
+
+    it("works properly with existing v5 UUID", () => {
+      expect.hasAssertions();
+
+      const existingInfoId = "a6e84936-3ee9-57d5-b041-ae124896f654";
+      const generateIdForTest = ({ variant = "" }: { variant?: string }) =>
+        gen_info_id(
+          "example_org",
+          "example_repo",
+          "src/lib.rs",
+          "ExampleClass",
+          "parent/fact/path",
+          "example_name",
+          existingInfoId,
+          variant,
+        );
+
+      const result = generateIdForTest({});
+
+      expect(result).toBe(existingInfoId);
+
+      // Generate again to ensure it is consistent
+      const result2 = generateIdForTest({});
+
+      expect(result2).toBe(result);
+
+      // Adding a variant changs the ID.
+      const resultWithVariant = generateIdForTest({ variant: "unix" });
+
+      expect(resultWithVariant).toBe("8057218b-95e4-5373-afbe-c366d4058615");
+    });
+
+    it("works properly without existing v5 UUID", () => {
+      expect.hasAssertions();
+
+      const generateIdForTest = ({ infoId }: { infoId?: string }) =>
+        gen_info_id(
+          "example_org",
+          "example_repo",
+          "src/lib.rs",
+          "ExampleClass",
+          "parent/fact/path",
+          "example_name",
+          infoId,
+          "unix",
+        );
+
+      const result = generateIdForTest({});
+
+      expect(result).toBe("c869cb93-66e2-516d-a0ea-15ff4b413c3f");
+
+      // Generate again to ensure it is consistent
+      const result2 = generateIdForTest({});
+
+      expect(result2).toBe(result);
+
+      // Existing UUID is ignored if it isn't V5
+      const resultForV4Uuid = generateIdForTest({
+        infoId: "08e1c642-3a55-45cf-8bf9-b9d0b21785dd", // V4
+      });
+
+      expect(resultForV4Uuid).toBe(result);
+    });
+  });
+});

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -374,8 +374,8 @@ pub fn gen_info_id(
     parent_fact_path: Option<String>,
     name: Option<String>,
     info_id: Option<String>,
-) -> PyResult<String> {
-    let info_id = id::gen_info_id(
+) -> String {
+    id::gen_info_id(
         &org_url_slug,
         &repo_full_name,
         file.as_deref(),
@@ -384,8 +384,7 @@ pub fn gen_info_id(
         name.as_deref(),
         info_id.as_deref(),
         &variant,
-    );
-    Ok(info_id)
+    )
 }
 
 #[pymodule]

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -10,7 +10,8 @@ use codeowners::{
 use context::{
     env,
     junit::{self, junit_path::TestRunnerReport},
-    meta, repo,
+    meta::{bindings, id, validator},
+    repo,
 };
 use prost::Message;
 use pyo3::{exceptions::PyTypeError, prelude::*};
@@ -209,16 +210,14 @@ pub fn parse_meta(meta_bytes: Vec<u8>) -> PyResult<bundle::BindingsVersionedBund
 
 #[gen_stub_pyfunction]
 #[pyfunction]
-fn meta_validate(
-    meta_context: meta::bindings::BindingsMetaContext,
-) -> meta::validator::MetaValidation {
-    meta::validator::validate(&meta::bindings::BindingsMetaContext::into(meta_context))
+fn meta_validate(meta_context: bindings::BindingsMetaContext) -> validator::MetaValidation {
+    validator::validate(&bindings::BindingsMetaContext::into(meta_context))
 }
 
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn meta_validation_level_to_string(
-    meta_validation_level: meta::validator::MetaValidationLevel,
+    meta_validation_level: validator::MetaValidationLevel,
 ) -> String {
     meta_validation_level.to_string()
 }
@@ -362,6 +361,42 @@ fn associate_codeowners_multithreaded_impl(
     Ok(results)
 }
 
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(signature = (
+    org_url_slug,
+    repo_full_name,
+    file=None,
+    classname=None,
+    parent_fact_path=None,
+    name=None,
+    info_id=None,
+    variant=None
+))]
+// trunk-ignore(clippy/too_many_arguments)
+pub fn gen_info_id(
+    org_url_slug: String,
+    repo_full_name: String,
+    file: Option<String>,
+    classname: Option<String>,
+    parent_fact_path: Option<String>,
+    name: Option<String>,
+    info_id: Option<String>,
+    variant: Option<String>,
+) -> PyResult<String> {
+    let info_id = id::gen_info_id(
+        &org_url_slug,
+        &repo_full_name,
+        file.as_deref(),
+        classname.as_deref(),
+        parent_fact_path.as_deref(),
+        name.as_deref(),
+        info_id.as_deref(),
+        &variant.unwrap_or_default(),
+    );
+    Ok(info_id)
+}
+
 #[pymodule]
 fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<env::parser::CIInfo>()?;
@@ -402,9 +437,9 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(repo_validate, m)?)?;
     m.add_function(wrap_pyfunction!(repo_validation_level_to_string, m)?)?;
 
-    m.add_class::<meta::bindings::BindingsMetaContext>()?;
-    m.add_class::<meta::validator::MetaValidation>()?;
-    m.add_class::<meta::validator::MetaValidationLevel>()?;
+    m.add_class::<bindings::BindingsMetaContext>()?;
+    m.add_class::<validator::MetaValidation>()?;
+    m.add_class::<validator::MetaValidationLevel>()?;
     m.add_function(wrap_pyfunction!(parse_meta_from_tarball, m)?)?;
     m.add_function(wrap_pyfunction!(parse_meta, m)?)?;
     m.add_class::<bundle::BindingsVersionedBundle>()?;
@@ -417,6 +452,7 @@ fn context_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(meta_validate, m)?)?;
     m.add_function(wrap_pyfunction!(meta_validation_level_to_string, m)?)?;
     m.add_function(wrap_pyfunction!(parse_internal_bin_from_tarball, m)?)?;
+    m.add_function(wrap_pyfunction!(gen_info_id, m)?)?;
 
     m.add_class::<codeowners::BindingsOwners>()?;
     m.add_function(wrap_pyfunction!(codeowners_parse, m)?)?;

--- a/context-py/src/lib.rs
+++ b/context-py/src/lib.rs
@@ -363,26 +363,17 @@ fn associate_codeowners_multithreaded_impl(
 
 #[gen_stub_pyfunction]
 #[pyfunction]
-#[pyo3(signature = (
-    org_url_slug,
-    repo_full_name,
-    file=None,
-    classname=None,
-    parent_fact_path=None,
-    name=None,
-    info_id=None,
-    variant=None
-))]
 // trunk-ignore(clippy/too_many_arguments)
+// trunk-ignore(clippy/deprecated)
 pub fn gen_info_id(
     org_url_slug: String,
     repo_full_name: String,
+    variant: String,
     file: Option<String>,
     classname: Option<String>,
     parent_fact_path: Option<String>,
     name: Option<String>,
     info_id: Option<String>,
-    variant: Option<String>,
 ) -> PyResult<String> {
     let info_id = id::gen_info_id(
         &org_url_slug,
@@ -392,7 +383,7 @@ pub fn gen_info_id(
         parent_fact_path.as_deref(),
         name.as_deref(),
         info_id.as_deref(),
-        &variant.unwrap_or_default(),
+        &variant,
     );
     Ok(info_id)
 }

--- a/context-py/tests/test_meta.py
+++ b/context-py/tests/test_meta.py
@@ -6,12 +6,12 @@ def test_generates_id_properly_for_trunk():
         return gen_info_id(
             "example_org",
             "example_repo",
+            "unix",
             "src/lib.rs",
             "ExampleClass",
             "parent/fact/path",
             "example_name",
             "trunk:12345",
-            "unix",
         )
 
     result = generate_id_for_test()
@@ -29,12 +29,12 @@ def test_works_properly_with_existing_v5_uuid():
         return gen_info_id(
             "example_org",
             "example_repo",
+            variant,
             "src/lib.rs",
             "ExampleClass",
             "parent/fact/path",
             "example_name",
             existing_info_id,
-            variant,
         )
 
     result = generate_id_for_test()
@@ -54,12 +54,12 @@ def test_works_properly_without_existing_v5_uuid():
         return gen_info_id(
             "example_org",
             "example_repo",
+            "unix",
             "src/lib.rs",
             "ExampleClass",
             "parent/fact/path",
             "example_name",
             info_id,
-            "unix",
         )
 
     result = generate_id_for_test()

--- a/context-py/tests/test_meta.py
+++ b/context-py/tests/test_meta.py
@@ -1,0 +1,76 @@
+from context_py import gen_info_id
+
+
+def test_generates_id_properly_for_trunk():
+    def generate_id_for_test():
+        return gen_info_id(
+            "example_org",
+            "example_repo",
+            "src/lib.rs",
+            "ExampleClass",
+            "parent/fact/path",
+            "example_name",
+            "trunk:12345",
+            "unix",
+        )
+
+    result = generate_id_for_test()
+    assert result == "4392f63c-8dc9-5cec-bbdc-e7b90c2e5a6b"
+
+    # Generate again to ensure it is consistent
+    result2 = generate_id_for_test()
+    assert result2 == result
+
+
+def test_works_properly_with_existing_v5_uuid():
+    existing_info_id = "a6e84936-3ee9-57d5-b041-ae124896f654"
+
+    def generate_id_for_test(variant: str = ""):
+        return gen_info_id(
+            "example_org",
+            "example_repo",
+            "src/lib.rs",
+            "ExampleClass",
+            "parent/fact/path",
+            "example_name",
+            existing_info_id,
+            variant,
+        )
+
+    result = generate_id_for_test()
+    assert result == existing_info_id
+
+    # Generate again to ensure it is consistent
+    result2 = generate_id_for_test()
+    assert result2 == result
+
+    # Adding a variant changes the ID
+    result_with_variant = generate_id_for_test(variant="unix")
+    assert result_with_variant == "8057218b-95e4-5373-afbe-c366d4058615"
+
+
+def test_works_properly_without_existing_v5_uuid():
+    def generate_id_for_test(info_id: str | None = None):
+        return gen_info_id(
+            "example_org",
+            "example_repo",
+            "src/lib.rs",
+            "ExampleClass",
+            "parent/fact/path",
+            "example_name",
+            info_id,
+            "unix",
+        )
+
+    result = generate_id_for_test()
+    assert result == "c869cb93-66e2-516d-a0ea-15ff4b413c3f"
+
+    # Generate again to ensure it is consistent
+    result2 = generate_id_for_test()
+    assert result2 == result
+
+    # Existing UUID is ignored if it isn't V5
+    result_for_v4_uuid = generate_id_for_test(
+        info_id="08e1c642-3a55-45cf-8bf9-b9d0b21785dd"
+    )  # V4
+    assert result_for_v4_uuid == result

--- a/context/src/meta/id.rs
+++ b/context/src/meta/id.rs
@@ -1,0 +1,222 @@
+use uuid::Uuid;
+
+fn generate_checksum_uuid(values: Vec<&str>) -> String {
+    let info_id_input: String = values.join("#");
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, info_id_input.as_bytes()).to_string()
+}
+
+fn generate_info_id(
+    info_id: Option<&str>,
+    base_values: Vec<&str>,
+    alt_values: Vec<&str>,
+    id_and_variant_values: Vec<&str>,
+    has_variant: bool,
+) -> String {
+    if let Some(info_id) = info_id {
+        if !info_id.is_empty() {
+            if info_id.starts_with("trunk:") {
+                return generate_checksum_uuid(alt_values);
+            } else if let Ok(uuid) = Uuid::parse_str(info_id) {
+                if uuid.get_version_num() == 5 {
+                    if has_variant {
+                        return generate_checksum_uuid(id_and_variant_values);
+                    } else {
+                        return info_id.to_string();
+                    }
+                }
+            }
+        }
+    }
+    generate_checksum_uuid(base_values)
+}
+
+pub fn gen_info_id(
+    org_url_slug: &str,
+    repo_full_name: &str,
+    file: Option<&str>,
+    classname: Option<&str>,
+    parent_fact_path: Option<&str>,
+    name: Option<&str>,
+    info_id: Option<&str>,
+    variant: &str,
+) -> String {
+    let mut base_values = vec![
+        org_url_slug,
+        repo_full_name,
+        file.unwrap_or(""),
+        classname.unwrap_or(""),
+        parent_fact_path.unwrap_or(""),
+        name.unwrap_or(""),
+        "JUNIT_TESTCASE", // Compatibility with legacy code
+    ];
+    let id_and_variant_values = vec![info_id.unwrap_or(""), variant];
+    let mut alt_values = vec![org_url_slug, repo_full_name, info_id.unwrap_or("")];
+    let mut has_variant = false;
+
+    if !variant.is_empty() {
+        base_values.push(variant);
+        alt_values.push(variant);
+        has_variant = true;
+    }
+
+    generate_info_id(
+        info_id,
+        base_values,
+        alt_values,
+        id_and_variant_values,
+        has_variant,
+    )
+}
+
+#[cfg(test)]
+#[cfg(feature = "bindings")]
+mod tests {
+    use crate::meta::id::gen_info_id;
+
+    #[cfg(feature = "bindings")]
+    #[test]
+    fn test_gen_info_id_trunk() {
+        let org_url_slug = "example_org";
+        let repo_full_name = "example_repo";
+        let file = Some("src/lib.rs");
+        let classname = Some("ExampleClass");
+        let parent_fact_path = Some("parent/fact/path");
+        let name = Some("example_name");
+        let info_id = Some("trunk:12345");
+        let variant = "unix";
+
+        let result = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+
+        assert_eq!(result, "4392f63c-8dc9-5cec-bbdc-e7b90c2e5a6b");
+
+        // Run again to ensure deterministic output
+        let result_again = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+        assert_eq!(result_again, result);
+    }
+
+    #[cfg(feature = "bindings")]
+    #[test]
+    fn test_gen_info_id_existing_v5_uuid() {
+        let org_url_slug = "example_org";
+        let repo_full_name = "example_repo";
+        let file = Some("src/lib.rs");
+        let classname = Some("ExampleClass");
+        let parent_fact_path = Some("parent/fact/path");
+        let name = Some("example_name");
+        let info_id = Some("a6e84936-3ee9-57d5-b041-ae124896f654");
+        let variant = "";
+
+        let result = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+
+        assert_eq!(result, info_id.unwrap());
+
+        // Run again to ensure deterministic output
+        let result_again = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+        assert_eq!(result_again, result);
+
+        // Check that adding a variant does generate a new ID
+        let variant = "unix";
+        let result_with_variant = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+        assert_ne!(result_with_variant, info_id.unwrap());
+        assert_eq!(result_with_variant, "8057218b-95e4-5373-afbe-c366d4058615");
+    }
+
+    #[cfg(feature = "bindings")]
+    #[test]
+    fn test_gen_info_id_no_existing_v5_uuid() {
+        let org_url_slug = "example_org";
+        let repo_full_name = "example_repo";
+        let file = Some("src/lib.rs");
+        let classname = Some("ExampleClass");
+        let parent_fact_path = Some("parent/fact/path");
+        let name = Some("example_name");
+        let info_id = None;
+        let variant = "unix";
+
+        let result = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+
+        assert_eq!(result, "c869cb93-66e2-516d-a0ea-15ff4b413c3f");
+
+        // Run again to ensure deterministic output
+        let result_again = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id,
+            variant,
+        );
+        assert_eq!(result_again, result);
+
+        // Test with v4 UUID
+        let info_id_v4 = Some("08e1c642-3a55-45cf-8bf9-b9d0b21785dd"); // v4 UUID
+        let result_v4 = gen_info_id(
+            org_url_slug,
+            repo_full_name,
+            file,
+            classname,
+            parent_fact_path,
+            name,
+            info_id_v4,
+            variant,
+        );
+        assert_ne!(result_v4, info_id_v4.unwrap());
+        assert_eq!(result_v4, result_again);
+    }
+}

--- a/context/src/meta/id.rs
+++ b/context/src/meta/id.rs
@@ -114,6 +114,26 @@ mod tests {
 
     #[cfg(feature = "bindings")]
     #[test]
+    fn test_gen_info_id_real_staging_test() {
+        // This test legitimately exists - checking to see that this code generates the
+        // expected ID.
+        let result = gen_info_id(
+            "trunk-staging-org",
+            "github.com/trunk-io/trunk",
+            None,
+            Some("modules/settings/repoName/__tests__/ticketing-integration.vitest.tsx"),
+            Some("modules/settings/repoName/__tests__/ticketing-integration.vitest.tsx"),
+            Some("Ticketing Integration > should allow you to select a ticketing system"),
+            None,
+            "",
+        );
+
+        // https://app.trunk-staging.io/trunk-staging-org/flaky-tests/test/3f507aef-e834-523b-a8ad-edaba6b137be?repo=trunk-io%2Ftrunk
+        assert_eq!(result, "3f507aef-e834-523b-a8ad-edaba6b137be")
+    }
+
+    #[cfg(feature = "bindings")]
+    #[test]
     fn test_gen_info_id_existing_v5_uuid() {
         let org_url_slug = "example_org";
         let repo_full_name = "example_repo";

--- a/context/src/meta/id.rs
+++ b/context/src/meta/id.rs
@@ -30,6 +30,7 @@ fn generate_info_id(
     generate_checksum_uuid(base_values)
 }
 
+// trunk-ignore(clippy/too_many_arguments)
 pub fn gen_info_id(
     org_url_slug: &str,
     repo_full_name: &str,
@@ -155,7 +156,7 @@ mod tests {
             variant,
         );
 
-        assert_eq!(result, info_id.unwrap());
+        assert_eq!(result, info_id.map_or(String::new(), |id| id.to_string()));
 
         // Run again to ensure deterministic output
         let result_again = gen_info_id(
@@ -182,7 +183,10 @@ mod tests {
             info_id,
             variant,
         );
-        assert_ne!(result_with_variant, info_id.unwrap());
+        assert_ne!(
+            result_with_variant,
+            info_id.map_or(String::new(), |id| id.to_string())
+        );
         assert_eq!(result_with_variant, "8057218b-95e4-5373-afbe-c366d4058615");
     }
 
@@ -236,7 +240,10 @@ mod tests {
             info_id_v4,
             variant,
         );
-        assert_ne!(result_v4, info_id_v4.unwrap());
+        assert_ne!(
+            result_v4,
+            info_id_v4.map_or(String::new(), |id| id.to_string())
+        );
         assert_eq!(result_v4, result_again);
     }
 }

--- a/context/src/meta/mod.rs
+++ b/context/src/meta/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[cfg(feature = "bindings")]
 pub mod bindings;
+pub mod id;
 pub mod validator;
 
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]


### PR DESCRIPTION
## Context 

Test Case IDs act as a checksum for tests - they're V5 UUID generated using aspects of the test like its filepath and name. If nothing about the test changes (including the variant used when running it), the ID remains fixed

## What Does The PR Do

Currently, generating the ID / Checksum for test runs is done [in the ETL when it runs](https://github.com/trunk-io/trunk/blob/5117073037075cc5f51c2bf59fe5422c8360c8fd/trunk/py/metrics_data_pipeline/trunk_etl_common/id_schema.py#L30). This PR moves that functionality over to rust bindings so that both the ETL and other processes (like our root cause AI agent) can use it

## Testing

This PR adds rust tests and tests for the TS and Python bindings. Also verified this against a recently uploaded test in staging, specifically https://app.trunk-staging.io/trunk-staging-org/flaky-tests/test/3f507aef-e834-523b-a8ad-edaba6b137be?repo=trunk-io%2Ftrunk (see actual rust test in `id.rs`

