### PR TITLE
[TRUNK-16320] Switch to sanitising user values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "context",
  "escargot",
  "exitcode",
+ "humantime",
  "junit-mock",
  "lazy_static",
  "more-asserts",
@@ -2355,9 +2356,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"

--- a/cli-tests/Cargo.toml
+++ b/cli-tests/Cargo.toml
@@ -36,5 +36,6 @@ wasm = []
 
 [dependencies]
 anyhow = "1.0.96"
+humantime = "2.2.0"
 proto = { version = "0.0.0", path = "../proto" }
 superconsole = "0.2.0"

--- a/cli/src/error_report.rs
+++ b/cli/src/error_report.rs
@@ -95,7 +95,7 @@ impl EndOutput for ErrorReport {
         )?]));
         if is_connection_refused(&self.error) {
             if let Some(base_message) = base_message {
-                lines.push(Line::from_iter([Span::new_unstyled(base_message)?]));
+                lines.push(Line::from_iter([Span::new_unstyled_lossy(base_message)]));
                 lines.push(Line::default());
             }
             lines.push(Line::from_iter([Span::new_unstyled(
@@ -107,15 +107,15 @@ impl EndOutput for ErrorReport {
         if is_unauthorized(&self.error) {
             {
                 lines.extend(vec![
-                    Line::from_iter([Span::new_unstyled(
+                    Line::from_iter([Span::new_unstyled_lossy(
                         base_message.as_deref().unwrap_or_default(),
-                    )?]),
+                    )]),
                     Line::default(),
                     Line::from_iter([Span::new_unstyled(UNAUTHORIZED_CONTEXT)?]),
-                    Line::from_iter([Span::new_unstyled(add_settings_url_to_context(
+                    Line::from_iter([Span::new_unstyled_lossy(add_settings_url_to_context(
                         api_host,
                         org_url_slug,
-                    ))?]),
+                    ))]),
                 ]);
                 if let Some(line) = lines.last_mut() {
                     line.pad_left(2);
@@ -124,14 +124,14 @@ impl EndOutput for ErrorReport {
             }
         }
         if base_message.is_some() {
-            lines.push(Line::from_iter([Span::new_unstyled(
+            lines.push(Line::from_iter([Span::new_unstyled_lossy(
                 base_message.as_deref().unwrap_or("An error occurred"),
-            )?]));
+            )]));
             lines.push(Line::default());
         } else {
-            lines.push(Line::from_iter([Span::new_unstyled(
+            lines.push(Line::from_iter([Span::new_unstyled_lossy(
                 self.error.to_string(),
-            )?]));
+            )]));
         }
         lines.push(Line::from_iter([Span::new_unstyled(HELP_TEXT)?]));
         lines.push(Line::default());

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -619,9 +619,9 @@ impl EndOutput for UploadRunResult {
                         if test.parent_name.is_empty() { "" } else { "/" },
                         test.name
                     );
-                    let mut test_line = Line::from_iter([Span::new_styled(
+                    let mut test_line = Line::from_iter([Span::new_styled_lossy(
                         style(output_name.to_string()).attribute(Attribute::Bold),
-                    )?]);
+                    )]);
                     test_line.pad_left(2);
                     output.push(test_line);
                     let link = url_for_test_case(

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -148,7 +148,7 @@ impl EndOutput for ValidateRunResult {
             if !bep_results.errors.is_empty() {
                 output.push(Line::from_iter([
                     Span::new_unstyled("⚠️  BEP file had parse errors: ")?,
-                    Span::new_unstyled(format!("{:?}", bep_results.errors))?,
+                    Span::new_unstyled_lossy(format!("{:?}", bep_results.errors)),
                 ]));
                 output.push(Line::default());
             }
@@ -187,9 +187,9 @@ impl EndOutput for ValidateRunResult {
             } else {
                 Color::Green
             };
-            output.push(Line::from_iter([Span::new_styled(
+            output.push(Line::from_iter([Span::new_styled_lossy(
                 style(file_parse_issue.file_path.clone()).with(title_colour),
-            )?]));
+            )]));
 
             let num_errors = if file_parse_issue.fatal_error.is_some() {
                 file_parse_issue.errors.len() + 1
@@ -214,20 +214,20 @@ impl EndOutput for ValidateRunResult {
                     ))]));
                 }
                 for error in file_parse_issue.errors.iter() {
-                    output.push(Line::from_iter([Span::new_unstyled(format!(
+                    output.push(Line::from_iter([Span::new_unstyled_lossy(format!(
                         "  {}",
                         error
-                    ))?]));
+                    ))]));
                 }
             }
 
             if has_warnings {
                 output.push(Line::from_iter([Span::new_unstyled(" ⚠️  Warnings:")?]));
                 for warning in file_parse_issue.warnings.iter() {
-                    output.push(Line::from_iter([Span::new_unstyled(format!(
+                    output.push(Line::from_iter([Span::new_unstyled_lossy(format!(
                         "  {}",
                         warning.clone()
-                    ))?]));
+                    ))]));
                 }
             }
 
@@ -248,9 +248,9 @@ impl EndOutput for ValidateRunResult {
             } else {
                 Color::Green
             };
-            output.push(Line::from_iter([Span::new_styled(
+            output.push(Line::from_iter([Span::new_styled_lossy(
                 style(test_issue.file_path.clone()).with(title_colour),
-            )?]));
+            )]));
 
             output.push(Line::from_iter([Span::new_styled(
                 style(format!(
@@ -268,20 +268,20 @@ impl EndOutput for ValidateRunResult {
                     " ❌ Errors:",
                 ))?]));
                 for error in test_issue.errors.iter() {
-                    output.push(Line::from_iter([Span::new_unstyled(format!(
+                    output.push(Line::from_iter([Span::new_unstyled_lossy(format!(
                         "  {}",
                         error.error_message
-                    ))?]));
+                    ))]));
                 }
             }
 
             if has_warnings {
                 output.push(Line::from_iter([Span::new_unstyled(" ⚠️  Warnings:")?]));
                 for warning in test_issue.warnings.iter() {
-                    output.push(Line::from_iter([Span::new_unstyled(format!(
+                    output.push(Line::from_iter([Span::new_unstyled_lossy(format!(
                         "  {}",
                         warning.error_message
-                    ))?]));
+                    ))]));
                 }
             }
         }
@@ -297,18 +297,18 @@ impl EndOutput for ValidateRunResult {
                 )?]));
             }
             Some(codeowners_issues) => {
-                output.push(Line::from_iter([Span::new_styled(
+                output.push(Line::from_iter([Span::new_styled_lossy(
                     style(format!(
                         "  Found codeowners path: {:?}",
                         codeowners_issues.file_path
                     ))
                     .attribute(Attribute::Italic),
-                )?]));
+                )]));
                 for warning in codeowners_issues.warnings.iter() {
-                    output.push(Line::from_iter([Span::new_unstyled(format!(
+                    output.push(Line::from_iter([Span::new_unstyled_lossy(format!(
                         "  {}",
                         warning.clone()
-                    ))?]));
+                    ))]));
                 }
             }
         }
