### PR TITLE
[TRUNK-15404] Separate staging notifications from prod

### DIFF
--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -38,7 +38,11 @@ runs:
         FAIL_TEST: true
       shell: bash
       run: |
-        exit 1
+        ./${{ inputs.cli-binary-location }} test \
+        --org-url-slug trunk-staging-org \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.staging-api-token }} \
+        cargo nextest run -p smoke-test --profile ci
 
     - name: Upload to staging
       id: staging-upload
@@ -47,10 +51,7 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
       run: |
-        ./${{ inputs.cli-binary-location }} upload \
-        --org-url-slug trunk-staging-org \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.staging-api-token }}
+        exit 1;
 
     - name: Staging result
       id: staging-result

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -12,10 +12,8 @@ inputs:
     description: staging if you only want to run for staging, production if you only want production, both for both
 
 outputs:
-  production-result:
-    description: If we were able to upload to production, success, otherwise failure. Set to 'success' if environment-type is 'staging'.
-  staging-result:
-    description: If we were able to upload to staging, success, otherwise failure. Set to 'success' if environment-type is 'production'.
+  production-success: ${{ steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}
+  staging-success: ${{ steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}
 
 runs:
   using: composite
@@ -54,16 +52,6 @@ runs:
         --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
         --token ${{ inputs.staging-api-token }}
 
-    - name: Set staging success status
-      if: always() && steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
-      shell: bash
-      run: echo "staging-result=success" >> $GITHUB_OUTPUT
-
-    - name: Set staging failure status
-      if: always() && steps.staging-upload.result != 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
-      shell: bash
-      run: echo "staging-result=failure" >> $GITHUB_OUTPUT
-
     - name: Run tests on production
       id: production-test-run
       if: always() && steps.make-exe.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
@@ -89,13 +77,3 @@ runs:
         --org-url-slug trunk \
         --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
         --token ${{ inputs.production-api-token }}
-
-    - name: Set production success status
-      if: always() && steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
-      shell: bash
-      run: echo "production-result=success" >> $GITHUB_OUTPUT
-
-    - name: Set production failure status
-      if: always() && steps.production-upload.result != 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
-      shell: bash
-      run: echo "production-result=failure" >> $GITHUB_OUTPUT

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -83,7 +83,10 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash
       run: |
-        exit 1;
+        ./${{ inputs.cli-binary-location }} upload \
+        --org-url-slug trunk \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.production-api-token }}
 
     - name: Production result
       id: production-result

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -51,7 +51,10 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
       run: |
-        exit 1;
+        ./${{ inputs.cli-binary-location }} upload \
+        --org-url-slug trunk-staging-org \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.staging-api-token }}
 
     - name: Staging result
       id: staging-result
@@ -67,11 +70,7 @@ runs:
         FAIL_TEST: true
       shell: bash
       run: |
-        ./${{ inputs.cli-binary-location }} test \
-        --org-url-slug trunk \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.production-api-token }} \
-        cargo nextest run -p smoke-test --profile ci
+        exit 1;
 
     - name: Upload to production
       id: production-upload

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -38,11 +38,7 @@ runs:
         FAIL_TEST: true
       shell: bash
       run: |
-        ./${{ inputs.cli-binary-location }} test \
-        --org-url-slug trunk-staging-org \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.staging-api-token }} \
-        cargo nextest run -p smoke-test --profile ci
+        exit 1;
 
     - name: Upload to staging
       id: staging-upload

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -12,8 +12,8 @@ inputs:
     description: staging if you only want to run for staging, production if you only want production, both for both
 
 outputs:
