### PR TITLE
Add uploader proto

### DIFF
--- a/proto/proto/upload_metrics.proto
+++ b/proto/proto/upload_metrics.proto
@@ -14,3 +14,11 @@ message UploadMetrics {
   bool failed = 6;
   string failure_reason = 7;
 }
+
+// Used by the analytics-uploader, kept here to avoid collisions in the future.
+message UploaderUploadMetrics {
+  Semver uploader_version = 1;
+  Repo repo = 2;
+  bool failed = 3;
+  string failure_reason = 4;
+}


### PR DESCRIPTION
Adds this proto message because the server's version of this proto has it. The message is actually used by the analytics-uploader, but we include it here as well to avoid collisions in the event of future updates.