### PR TITLE
Allow users to specify GitHub job url manually

### DIFF
--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -303,7 +303,9 @@ impl<'a> CIInfoParser<'a> {
 
         self.ci_info.actor = self.get_env_var("GITHUB_ACTOR");
         self.ci_info.title = self.get_env_var("PR_TITLE");
-        if let (Some(repo_name), Some(run_id)) = (
+        if let Some(job_url) = self.get_env_var("JOB_URL") {
+            self.ci_info.job_url = Some(job_url);
+        } else if let (Some(repo_name), Some(run_id)) = (
             self.get_env_var("GITHUB_REPOSITORY"),
             self.get_env_var("GITHUB_RUN_ID"),
         ) {

--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -303,6 +303,90 @@ fn test_simple_github_pr() {
 }
 
 #[test]
+fn test_github_job_url_override() {
+    let run_id = String::from("42069");
+    let pr_number = 123;
+    let actor = String::from("username");
+    let repository = String::from("test/tester");
+    let branch = String::from("some-branch-name");
+    let workflow = String::from("Pull Request");
+    let job = String::from("test-job");
+
+    let env_vars = EnvVars::from_iter(vec![
+        (String::from("GITHUB_ACTIONS"), String::from("true")),
+        (
+            String::from("GITHUB_EVENT_NAME"),
+            String::from("pull_request"),
+        ),
+        (String::from("GITHUB_RUN_ID"), String::from(&run_id)),
+        (String::from("GITHUB_ACTOR"), String::from(&actor)),
+        (String::from("GITHUB_REPOSITORY"), String::from(&repository)),
+        (String::from("GITHUB_HEAD_REF"), String::from(&branch)),
+        (
+            String::from("GITHUB_REF"),
+            format!("refs/pull/{pr_number}/merge"),
+        ),
+        (String::from("GITHUB_WORKFLOW"), String::from(&workflow)),
+        (String::from("GITHUB_JOB"), String::from(&job)),
+        (
+            String::from("JOB_URL"),
+            String::from("https://example.com/job-url"),
+        ),
+    ]);
+
+    let mut env_parser = EnvParser::new();
+    env_parser.parse(&env_vars, &[]);
+
+    let ci_info = env_parser.into_ci_info_parser().unwrap().info_ci_info();
+
+    pretty_assertions::assert_eq!(
+        ci_info,
+        CIInfo {
+            platform: CIPlatform::GitHubActions,
+            job_url: Some(String::from("https://example.com/job-url")),
+            branch: Some(branch),
+            branch_class: Some(BranchClass::PullRequest),
+            pr_number: Some(pr_number),
+            actor: Some(actor),
+            committer_name: None,
+            committer_email: None,
+            author_name: None,
+            author_email: None,
+            commit_message: None,
+            title: None,
+            workflow: Some(workflow),
+            job: Some(job),
+        }
+    );
+
+    let env_validation = env::validator::validate(&ci_info);
+    assert_eq!(env_validation.max_level(), EnvValidationLevel::SubOptimal);
+    pretty_assertions::assert_eq!(
+        env_validation.issues(),
+        &[
+            EnvValidationIssue::SubOptimal(
+                EnvValidationIssueSubOptimal::CIInfoAuthorEmailTooShort(String::from(""),),
+            ),
+            EnvValidationIssue::SubOptimal(EnvValidationIssueSubOptimal::CIInfoAuthorNameTooShort(
+                String::from(""),
+            ),),
+            EnvValidationIssue::SubOptimal(
+                EnvValidationIssueSubOptimal::CIInfoCommitMessageTooShort(String::from(""),),
+            ),
+            EnvValidationIssue::SubOptimal(
+                EnvValidationIssueSubOptimal::CIInfoCommitterEmailTooShort(String::from(""),),
+            ),
+            EnvValidationIssue::SubOptimal(
+                EnvValidationIssueSubOptimal::CIInfoCommitterNameTooShort(String::from(""),),
+            ),
+            EnvValidationIssue::SubOptimal(EnvValidationIssueSubOptimal::CIInfoTitleTooShort(
+                String::from(""),
+            ),),
+        ]
+    );
+}
+
+#[test]
 fn test_simple_github_merge_queue() {
     let run_id = String::from("42069");
     let actor = String::from("username");


### PR DESCRIPTION
Update the ETL bindings to support using the `JOB_URL` environment variable.