-  production-success: ${{ steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}
-  staging-success: ${{ steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}
+  production-success: ${{ steps.production-result.outputs.production-success }}
+  staging-success: ${{ steps.staging-result.outputs.staging-success }}
 
 runs:
   using: composite
@@ -52,6 +52,11 @@ runs:
         --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
         --token ${{ inputs.staging-api-token }}
 
+    - name: Staging result
+      id: staging-result
+      shell: bash
+      run: echo "staging-success=${{ steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUTS
+
     - name: Run tests on production
       id: production-test-run
       if: always() && steps.make-exe.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
@@ -77,3 +82,8 @@ runs:
         --org-url-slug trunk \
         --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
         --token ${{ inputs.production-api-token }}
+
+    - name: Production result
+      id: production-result
+      shell: bash
+      run: echo "production-success=${{ steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUTS

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -30,8 +30,7 @@ runs:
 
     - name: Run tests on staging
       id: staging-test-run
-      needs: make-exe
-      if: always() && needs.make-exe.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && steps.make-exe.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         FAIL_TEST: true
@@ -45,8 +44,7 @@ runs:
 
     - name: Upload to staging
       id: staging-upload
-      needs: staging-test-run
-      if: always() && needs.staging-test-run.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && steps.staging-test-run.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
@@ -57,21 +55,18 @@ runs:
         --token ${{ inputs.staging-api-token }}
 
     - name: Set staging success status
-      needs: staging-upload
-      if: always() && needs.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       shell: bash
       run: echo "staging-result=success" >> $GITHUB_OUTPUT
 
     - name: Set staging failure status
-      needs: staging-upload
-      if: always() && needs.staging-upload.result != 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && steps.staging-upload.result != 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       shell: bash
       run: echo "staging-result=failure" >> $GITHUB_OUTPUT
 
     - name: Run tests on production
       id: production-test-run
-      needs: make-exe
-      if: always() && needs.make-exe.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.make-exe.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
         FAIL_TEST: true
@@ -85,8 +80,7 @@ runs:
 
     - name: Upload to production
       id: production-upload
-      needs: production-test-run
-      if: always() && needs.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash
@@ -97,13 +91,11 @@ runs:
         --token ${{ inputs.production-api-token }}
 
     - name: Set production success status
-      needs: production-upload
-      if: always() && needs.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       shell: bash
       run: echo "production-result=success" >> $GITHUB_OUTPUT
 
     - name: Set production failure status
-      needs: production-upload
-      if: always() && needs.production-upload.result != 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.production-upload.result != 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       shell: bash
       run: echo "production-result=failure" >> $GITHUB_OUTPUT

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -38,11 +38,7 @@ runs:
         FAIL_TEST: true
       shell: bash
       run: |
-        ./${{ inputs.cli-binary-location }} test \
-        --org-url-slug trunk-staging-org \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.staging-api-token }} \
-        cargo nextest run -p smoke-test --profile ci
+        exit 1
 
     - name: Upload to staging
       id: staging-upload

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -32,7 +32,7 @@ runs:
 
     - name: Run tests on staging
       id: staging-test-run
-      if: always() && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && steps.make-exe.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         FAIL_TEST: true
@@ -46,7 +46,7 @@ runs:
 
     - name: Upload to staging
       id: staging-upload
-      if: always() && steps.staging-test-run.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && steps.staging-test-run.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
@@ -59,11 +59,11 @@ runs:
     - name: Staging result
       id: staging-result
       shell: bash
-      run: echo "staging-success=${{ steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT
+      run: echo "staging-success=${{ steps.staging-upload.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT
 
     - name: Run tests on production
       id: production-test-run
-      if: always() && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.make-exe.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
         FAIL_TEST: true
@@ -77,7 +77,7 @@ runs:
 
     - name: Upload to production
       id: production-upload
-      if: always() && steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.production-upload.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash
@@ -90,4 +90,4 @@ runs:
     - name: Production result
       id: production-result
       shell: bash
-      run: echo "production-success=${{ steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT
+      run: echo "production-success=${{ steps.production-upload.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -32,7 +32,7 @@ runs:
 
     - name: Run tests on staging
       id: staging-test-run
-      if: always() && steps.make-exe.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      if: always() && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         FAIL_TEST: true
@@ -63,7 +63,7 @@ runs:
 
     - name: Run tests on production
       id: production-test-run
-      if: always() && steps.make-exe.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
         FAIL_TEST: true

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -77,7 +77,7 @@ runs:
 
     - name: Upload to production
       id: production-upload
