### PR TITLE
[TRUNK-15403] Use arm-based vm for linux aarch64 branch

### DIFF
--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -100,7 +100,7 @@ jobs:
           - name: x86_64-linux
             os: ubuntu-latest
           - name: aarch64-linux
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
           - name: arm64-darwin
             os: macos-latest
           - name: x86_64-darwin


### PR DESCRIPTION
It looks like the issue here was running `gem unpack rspec_trunk_flaky_tests*` would unpack the latest matching version of the gem, but gem was now taking the architecture of the vm it was running on into account. This meant that it would go looking for an x86_64 build, which meant that when we were using local builds for aarch64, we would get the last completed build, breaking the test and release process. To fix this, we switch the runner to a linux runner on aarch64. Since none of github's mainline runners or our custom-hosted runners have this combination, we use a [partner
runner](https://github.com/actions/partner-runner-images).

Successful run with this change (and also the actual releasing stuff commented out): https://github.com/trunk-io/analytics-cli/actions/runs/16754422283