### PR TITLE
[TRUNK-16335] Set is_quarantined in internal.bin

### DIFF
--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -331,6 +331,9 @@ pub fn generate_internal_file_from_bep(
     codeowners: Option<&CodeOwners>,
     show_warnings: bool,
     variant: Option<String>,
+    org_slug: &String,
+    repo: &RepoUrlParts,
+    quarantined_test_ids: &Vec<String>,
 ) -> anyhow::Result<(
     BundledFile,
     BTreeMap<String, anyhow::Result<JunitReportValidation>>,
@@ -359,7 +362,12 @@ pub fn generate_internal_file_from_bep(
                         &mut junit_validations,
                     );
 
-                    let mut xml_test_case_runs = junit_parser.into_test_case_runs(codeowners);
+                    let mut xml_test_case_runs = junit_parser.into_test_case_runs(
+                        codeowners,
+                        org_slug,
+                        repo,
+                        quarantined_test_ids,
+                    );
                     for test_case_run in &mut xml_test_case_runs {
                         test_case_run.attempt_number = xml_file.attempt;
                     }
@@ -381,7 +389,12 @@ pub fn generate_internal_file_from_bep(
                         show_warnings,
                         &mut junit_validations,
                     );
-                    test_case_runs.extend(junit_parser.into_test_case_runs(codeowners));
+                    test_case_runs.extend(junit_parser.into_test_case_runs(
+                        codeowners,
+                        org_slug,
+                        repo,
+                        quarantined_test_ids,
+                    ));
                 }
             }
         }
@@ -411,6 +424,9 @@ pub fn generate_internal_file(
     codeowners: Option<&CodeOwners>,
     show_warnings: bool,
     variant: Option<String>,
+    org_slug: &String,
+    repo: &RepoUrlParts,
+    quarantined_test_ids: &Vec<String>,
 ) -> anyhow::Result<(
     BundledFile,
     BTreeMap<String, anyhow::Result<JunitReportValidation>>,
@@ -442,7 +458,12 @@ pub fn generate_internal_file(
                         show_warnings,
                         &mut junit_validations,
                     );
-                    test_case_runs.extend(junit_parser.into_test_case_runs(codeowners));
+                    test_case_runs.extend(junit_parser.into_test_case_runs(
+                        codeowners,
+                        org_slug,
+                        repo,
+                        quarantined_test_ids,
+                    ));
                 }
             }
         }

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -334,39 +334,6 @@ pub async fn run_upload(
         upload_args.allow_empty_test_results,
         &test_run_result,
     )?;
-    let temp_dir = tempfile::tempdir()?;
-    let internal_bundled_file = if let Some(ref bep_result) = bep_result {
-        generate_internal_file_from_bep(
-            bep_result,
-            &temp_dir,
-            meta.base_props.codeowners.as_ref(),
-            // hide warnings on parsed xcresult output
-            #[cfg(target_os = "macos")]
-            upload_args.xcresult_path.is_none(),
-            #[cfg(not(target_os = "macos"))]
-            true,
-            upload_args.variant,
-        )
-    } else {
-        generate_internal_file(
-            &meta.base_props.file_sets,
-            &temp_dir,
-            meta.base_props.codeowners.as_ref(),
-            // hide warnings on parsed xcresult output
-            #[cfg(target_os = "macos")]
-            upload_args.xcresult_path.is_none(),
-            #[cfg(not(target_os = "macos"))]
-            true,
-            upload_args.variant,
-        )
-    };
-    let validations = if let Ok((internal_bundled_file, junit_validations)) = internal_bundled_file
-    {
-        meta.internal_bundled_file = Some(internal_bundled_file);
-        JunitReportValidations::new(junit_validations)
-    } else {
-        JunitReportValidations::new(BTreeMap::new())
-    };
 
     let default_exit_code = if let Some(exit_code) = upload_args.test_process_exit_code {
         Some(exit_code)
@@ -388,6 +355,55 @@ pub async fn run_upload(
             QuarantineContext::fail_fetch(e)
         }
     };
+
+    let quarantined_test_ids = quarantine_context
+        .quarantine_status
+        .quarantine_results
+        .clone()
+        .iter()
+        .map(|test| test.id.clone())
+        .collect();
+
+    let temp_dir = tempfile::tempdir()?;
+    let internal_bundled_file = if let Some(ref bep_result) = bep_result {
+        generate_internal_file_from_bep(
+            bep_result,
+            &temp_dir,
+            meta.base_props.codeowners.as_ref(),
+            // hide warnings on parsed xcresult output
+            #[cfg(target_os = "macos")]
+            upload_args.xcresult_path.is_none(),
+            #[cfg(not(target_os = "macos"))]
+            true,
+            upload_args.variant,
+            &upload_args.org_url_slug,
+            &quarantine_context.repo,
+            &quarantined_test_ids,
+        )
+    } else {
+        generate_internal_file(
+            &meta.base_props.file_sets,
+            &temp_dir,
+            meta.base_props.codeowners.as_ref(),
+            // hide warnings on parsed xcresult output
+            #[cfg(target_os = "macos")]
+            upload_args.xcresult_path.is_none(),
+            #[cfg(not(target_os = "macos"))]
+            true,
+            upload_args.variant,
+            &upload_args.org_url_slug,
+            &quarantine_context.repo,
+            &quarantined_test_ids,
+        )
+    };
+    let validations = if let Ok((internal_bundled_file, junit_validations)) = internal_bundled_file
+    {
+        meta.internal_bundled_file = Some(internal_bundled_file);
+        JunitReportValidations::new(junit_validations)
+    } else {
+        JunitReportValidations::new(BTreeMap::new())
+    };
+
     meta.base_props.quarantined_tests = quarantine_context
         .quarantine_status
         .quarantine_results

--- a/context/src/junit/bindings.rs
+++ b/context/src/junit/bindings.rs
@@ -1277,6 +1277,8 @@ mod tests {
     #[cfg(feature = "bindings")]
     #[test]
     fn test_junit_conversion_paths() {
+        use crate::repo::RepoUrlParts;
+
         let mut junit_parser = JunitParser::new();
         let file_contents = r#"
         <xml version="1.0" encoding="UTF-8"?>
@@ -1295,7 +1297,16 @@ mod tests {
         assert!(parsed_results.is_ok());
 
         // Get test case runs from parser
-        let test_case_runs = junit_parser.into_test_case_runs(None);
+        let test_case_runs = junit_parser.into_test_case_runs(
+            None,
+            &String::from(""),
+            &RepoUrlParts {
+                host: "".into(),
+                owner: "".into(),
+                name: "".into(),
+            },
+            &vec![],
+        );
         assert_eq!(test_case_runs.len(), 2);
 
         // Convert test case runs to bindings


### PR DESCRIPTION
Sets the is_quarantined flag for tests in the internal.bin so that we can check it in order to avoid sending failure hooks for quarantined tests.