### PR TITLE
add codeowners debug cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "clap",
  "const_format",
  "constants",
  "fancy-regex",

--- a/codeowners/Cargo.toml
+++ b/codeowners/Cargo.toml
@@ -3,12 +3,17 @@ name = "codeowners"
 edition = "2018"
 version = "0.1.3"
 
+[[bin]]
+name = "check-codeowners"
+path = "src/main.rs"
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 pretty_assertions = "0.6"
 rand = "0.8.5"
 
 [dependencies]
+clap = { version = "4.4.18", features = ["derive", "env"] }
 glob = "0.3"
 regex = "1.2"
 lazy_static = "1.4"

--- a/codeowners/src/codeowners.rs
+++ b/codeowners/src/codeowners.rs
@@ -170,7 +170,7 @@ impl BindingsOwners {
     }
 }
 
-fn associate_codeowners<T: AsRef<Path>>(owners: &Owners, file: T) -> Vec<String> {
+pub fn associate_codeowners<T: AsRef<Path>>(owners: &Owners, file: T) -> Vec<String> {
     match owners {
         Owners::GitHubOwners(gho) => gho
             .of(file)

--- a/codeowners/src/lib.rs
+++ b/codeowners/src/lib.rs
@@ -4,7 +4,8 @@ mod gitlab;
 mod traits;
 
 pub use codeowners::{
-    associate_codeowners_multithreaded, flatten_code_owners, BindingsOwners, CodeOwners, Owners,
+    associate_codeowners, associate_codeowners_multithreaded, flatten_code_owners, BindingsOwners,
+    CodeOwners, Owners,
 };
 pub use github::{BindingsGitHubOwners, GitHubOwner, GitHubOwners};
 pub use gitlab::{BindingsGitLabOwners, GitLabOwner, GitLabOwners};

--- a/codeowners/src/main.rs
+++ b/codeowners/src/main.rs
@@ -1,0 +1,55 @@
+use std::{fs::File, path::PathBuf};
+
+use clap::{Parser, ValueEnum};
+use codeowners::{associate_codeowners, FromReader, GitHubOwners, GitLabOwners, Owners};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum CodeownersType {
+    GitHub,
+    GitLab,
+}
+
+#[derive(Debug, Parser)]
+pub struct Cli {
+    /// How to parse CODEOWNERS
+    #[arg(long)]
+    pub codeowners_type: CodeownersType,
+    /// Path to CODEOWNERS file to parse
+    #[arg(long)]
+    pub codeowners_path: PathBuf,
+    /// Test case path to check against CODEOWNERS
+    #[arg(long)]
+    pub test_case_path: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    let Cli {
+        codeowners_type,
+        codeowners_path,
+        test_case_path,
+    } = Cli::parse();
+
+    let owners = match codeowners_type {
+        CodeownersType::GitHub => File::open(&codeowners_path)
+            .map_err(anyhow::Error::from)
+            .and_then(|file| GitHubOwners::from_reader(&file).map(Owners::GitHubOwners))?,
+        CodeownersType::GitLab => File::open(&codeowners_path)
+            .map_err(anyhow::Error::from)
+            .and_then(|file| GitLabOwners::from_reader(&file).map(Owners::GitLabOwners))?,
+    };
+
+    let associated_owners = associate_codeowners(&owners, &test_case_path);
+
+    if associated_owners.is_empty() {
+        eprintln!("No owners found for {}", test_case_path);
+        std::process::exit(1);
+    } else {
+        println!("Owners found for {}:", test_case_path);
+        for owner in associated_owners {
+            println!("{}", owner);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This helped me figure out that we are associating GitLab files differently than GitHub files and that because we default to GitLab we get bad results.

Example:
**`CODEOWNERS`**
```
my_top_level/my_second_level @dylan
```

**Attmpting to match using GitLab**

```bash
cargo run -- --codeowners-type gitlab --codeowners-path ./CODEOWNERS --test-case-path my_top_level/my_second_level/src/file.js
```

```
No owners found for my_top_level/my_second_level/src/file.js
```

**Attmpting to match using GitHub**

```bash
cargo run -- --codeowners-type github --codeowners-path ./CODEOWNERS --test-case-path my_top_level/my_second_level/src/file.js
```

```
Owners found for my_top_level/my_second_level/src/file.js:
@dylan
```

Places in code we try to parse GitLab, then as GitHub:
* https://github.com/trunk-io/analytics-cli/blob/24666bbbbe53044d537be447b92f0a5b87c7b640/codeowners/src/codeowners.rs#L83-L91
* https://github.com/trunk-io/analytics-cli/blob/24666bbbbe53044d537be447b92f0a5b87c7b640/codeowners/src/codeowners.rs#L112-L116
* 