-      if: always() && steps.production-upload.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      if: always() && steps.production-test-run.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -38,7 +38,11 @@ runs:
         FAIL_TEST: true
       shell: bash
       run: |
-        exit 1;
+        ./${{ inputs.cli-binary-location }} test \
+        --org-url-slug trunk-staging-org \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.staging-api-token }} \
+        cargo nextest run -p smoke-test --profile ci
 
     - name: Upload to staging
       id: staging-upload
@@ -47,10 +51,7 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
       run: |
-        ./${{ inputs.cli-binary-location }} upload \
-        --org-url-slug trunk-staging-org \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.staging-api-token }}
+        exit 1;
 
     - name: Staging result
       id: staging-result

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -12,8 +12,12 @@ inputs:
     description: staging if you only want to run for staging, production if you only want production, both for both
 
 outputs:
-  production-success: ${{ steps.production-result.outputs.production-success }}
-  staging-success: ${{ steps.staging-result.outputs.staging-success }}
+  production-success:
+    description: True if we ran and uploaded to production
+    value: ${{ steps.production-result.outputs.production-success }}
+  staging-success:
+    description: True if we ran and uploaded to staging
+    value: ${{ steps.staging-result.outputs.staging-success }}
 
 runs:
   using: composite

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -51,12 +51,16 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
       shell: bash
       run: |
-        exit 1;
+        ./${{ inputs.cli-binary-location }} upload \
+        --org-url-slug trunk-staging-org \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.staging-api-token }}
 
     - name: Staging result
       id: staging-result
+      if: always()
       shell: bash
-      run: echo "staging-success=${{ steps.staging-upload.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT
+      run: echo "staging-success=${{ (steps.staging-upload.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')) || inputs.environment-type == 'production' }}" >> $GITHUB_OUTPUT
 
     - name: Run tests on production
       id: production-test-run
@@ -86,5 +90,6 @@ runs:
 
     - name: Production result
       id: production-result
+      if: always()
       shell: bash
-      run: echo "production-success=${{ steps.production-upload.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT
+      run: echo "production-success=${{ (steps.production-upload.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')) || inputs.environment-type == 'staging' }}" >> $GITHUB_OUTPUT

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -70,7 +70,11 @@ runs:
         FAIL_TEST: true
       shell: bash
       run: |
-        exit 1;
+        ./${{ inputs.cli-binary-location }} test \
+        --org-url-slug trunk \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.production-api-token }} \
+        cargo nextest run -p smoke-test --profile ci
 
     - name: Upload to production
       id: production-upload
@@ -79,10 +83,7 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash
       run: |
-        ./${{ inputs.cli-binary-location }} upload \
-        --org-url-slug trunk \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.production-api-token }}
+        exit 1;
 
     - name: Production result
       id: production-result

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -59,7 +59,7 @@ runs:
     - name: Staging result
       id: staging-result
       shell: bash
-      run: echo "staging-success=${{ steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUTS
+      run: echo "staging-success=${{ steps.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT
 
     - name: Run tests on production
       id: production-test-run
@@ -90,4 +90,4 @@ runs:
     - name: Production result
       id: production-result
       shell: bash
-      run: echo "production-success=${{ steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUTS
+      run: echo "production-success=${{ steps.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both') }}" >> $GITHUB_OUTPUT

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -11,10 +11,17 @@ inputs:
   environment-type:
     description: staging if you only want to run for staging, production if you only want production, both for both
 
+outputs:
+  production-result:
+    description: If we were able to upload to production, success, otherwise failure. Set to 'success' if environment-type is 'staging'.
+  staging-result:
+    description: If we were able to upload to staging, success, otherwise failure. Set to 'success' if environment-type is 'production'.
+
 runs:
   using: composite
   steps:
     - name: Make executable
+      id: make-exe
       shell: bash
       run: |
         chmod +x ${{ inputs.cli-binary-location }}
@@ -22,7 +29,9 @@ runs:
         ls -l ${{ inputs.cli-binary-location }}
 
     - name: Run tests on staging
