### PR TITLE
[bindings] Add crate tests for parsing metadata

### DIFF
--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -6,7 +6,9 @@
 use std::collections::HashMap;
 
 use codeowners::CodeOwners;
-use context::{junit, repo::BundleRepo};
+#[cfg(feature = "bindings")]
+use context::junit;
+use context::repo::BundleRepo;
 #[cfg(feature = "pyo3")]
 use pyo3::{exceptions::PyTypeError, prelude::*};
 #[cfg(feature = "pyo3")]
@@ -221,6 +223,7 @@ pub enum VersionedBundle {
 #[derive(Debug, Clone)]
 pub struct VersionedBundleWithBindingsReport {
     pub versioned_bundle: VersionedBundle,
+    #[cfg(feature = "bindings")]
     pub bindings_report: Vec<junit::bindings::BindingsReport>,
 }
 


### PR DESCRIPTION
We were also missing conditional feature flags. These were failing to build locally when running from the crate directory. This passed CI because it runs all tests using the feature flag.