### PR TITLE
Upload output - don't truncate test names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5610,7 +5610,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "unicode-ellipsis",
  "url",
  "vergen",
  "xcresult",
@@ -5750,16 +5749,6 @@ name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
-
-[[package]]
-name = "unicode-ellipsis"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ed7a61d66ae6471dc2fa895bc9c30c3351760c95e8c7afeb978acab3ccf04b"
-dependencies = [
- "unicode-segmentation",
- "unicode-width 0.2.0",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,7 +58,6 @@ url = "2.5.4"
 prost = "0.12.6"
 superconsole = "0.2.0"
 console = "0.15.11"
-unicode-ellipsis = "0.3.0"
 pluralizer = "0.5.0"
 
 [dev-dependencies]

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -15,7 +15,6 @@ use superconsole::{
     style::{style, Attribute, Color, Stylize},
     Line, Lines, Span,
 };
-use unicode_ellipsis::truncate_str_leading;
 
 use crate::context_quarantine::QuarantineContext;
 use crate::validate_command::JunitReportValidations;
@@ -481,7 +480,6 @@ impl EndOutput for UploadRunResult {
                     if test.parent_name.is_empty() { "" } else { "/" },
                     test.name
                 );
-                let truncated = truncate_str_leading(&output_name, 60);
                 let link = url_for_test_case(
                     &get_api_host(),
                     &self.quarantine_context.org_url_slug,
@@ -489,7 +487,7 @@ impl EndOutput for UploadRunResult {
                     test,
                 )?;
                 output.push(Line::from_iter([Span::new_styled(
-                    style(truncated.to_string()).attribute(Attribute::Italic),
+                    style(output_name.to_string()).attribute(Attribute::Italic),
                 )?]));
                 let mut link_output = Line::from_iter([
                     Span::new_unstyled("⤷ ")?,


### PR DESCRIPTION
We had a customer who was unable to see their test names. Let's drop truncation for now and put it back in if anyone really needs it.