-      if: inputs.environment-type == 'staging' || inputs.environment-type == 'both'
+      id: staging-test-run
+      needs: make-exe
+      if: always() && needs.make-exe.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
         FAIL_TEST: true
@@ -34,8 +43,35 @@ runs:
         --token ${{ inputs.staging-api-token }} \
         cargo nextest run -p smoke-test --profile ci
 
+    - name: Upload to staging
+      id: staging-upload
+      needs: staging-test-run
+      if: always() && needs.staging-test-run.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+      shell: bash
+      run: |
+        ./${{ inputs.cli-binary-location }} upload \
+        --org-url-slug trunk-staging-org \
+        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+        --token ${{ inputs.staging-api-token }}
+
+    - name: Set staging success status
+      needs: staging-upload
+      if: always() && needs.staging-upload.result == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      shell: bash
+      run: echo "staging-result=success" >> $GITHUB_OUTPUT
+
+    - name: Set staging failure status
+      needs: staging-upload
+      if: always() && needs.staging-upload.result != 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      shell: bash
+      run: echo "staging-result=failure" >> $GITHUB_OUTPUT
+
     - name: Run tests on production
-      if: inputs.environment-type == 'production' || inputs.environment-type == 'both'
+      id: production-test-run
+      needs: make-exe
+      if: always() && needs.make-exe.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
         FAIL_TEST: true
@@ -47,19 +83,10 @@ runs:
         --token ${{ inputs.production-api-token }} \
         cargo nextest run -p smoke-test --profile ci
 
-    - name: Upload to staging
-      if: inputs.environment-type == 'staging' || inputs.environment-type == 'both'
-      env:
-        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
-      shell: bash
-      run: |
-        ./${{ inputs.cli-binary-location }} upload \
-        --org-url-slug trunk-staging-org \
-        --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
-        --token ${{ inputs.staging-api-token }}
-
     - name: Upload to production
-      if: inputs.environment-type == 'production' || inputs.environment-type == 'both'
+      id: production-upload
+      needs: production-test-run
+      if: always() && needs.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
       shell: bash
@@ -68,3 +95,15 @@ runs:
         --org-url-slug trunk \
         --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
         --token ${{ inputs.production-api-token }}
+
+    - name: Set production success status
+      needs: production-upload
+      if: always() && needs.production-upload.result == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      shell: bash
+      run: echo "production-result=success" >> $GITHUB_OUTPUT
+
+    - name: Set production failure status
+      needs: production-upload
+      if: always() && needs.production-upload.result != 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
+      shell: bash
+      run: echo "production-result=failure" >> $GITHUB_OUTPUT

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -16,8 +16,8 @@ jobs:
     name: Smoke test ${{ matrix.platform.name }} cli from release
     runs-on: ${{ matrix.platform.os }}
     outputs:
-      production-result: $
-      staging-result: $
+      production-success: ${{ steps.run-tests.outputs.production-success }}
+      staging-success: ${{ steps.run-tests.outputs.staging-success }}
 
     strategy:
       matrix:
@@ -53,14 +53,8 @@ jobs:
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.action == 'staging-release' && 'staging') || 'both' }}
 
-      - name: Set outputs - ${{ matrix.platform.name }}
-        shell: bash
-        run: |
-          echo "production-result=${{ steps.run-tests.outputs.production-result }}" >> $GITHUB_OUTPUT
-          echo "staging-result=${{ steps.run-tests.outputs.staging-result }}" >> $GITHUB_OUTPUT
-
   production-workflow-status:
-    if: always() && needs.build_cli.outputs.production-result != 'success'
+    if: always() && needs.build_cli.outputs.production-success != 'true'
     name: Post Production Smoke Test Failure
     needs:
       - build_cli
@@ -73,7 +67,7 @@ jobs:
         run: echo "Prod fail"
 
   staging-workflow-status:
-    if: always() && needs.build_cli.outputs.staging-result != 'success'
+    if: always() && needs.build_cli.outputs.staging-success != 'true'
     name: Post staging Smoke Test Failure
     needs:
       - build_cli
