### PR TITLE
[workflows]  Fix broken uploads

### DIFF
--- a/.github/actions/run_tests/action.yaml
+++ b/.github/actions/run_tests/action.yaml
@@ -29,16 +29,16 @@ runs:
     - name: Collect coverage data (including doctests)
       shell: bash
       run: |
-        cargo llvm-cov --no-report nextest
+        set +e
+        cargo llvm-cov --no-report nextest --features=bindings --workspace ${{ contains(inputs.target, 'musl') && '--exclude context-js --exclude context-py --exclude context_ruby' || '' }} --profile=ci
+        exitcode="$?"
         cargo llvm-cov --no-report --doc
         cargo llvm-cov report --doctests --lcov --output-path lcov.info
-
-    - name: Run tests
-      shell: bash
-      run: cargo nextest run --features=bindings --workspace ${{ contains(inputs.target, 'musl') && '--exclude context-js --exclude context-py --exclude context_ruby' || '' }} --profile=ci
+        exit "$exitcode"
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
+      if: always()
       with:
         token: ${{ inputs.codecov-token }}
         slug: trunk-io/analytics-cli


### PR DESCRIPTION
`cargo llvm-cov --no-report nextest` was running the tests and would finish the `run_tests` action before we'd generated the xml. Merge that logic together and make sure to return the original exit code when done.