### PR TITLE
[TRUNK-15446] Fall back to reporting failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "bazel-bep",
  "bundle",
  "chrono",
+ "clap",
  "codeowners",
  "constants",
  "context",

--- a/cli-tests/Cargo.toml
+++ b/cli-tests/Cargo.toml
@@ -11,6 +11,7 @@ axum = { version = "0.7.5", features = ["macros"] }
 bazel-bep = { path = "../bazel-bep" }
 bundle = { path = "../bundle" }
 chrono = "0.4.33"
+clap = { version = "4.4.18", features = ["derive", "env"] }
 codeowners = { path = "../codeowners" }
 constants = { path = "../constants" }
 context = { path = "../context" }

--- a/cli-tests/src/upload.rs
+++ b/cli-tests/src/upload.rs
@@ -1659,6 +1659,8 @@ async fn does_not_print_exit_code_with_validation_reports_none() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reports_failures_even_if_cannot_get_quarantine_context() {
+    // In the event we cannot get quarantine context, we want to fail for the failing tests
+    // (ie, the upload becomes a no-op in terms of how your ci status is affected).
     let temp_dir = tempdir().unwrap();
     generate_mock_git_repo(&temp_dir);
     generate_mock_valid_junit_xmls_with_failures(&temp_dir);
@@ -1675,7 +1677,7 @@ async fn reports_failures_even_if_cannot_get_quarantine_context() {
     let mut command = CommandBuilder::upload(temp_dir.path(), state.host.clone()).command();
 
     let assert = command.assert().failure().stderr(predicate::str::contains(
-        "We were not able to fetch quarantine states for tests",
+        "We were unable to determine the quarantine status for tests.",
     ));
 
     println!("{assert}");

--- a/cli-tests/src/utils.rs
+++ b/cli-tests/src/utils.rs
@@ -49,13 +49,11 @@ pub fn generate_mock_valid_junit_xmls_with_failures<T: AsRef<Path>>(directory: T
     let test_case_options = junit_mock::TestCaseOptions {
         test_case_names: Some(vec![String::from("test_case")]),
         test_case_classnames: Some(vec![String::from("TestClass")]),
-        test_case_random_count: 0 as usize,
-        test_case_sys_out_percentage: 0 as u8,
-        test_case_sys_err_percentage: 0 as u8,
+        test_case_random_count: 0usize,
+        test_case_sys_out_percentage: 0u8,
+        test_case_sys_err_percentage: 0u8,
         test_case_duration_range: vec![Duration::new(10, 0).into(), Duration::new(20, 0).into()],
-        test_case_success_to_skip_to_fail_to_error_percentage: vec![vec![
-            0 as u8, 0 as u8, 100 as u8, 0 as u8,
-        ]],
+        test_case_success_to_skip_to_fail_to_error_percentage: vec![vec![0u8, 0u8, 100u8, 0u8]],
     };
     let mut options = junit_mock::Options::default();
     options.test_case = test_case_options;

--- a/cli-tests/src/utils.rs
+++ b/cli-tests/src/utils.rs
@@ -12,6 +12,7 @@ use bazel_bep::types::build_event_stream::{
     BuildEvent, BuildEventId, File, TestResult, TestStatus, TestSummary,
 };
 use chrono::{TimeDelta, Utc};
+use clap::Parser;
 use escargot::{CargoBuild, CargoRun};
 use junit_mock::JunitMock;
 use lazy_static::lazy_static;
@@ -55,8 +56,13 @@ pub fn generate_mock_valid_junit_xmls_with_failures<T: AsRef<Path>>(directory: T
         test_case_duration_range: vec![Duration::new(10, 0).into(), Duration::new(20, 0).into()],
         test_case_success_to_skip_to_fail_to_error_percentage: vec![vec![0u8, 0u8, 100u8, 0u8]],
     };
-    let mut options = junit_mock::Options::default();
-    options.test_case = test_case_options;
+    let options = junit_mock::Options {
+        global: junit_mock::GlobalOptions::try_parse_from([""]).unwrap(),
+        report: junit_mock::ReportOptions::try_parse_from([""]).unwrap(),
+        test_suite: junit_mock::TestSuiteOptions::try_parse_from([""]).unwrap(),
+        test_case: test_case_options,
+        test_rerun: junit_mock::TestRerunOptions::try_parse_from([""]).unwrap(),
+    };
     let mut mock = JunitMock::new(options);
     let reports = mock.generate_reports();
     mock.write_reports_to_file(directory.as_ref(), reports)

--- a/cli-tests/src/utils.rs
+++ b/cli-tests/src/utils.rs
@@ -2,6 +2,7 @@ use std::{
     env, fs,
     io::Write,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use bazel_bep::types::build_event_stream::{
@@ -34,10 +35,6 @@ pub fn generate_mock_git_repo<T: AsRef<Path>>(directory: T) {
 }
 
 fn generate_mock_valid_junit_mocker() -> JunitMock {
-    let mut jm_options = junit_mock::Options::default();
-    jm_options.global.timestamp = Utc::now()
-        .fixed_offset()
-        .checked_sub_signed(TimeDelta::minutes(1));
     JunitMock::new(junit_mock::Options::default())
 }
 
@@ -45,6 +42,26 @@ pub fn generate_mock_valid_junit_xmls<T: AsRef<Path>>(directory: T) -> Vec<PathB
     let mut jm = generate_mock_valid_junit_mocker();
     let reports = jm.generate_reports();
     jm.write_reports_to_file(directory.as_ref(), reports)
+        .unwrap()
+}
+
+pub fn generate_mock_valid_junit_xmls_with_failures<T: AsRef<Path>>(directory: T) -> Vec<PathBuf> {
+    let test_case_options = junit_mock::TestCaseOptions {
+        test_case_names: Some(vec![String::from("test_case")]),
+        test_case_classnames: Some(vec![String::from("TestClass")]),
+        test_case_random_count: 0 as usize,
+        test_case_sys_out_percentage: 0 as u8,
+        test_case_sys_err_percentage: 0 as u8,
+        test_case_duration_range: vec![Duration::new(10, 0).into(), Duration::new(20, 0).into()],
+        test_case_success_to_skip_to_fail_to_error_percentage: vec![vec![
+            0 as u8, 0 as u8, 100 as u8, 0 as u8,
+        ]],
+    };
+    let mut options = junit_mock::Options::default();
+    options.test_case = test_case_options;
+    let mut mock = JunitMock::new(options);
+    let reports = mock.generate_reports();
+    mock.write_reports_to_file(directory.as_ref(), reports)
         .unwrap()
 }
 

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -526,9 +526,8 @@ impl EndOutput for UploadRunResult {
             total_tests, passes, failures, quarantined, pass_ratio
         ))?]));
         if self.quarantine_context.fetch_status.is_failure() {
-            println!("fstat {:?}", self.quarantine_context.fetch_status);
             output.push(Line::from_iter([Span::new_styled(
-                style("   We were not able to fetch quarantine states for tests, a failing flaky test will be reported as a failure".to_string()).attribute(Attribute::Dim),
+                style("   We were unable to determine the quarantine status for tests. Any failing tests will be reported as failures".to_string()).attribute(Attribute::Dim),
             )?]));
         }
         output.push(Line::default());

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -360,7 +360,7 @@ pub async fn run_upload(
         Ok(context) => context,
         Err(e) => {
             tracing::error!("Failed to gather quarantine context: {}", e);
-            QuarantineContext::default()
+            QuarantineContext::fail_fetch(e)
         }
     };
     meta.base_props.quarantined_tests = quarantine_context
@@ -525,6 +525,12 @@ impl EndOutput for UploadRunResult {
             "   Total: {}   Pass: {}   Fail: {}   Quarantined: {}   Pass Ratio: {}",
             total_tests, passes, failures, quarantined, pass_ratio
         ))?]));
+        if self.quarantine_context.fetch_status.is_failure() {
+            println!("fstat {:?}", self.quarantine_context.fetch_status);
+            output.push(Line::from_iter([Span::new_styled(
+                style("   We were not able to fetch quarantine states for tests, a failing flaky test will be reported as a failure".to_string()).attribute(Attribute::Dim),
+            )?]));
+        }
         output.push(Line::default());
         let qc = &self.quarantine_context;
         let quarantined = &qc.quarantine_status.quarantine_results;


### PR DESCRIPTION
Falls back to reporting failures when we cannot get a quarantine config. In this situation, we also add a note to the test report so that users will know why we are reporting tests as failing even if they are usually quarantined.

<img width="1063" height="359" alt="Screenshot from 2025-07-30 14-08-25" src="https://github.com/user-attachments/assets/1146430e-e8a3-4697-9fee-832163939bf1" />