### PR TITLE
[upload] Update output to conditionally show failure messages

### DIFF
--- a/api/src/urls.rs
+++ b/api/src/urls.rs
@@ -45,6 +45,7 @@ fn test_url_generated() {
         id: String::from("c33a7f64-8f3e-5db9-b37b-2ea870d2441b"),
         timestamp_millis: None,
         is_quarantined: false,
+        failure_message: None,
     };
 
     let actual = url_for_test_case(

--- a/bundle/src/types.rs
+++ b/bundle/src/types.rs
@@ -24,6 +24,7 @@ pub struct Test {
     /// Added in v0.6.9
     pub timestamp_millis: Option<i64>,
     pub is_quarantined: bool,
+    pub failure_message: Option<String>,
 }
 
 impl Test {
@@ -45,6 +46,7 @@ impl Test {
             id: String::with_capacity(0),
             timestamp_millis,
             is_quarantined: false,
+            failure_message: None,
         };
 
         if let Some(id) = id {
@@ -182,6 +184,7 @@ mod tests {
             id: String::from("da5b8893-d6ca-5c1c-9a9c-91f40a2a3649"),
             timestamp_millis: Some(0),
             is_quarantined: false,
+            failure_message: None,
         };
         assert_eq!(result.name, name);
         assert_eq!(result.parent_name, parent_name);

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -562,4 +562,41 @@ mod tests {
         assert_eq!(multi_failures.len(), 1);
         assert_eq!(multi_failures[0].name, "Hello");
     }
+
+    #[test]
+    fn test_convert_case_to_test_populates_failure_message() {
+        use quick_junit::{NonSuccessKind, TestCase, TestCaseStatus, TestSuite};
+
+        let repo = RepoUrlParts {
+            host: "github.com".to_string(),
+            owner: "test-owner".to_string(),
+            name: "test-repo".to_string(),
+        };
+        let org_slug = "test-org";
+        let parent_name = "TestSuite".to_string();
+
+        // Create the underlying types first
+        let mut test_case = TestCase::new(
+            String::from("test_case"),
+            TestCaseStatus::NonSuccess {
+                kind: NonSuccessKind::Failure,
+                message: Some("Failure message".into()),
+                ty: None,
+                description: Some("This is a failure".into()),
+                reruns: vec![],
+            },
+        );
+        test_case.classname = Some("TestClass".into());
+
+        let test_suite = TestSuite::new(parent_name.clone());
+
+        // Convert to bindings
+        let case = BindingsTestCase::from(test_case);
+        let suite = BindingsTestSuite::from(test_suite);
+
+        let test = super::convert_case_to_test(&repo, org_slug, parent_name, &case, &suite);
+
+        assert_eq!(test.name, "test_case");
+        assert_eq!(test.failure_message, Some("This is a failure".to_string()));
+    }
 }

--- a/cli/src/context_quarantine.rs
+++ b/cli/src/context_quarantine.rs
@@ -47,6 +47,13 @@ fn convert_case_to_test<T: AsRef<str>>(
             .or(suite.timestamp_micros)
             .unwrap_or(0),
     )));