@@ -83,7 +77,7 @@ jobs:
     steps:
       - name: Analytics Cli Smoke Test Failure
         shell: bash
-        run: echo "Prod fail"
+        run: echo "Stag fail"
 #  production-slack-workflow-status:
 #    if: always() && needs.build_cli.outputs.production-result != 'success'
 #    name: Post Production Smoke Test Failure

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -53,7 +53,7 @@ jobs:
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.action == 'staging-release' && 'staging') || 'both' }}
 
-  production-workflow-status:
+  production-slack-workflow-status:
     if: always() && needs.build_cli.outputs.production-success != 'true'
     name: Post Production Smoke Test Failure
     needs:
@@ -61,75 +61,50 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
     steps:
       - name: Analytics Cli Smoke Test Failure
-        shell: bash
-        run: echo "Prod fail"
+        uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: production-notifications
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken on production! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
+                  }
+                }
+              ]
+            }
 
-  staging-workflow-status:
+  staging-slack-workflow-status:
     if: always() && needs.build_cli.outputs.staging-success != 'true'
-    name: Post staging Smoke Test Failure
+    name: Post Staging Smoke Test Failure
     needs:
       - build_cli
     runs-on: ubuntu-latest
     permissions:
       actions: read
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
     steps:
       - name: Analytics Cli Smoke Test Failure
-        shell: bash
-        run: echo "Stag fail"
-#  production-slack-workflow-status:
-#    if: always() && needs.build_cli.outputs.production-result != 'success'
-#    name: Post Production Smoke Test Failure
-#    needs:
-#      - build_cli
-#    runs-on: ubuntu-latest
-#    permissions:
-#      actions: read
-#    env:
-#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-#    steps:
-#      - name: Analytics Cli Smoke Test Failure
-#        uses: slackapi/slack-github-action@v1
-#        with:
-#          channel-id: production-notifications
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken on production! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
-#                  }
-#                }
-#              ]
-#            }
-#
-#  staging-slack-workflow-status:
-#    if: always() && needs.build_cli.outputs.staging-result != 'success'
-#    name: Post Staging Smoke Test Failure
-#    needs:
-#      - build_cli
-#    runs-on: ubuntu-latest
-#    permissions:
-#      actions: read
-#    env:
-#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-#    steps:
-#      - name: Analytics Cli Smoke Test Failure
-#        uses: slackapi/slack-github-action@v1
-#        with:
-#          channel-id: staging-notifications
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken on staging! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
-#                  }
-#                }
-#              ]
-#            }
+        uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: staging-notifications
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken on staging! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -16,10 +16,8 @@ jobs:
     name: Smoke test ${{ matrix.platform.name }} cli from release
     runs-on: ${{ matrix.platform.os }}
     outputs:
-      production-result:
-        description: If we were able to upload to production, success, otherwise failure. Set to 'success' if environment-type is 'staging'.
-      staging-result:
-        description: If we were able to upload to staging, success, otherwise failure. Set to 'success' if environment-type is 'production'.
+      production-result: $
+      staging-result: $
 
     strategy:
       matrix:
@@ -56,11 +54,10 @@ jobs:
           environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.action == 'staging-release' && 'staging') || 'both' }}
 
       - name: Set outputs - ${{ matrix.platform.name }}
-        needs: run-tests
         shell: bash
         run: |
-          echo "production-result=${{ needs.run-tests-production-result }}" >> $GITHUB_OUTPUT
-          echo "staging-result=${{ needs.run-tests-staging-result }}" >> $GITHUB_OUTPUT
+          echo "production-result=${{ steps.run-tests.outputs.production-result }}" >> $GITHUB_OUTPUT
+          echo "staging-result=${{ steps.run-tests.outputs.staging-result }}" >> $GITHUB_OUTPUT
 
   production-workflow-status:
     if: always() && needs.build_cli.outputs.production-result != 'success'

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -15,6 +15,12 @@ jobs:
   build_cli:
     name: Smoke test ${{ matrix.platform.name }} cli from release
     runs-on: ${{ matrix.platform.os }}
