### PR TITLE
Lossify test command output

### DIFF
--- a/cli-tests/src/test.rs
+++ b/cli-tests/src/test.rs
@@ -590,3 +590,57 @@ async fn returns_exit_code_from_execution_when_failures_not_quarantined() {
     // HINT: View CLI output with `cargo test -- --nocapture`
     println!("{assert}");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_command_can_print_subcommand_output_with_special_characters() {
+    let temp_dir = tempdir().unwrap();
+    generate_mock_git_repo(&temp_dir);
+    generate_mock_valid_junit_xmls(&temp_dir);
+    generate_mock_codeowners(&temp_dir);
+
+    let state = MockServerBuilder::new().spawn_mock_server().await;
+
+    CommandBuilder::test(
+        temp_dir.path(),
+        state.host.clone(),
+        vec![
+            String::from("bash"),
+            String::from("-c"),
+            String::from("echo \"Firstline\nAfterNewline\r\tindented\""),
+        ],
+    )
+    .use_quarantining(false)
+    .command()
+    .assert()
+    .success()
+    .stderr(predicate::str::contains("Firstline"))
+    .stderr(predicate::str::contains("AfterNewline"))
+    .stderr(predicate::str::contains("    indented"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_command_can_print_subcommand_output_with_faux_html() {
+    let temp_dir = tempdir().unwrap();
+    generate_mock_git_repo(&temp_dir);
+    generate_mock_valid_junit_xmls(&temp_dir);
+    generate_mock_codeowners(&temp_dir);
+
+    let state = MockServerBuilder::new().spawn_mock_server().await;
+
+    CommandBuilder::test(
+        temp_dir.path(),
+        state.host.clone(),
+        vec![
+            String::from("bash"),
+            String::from("-c"),
+            String::from("echo \"<head>This breaks superconsole</head>\""),
+        ],
+    )
+    .use_quarantining(false)
+    .command()
+    .assert()
+    .success()
+    .stderr(predicate::str::contains(
+        "<head>This breaks superconsole</head>",
+    ));
+}

--- a/cli/src/test_command.rs
+++ b/cli/src/test_command.rs
@@ -57,6 +57,18 @@ pub struct TestRunResult {
     pub command_stderr: String,
 }
 
+fn lines_of(output: String) -> impl Iterator<Item = String> {
+    output
+        .lines()
+        .flat_map(|lf_line| {
+            lf_line
+                .split('\r')
+                .map(|crlf_line| crlf_line.replace('\t', "    "))
+        })
+        .collect::<Vec<String>>()
+        .into_iter()
+}
+
 impl EndOutput for TestRunResult {
     fn output(&self) -> anyhow::Result<Vec<Line>> {
         let mut output: Vec<Line> = Vec::new();
@@ -68,14 +80,14 @@ impl EndOutput for TestRunResult {
             Line::default(),
         ]);
 
-        for stdout_line in self.command_stdout.lines() {
-            output.push(Line::from_iter([Span::new_unstyled(stdout_line)?]));
+        for stdout_line in lines_of(self.command_stdout.clone()) {
+            output.push(Line::from_iter([Span::new_unstyled_lossy(stdout_line)]));
         }
 
         output.push(Line::default());
 
-        for stderr_line in self.command_stderr.lines() {
-            output.push(Line::from_iter([Span::new_unstyled(stderr_line)?]));
+        for stderr_line in lines_of(self.command_stderr.clone()) {
+            output.push(Line::from_iter([Span::new_unstyled_lossy(stderr_line)]));
         }
 
         Ok(output)

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -450,13 +450,13 @@ impl EndOutput for UploadRunResult {
             output.extend(error_report.output()?);
             return Ok(output);
         }
-        if !self.validations.validations.is_empty() {
-            output.extend(
-                self.validations
-                    .output_with_report_limits(&self.validation_report)?,
-            );
-            output.push(Line::default());
-        }
+        //if !self.validations.validations.is_empty() {
+        output.extend(
+            self.validations
+                .output_with_report_limits(&self.validation_report)?,
+        );
+        output.push(Line::default());
+        //}
 
         output.push(Line::from_iter([Span::new_styled(
             String::from("📚 Test Report").attribute(Attribute::Bold),

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -450,13 +450,13 @@ impl EndOutput for UploadRunResult {
             output.extend(error_report.output()?);
             return Ok(output);
         }
-        //if !self.validations.validations.is_empty() {
-        output.extend(
-            self.validations
-                .output_with_report_limits(&self.validation_report)?,
-        );
-        output.push(Line::default());
-        //}
+        if !self.validations.validations.is_empty() {
+            output.extend(
+                self.validations
+                    .output_with_report_limits(&self.validation_report)?,
+            );
+            output.push(Line::default());
+        }
 
         output.push(Line::from_iter([Span::new_styled(
             String::from("📚 Test Report").attribute(Attribute::Bold),


### PR DESCRIPTION
Since the test command is untrusted, it can contain text that looks like html, which superconsole chokes on. Switching to the lossy variant of the functions that output those to prevent this. Also substituting carriage returns and tab characters, which superconsole also cannot handle.