+    let failure_message = match &case.status.non_success {
+        Some(non_success) => non_success
+            .description
+            .clone()
+            .or_else(|| non_success.message.clone()),
+        _ => None,
+    };
     let mut test = Test {
         name,
         parent_name,
@@ -55,6 +62,7 @@ fn convert_case_to_test<T: AsRef<str>>(
         id: String::with_capacity(0),
         timestamp_millis,
         is_quarantined: case.is_quarantined(),
+        failure_message,
     };
     if let Some(id) = case.extra().get("id") {
         if id.is_empty() {

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -588,6 +588,9 @@ impl EndOutput for UploadRunResult {
                     link_output.pad_left(4);
                     output.push(link_output);
                     // Display failure message if present and enabled
+                    // TODO: show_failure_messages is a temporary flag to show failure messages
+                    // in the output. It should be removed once we are confident in this flow
+                    // and we should use the validation report flag instead.
                     if self.show_failure_messages && test.failure_message.is_some() {
                         let failure_message = test.failure_message.as_ref().unwrap();
                         let lines: Vec<&str> = failure_message.split('\n').collect();
@@ -603,11 +606,11 @@ impl EndOutput for UploadRunResult {
                             if !sanitized_line.trim().is_empty() || j == 0 {
                                 let mut failure_output = Line::from_iter([
                                     Span::new_unstyled("   ")?,
-                                    Span::new_styled(
+                                    Span::new_styled_lossy(
                                         style(sanitized_line.to_string())
                                             .with(Color::Grey)
                                             .attribute(Attribute::Italic),
-                                    )?,
+                                    ),
                                 ]);
                                 failure_output.pad_left(4);
                                 output.push(failure_output);

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -211,6 +211,15 @@ pub struct UploadArgs {
         default_missing_value = "limited"
     )]
     pub validation_report: ValidationReport,
+    #[arg(
+        long,
+        help = "Show failure messages in the output.",
+        required = false,
+        num_args = 0,
+        default_value = "false",
+        default_missing_value = "true"
+    )]
+    pub show_failure_messages: bool,
 }
 
 impl UploadArgs {
@@ -230,6 +239,7 @@ impl UploadArgs {
             allow_empty_test_results: true,
             use_quarantining,
             disable_quarantining,
+            show_failure_messages: false,
             ..Default::default()
         }
     }
@@ -257,6 +267,7 @@ pub struct UploadRunResult {
     pub meta: BundleMeta,
     pub validations: JunitReportValidations,
     pub validation_report: ValidationReport,
+    pub show_failure_messages: bool,
 }
 
 pub async fn run_upload(
@@ -429,6 +440,7 @@ pub async fn run_upload(
         meta,
         validations,
         validation_report: upload_args.validation_report,
+        show_failure_messages: upload_args.show_failure_messages,
     })
 }
 
@@ -492,10 +504,27 @@ impl EndOutput for UploadRunResult {
             );
             output.push(Line::default());
         }
-
+        // Summary statistics
+        let total_tests = self.meta.junit_props.num_tests;
+        let quarantined = self
+            .quarantine_context
+            .quarantine_status
+            .quarantine_results
+            .len();
+        let failures = self.quarantine_context.failures.len();
+        let passes = total_tests.saturating_sub(quarantined + failures);
+        let pass_ratio = if total_tests > 0 {
+            format!("{:.1}%", (passes as f64 / total_tests as f64) * 100.0)
+        } else {
+            "N/A".to_string()
+        };
         output.push(Line::from_iter([Span::new_styled(
-            String::from("📚 Test Report").attribute(Attribute::Bold),
+            style("📚 Test Report".to_string()).attribute(Attribute::Bold),
         )?]));
+        output.push(Line::from_iter([Span::new_unstyled(format!(
+            "   Total: {}   Pass: {}   Fail: {}   Quarantined: {}   Pass Ratio: {}",
+            total_tests, passes, failures, quarantined, pass_ratio
+        ))?]));
         output.push(Line::default());
         let qc = &self.quarantine_context;
         let quarantined = &qc.quarantine_status.quarantine_results;
@@ -506,40 +535,124 @@ impl EndOutput for UploadRunResult {
 
         // Helper closure to render the test table
         let render_test_table = |tests: &[Test]| -> anyhow::Result<Lines> {
+            use std::collections::BTreeMap;
             let mut output = Vec::new();
-            // look at the first 12 tests
-            let max_take = 12;
-            for test in tests.iter().take(max_take) {
-                let output_name = format!(
-                    "{}{}{}",
-                    test.parent_name,
-                    if test.parent_name.is_empty() { "" } else { "/" },
-                    test.name
-                );
-                let link = url_for_test_case(
-                    &get_api_host(),
-                    &self.quarantine_context.org_url_slug,
-                    &self.quarantine_context.repo,
-                    test,
-                )?;
+            // Group tests by file path, then by suite, then standalone
+            let mut groups: BTreeMap<String, Vec<&Test>> = BTreeMap::new();
+            let mut suite_groups: BTreeMap<String, Vec<&Test>> = BTreeMap::new();
+            let mut standalone: Vec<&Test> = Vec::new();
+            for test in tests.iter() {
+                if let Some(file) = &test.file {
+                    groups.entry(file.clone()).or_default().push(test);
+                } else if !test.parent_name.is_empty() {
+                    suite_groups
+                        .entry(test.parent_name.clone())
+                        .or_default()
+                        .push(test);
+                } else {
+                    standalone.push(test);
+                }
+            }
+            // Helper to render a group
+            let mut render_group = |header: &str,
+                                    color: Color,
+                                    group: &Vec<&Test>|
+             -> anyhow::Result<()> {
                 output.push(Line::from_iter([Span::new_styled(
-                    style(output_name.to_string()).attribute(Attribute::Italic),
+                    style(header.to_string())
+                        .with(color)
+                        .attribute(Attribute::Bold),
                 )?]));
-                let mut link_output = Line::from_iter([
-                    Span::new_unstyled("⤷ ")?,
-                    Span::new_styled(style(link).attribute(Attribute::Underlined))?,
-                ]);
-                link_output.pad_left(2);
-                output.push(link_output);
+                for test in group.iter().take(3) {
+                    let output_name = format!(
+                        "{}{}{}",
+                        test.parent_name,
+                        if test.parent_name.is_empty() { "" } else { "/" },
+                        test.name
+                    );
+                    let mut test_line = Line::from_iter([Span::new_styled(
+                        style(output_name.to_string()).attribute(Attribute::Bold),
+                    )?]);
+                    test_line.pad_left(2);
+                    output.push(test_line);
+                    let link = url_for_test_case(
+                        &get_api_host(),
+                        &self.quarantine_context.org_url_slug,
+                        &self.quarantine_context.repo,
+                        test,
+                    )?;
+                    let mut link_output = Line::from_iter([
+                        Span::new_unstyled("⤷ ")?,
+                        Span::new_styled(style(link.to_string()).attribute(Attribute::Underlined))?,
+                    ]);
+                    link_output.pad_left(4);
+                    output.push(link_output);
+                    // Display failure message if present and enabled
+                    if self.show_failure_messages && test.failure_message.is_some() {
+                        let failure_message = test.failure_message.as_ref().unwrap();
+                        let lines: Vec<&str> = failure_message.split('\n').collect();
+                        let max_lines = 10;
+                        let shown_lines = lines.iter().take(max_lines);
+                        let mut failure_header = Line::from_iter([Span::new_styled(
+                            style("Failure: ".to_string()).with(Color::DarkGrey),
+                        )?]);
+                        failure_header.pad_left(4);
+                        output.push(failure_header);
+                        for (j, line) in shown_lines.enumerate() {
+                            let sanitized_line = line.replace('\t', "    ").replace('\r', "");
+                            if !sanitized_line.trim().is_empty() || j == 0 {
+                                let mut failure_output = Line::from_iter([
+                                    Span::new_unstyled("   ")?,
+                                    Span::new_styled(
+                                        style(sanitized_line.to_string())
+                                            .with(Color::Grey)
+                                            .attribute(Attribute::Italic),
+                                    )?,
+                                ]);
+                                failure_output.pad_left(4);
+                                output.push(failure_output);
+                            }
+                        }
+                        if lines.len() > max_lines {
+                            let omitted = lines.len() - max_lines;
+                            let mut more_output = Line::from_iter([
+                                Span::new_unstyled("   ")?,
+                                Span::new_styled(
+                                    style(format!("…and {omitted} more lines not shown"))
+                                        .with(Color::Grey)
+                                        .attribute(Attribute::Italic),
+                                )?,
+                            ]);
+                            more_output.pad_left(4);
+                            output.push(more_output);
+                        }
+                    }
+                }
+                if group.len() > 3 {
+                    let mut more_failures = Line::from_iter([Span::new_unstyled(format!(
+                        "…and {} more failures in this group",
+                        group.len() - 3
+                    ))?]);
+                    more_failures.pad_left(2);
+                    output.push(more_failures);
+                }
+                output.push(Line::default());
+                Ok(())
+            };
+            // Render file path groups (cyan)
+            for (file, group) in &groups {
+                render_group(&format!("📁 {}", file), Color::Cyan, group)?;
+            }
+            // Render suite groups (magenta)
+            for (suite, group) in &suite_groups {
+                render_group(&format!("📦 {}", suite), Color::Magenta, group)?;
+            }
+            // Render standalone (yellow)
+            if !standalone.is_empty() {
+                render_group("🔍 Other", Color::Yellow, &standalone)?;
             }
             let mut output = Lines(output);
             output.pad_lines_left(2);
-            if tests.len() > max_take {
-                output.push(Line::from_iter([Span::new_unstyled(format!(
-                    "…and {} more",
-                    tests.len() - max_take
-                ))?]));
-            }
             output.pad_lines_bottom(1);
             Ok(output)
         };


### PR DESCRIPTION
Group by file, then test suite, and finally by test case in that order of existence. Include the captured failure message in the output if `--show-failure-messages` is present. This will default to false for the time being.

<img width="952" alt="Screenshot 2025-07-07 at 10 08 14 AM" src="https://github.com/user-attachments/assets/630aa888-321f-46dc-bdf6-c8388acab4d4" />
<img width="966" alt="Screenshot 2025-07-07 at 10 08 27 AM" src="https://github.com/user-attachments/assets/cae56e96-ffdf-416d-949d-afeb93018f19" />