+    outputs:
+      production-result:
+        description: If we were able to upload to production, success, otherwise failure. Set to 'success' if environment-type is 'staging'.
+      staging-result:
+        description: If we were able to upload to staging, success, otherwise failure. Set to 'success' if environment-type is 'production'.
+
     strategy:
       matrix:
         platform:
@@ -26,6 +32,7 @@ jobs:
             os: macos-latest
             target: arm64-apple-darwin
             download-target: aarch64-apple-darwin
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,36 +47,98 @@ jobs:
         uses: ./.github/actions/setup_run_smoke_tests
 
       - name: Run Smoke Tests - ${{ matrix.platform.name }}
+        id: run-tests
         uses: ./.github/actions/perform_smoke_test
         with:
           cli-binary-location: trunk-analytics-cli
           staging-api-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           production-api-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           environment-type: ${{ (github.event.action == 'production-release' && 'production') || (github.event.action == 'staging-release' && 'staging') || 'both' }}
-  slack-workflow-status:
-    if: always() && needs.build_cli.result != 'success'
-    name: Post Smoke Test Failure
+
+      - name: Set outputs - ${{ matrix.platform.name }}
+        needs: run-tests
+        shell: bash
+        run: |
+          echo "production-result=${{ needs.run-tests-production-result }}" >> $GITHUB_OUTPUT
+          echo "staging-result=${{ needs.run-tests-staging-result }}" >> $GITHUB_OUTPUT
+
+  production-workflow-status:
+    if: always() && needs.build_cli.outputs.production-result != 'success'
+    name: Post Production Smoke Test Failure
     needs:
       - build_cli
     runs-on: ubuntu-latest
     permissions:
       actions: read
-    env:
-      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
     steps:
       - name: Analytics Cli Smoke Test Failure
-        uses: slackapi/slack-github-action@v1
-        with:
-          channel-id: production-notifications
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
-                  }
-                }
-              ]
-            }
+        shell: bash
+        run: echo "Prod fail"
+
+  staging-workflow-status:
+    if: always() && needs.build_cli.outputs.staging-result != 'success'
+    name: Post staging Smoke Test Failure
+    needs:
+      - build_cli
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Analytics Cli Smoke Test Failure
+        shell: bash
+        run: echo "Prod fail"
+#  production-slack-workflow-status:
+#    if: always() && needs.build_cli.outputs.production-result != 'success'
+#    name: Post Production Smoke Test Failure
+#    needs:
+#      - build_cli
+#    runs-on: ubuntu-latest
+#    permissions:
+#      actions: read
+#    env:
+#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+#    steps:
+#      - name: Analytics Cli Smoke Test Failure
+#        uses: slackapi/slack-github-action@v1
+#        with:
+#          channel-id: production-notifications
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken on production! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
+#                  }
+#                }
+#              ]
+#            }
+#
+#  staging-slack-workflow-status:
+#    if: always() && needs.build_cli.outputs.staging-result != 'success'
+#    name: Post Staging Smoke Test Failure
+#    needs:
+#      - build_cli
+#    runs-on: ubuntu-latest
+#    permissions:
+#      actions: read
+#    env:
+#      SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+#    steps:
+#      - name: Analytics Cli Smoke Test Failure
+#        uses: slackapi/slack-github-action@v1
+#        with:
+#          channel-id: staging-notifications
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Release ${{ env.RELEASE }} of the analytics cli is broken on staging! The job attempting a simple upload had a result of ${{ needs.build_cli.result }}. Runs can be found at https://github.com/trunk-io/analytics-cli/actions/workflows/smoke_test.yml"
+#                  }
+#                }
+#              ]
+#            }


### PR DESCRIPTION
Splits out the staging failures from testing main so that we only send
to production-notifications if we fail to upload to prod, and notify
staging-notifications if we fail to upload to staging. We're doing this
because staging goes down through no fault of its own pretty regularly,
and is creating noise in production-notifications.