@@ -813,10 +813,10 @@ impl JunitReportValidations {
                     lines.extend([
                         Line::from_iter([
                             Span::new_unstyled("❌ ")?,
-                            Span::new_styled(
+                            Span::new_styled_lossy(
                                 format!("{file_name} Could Not Be Parsed")
                                     .attribute(Attribute::Bold),
-                            )?,
+                            ),
                         ]),
                         Line::from_iter([
                             Span::new_unstyled(" ↪ ")?,
@@ -838,10 +838,10 @@ impl JunitReportValidations {
                         (false, false) => {
                             lines.push(Line::from_iter([
                                 Span::new_unstyled("❌ ")?,
-                                Span::new_styled(
+                                Span::new_styled_lossy(
                                     format!("{file_name} Has Errors And Warnings")
                                         .attribute(Attribute::Bold),
-                                )?,
+                                ),
                             ]));
                             lines.push(Line::from_iter([
                                 Span::new_unstyled(" ↪ ❌ ")?,
@@ -852,7 +852,7 @@ impl JunitReportValidations {
                             for error in limits.limit_issues(invalid_issues.iter()) {
                                 lines.push(Line::from_iter([
                                     Span::new_unstyled("   ↪ ")?,
-                                    Span::new_unstyled(error.error_message.clone())?,
+                                    Span::new_unstyled_lossy(error.error_message.clone()),
                                 ]));
                             }
                             lines.push(Line::from_iter([
@@ -864,35 +864,35 @@ impl JunitReportValidations {
                             for warning in limits.limit_issues(sub_optimal_issues.iter()) {
                                 lines.push(Line::from_iter([
                                     Span::new_unstyled("   ↪ ")?,
-                                    Span::new_unstyled(warning.error_message.clone())?,
+                                    Span::new_unstyled_lossy(warning.error_message.clone()),
                                 ]));
                             }
                         }
                         (true, false) => {
                             lines.push(Line::from_iter([
                                 Span::new_unstyled("❌ ")?,
-                                Span::new_styled(
+                                Span::new_styled_lossy(
                                     format!("{file_name} Has Errors").attribute(Attribute::Bold),
-                                )?,
+                                ),
                             ]));
                             for issue in limits.limit_issues(invalid_issues.iter()) {
                                 lines.push(Line::from_iter([
                                     Span::new_unstyled(" ↪ ")?,
-                                    Span::new_unstyled(issue.error_message.clone())?,
+                                    Span::new_unstyled_lossy(issue.error_message.clone()),
                                 ]));
                             }
                         }
                         (false, true) => {
                             lines.push(Line::from_iter([
                                 Span::new_unstyled("⚠️  ")?,
-                                Span::new_styled(
+                                Span::new_styled_lossy(
                                     format!("{file_name} Has Warnings").attribute(Attribute::Bold),
-                                )?,
+                                ),
                             ]));
                             for warning in limits.limit_issues(sub_optimal_issues.iter()) {
                                 lines.push(Line::from_iter([
                                     Span::new_unstyled(" ↪ ")?,
-                                    Span::new_unstyled(warning.error_message.clone())?,
+                                    Span::new_unstyled_lossy(warning.error_message.clone()),
                                 ]));
                             }
                         }

--- a/display/src/message.rs
+++ b/display/src/message.rs
@@ -45,7 +45,7 @@ impl Component for ProgressMessage {
     fn draw_unchecked(&self, _dimensions: Dimensions, _mode: DrawMode) -> Result<Lines> {
         let output = vec![Line::from_iter([
             Span::new_unstyled("⏳ ")?,
-            Span::new_unstyled(self.message.clone())?,
+            Span::new_unstyled_lossy(self.message.clone()),
         ])];
         Ok(Lines(output))
     }


### PR DESCRIPTION
Superconsole has a bunch of things it crashes when attempting to display, but has _lossy variants of functions which will sanitise any text given to them. Switching to those for anything that can contain user-provided values.