### PR TITLE
[TRUNK-16539] Use path in meta_json for internal bin

### DIFF
--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -219,6 +219,15 @@ pub enum VersionedBundle {
     V0_7_7(BundleMetaV0_7_7),
 }
 
+impl VersionedBundle {
+    pub fn internal_bundled_file(&self) -> Option<BundledFile> {
+        match self {
+            Self::V0_7_7(data) => data.internal_bundled_file.clone(),
+            _ => None,
+        }
+    }
+}
+
 #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Clone)]
 pub struct VersionedBundleWithBindingsReport {

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -419,6 +419,7 @@ mod tests {
             path: bin_path,
             owners: Vec::new(),
             team: None,
+            ..Default::default()
         });
         let meta = create_bundle_meta(bundled_file.clone());
         let bundler_util = BundlerUtil::new(&meta, None);

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -225,7 +225,6 @@ async fn find_internal_bin_in_entries<R: futures_io::AsyncRead + Unpin>(
         if path_str == target_name {
             let mut bytes = Vec::new();
             unwrapped_entry.read_to_end(&mut bytes).await?;
-            println!("bytes read {:?} from {:?}", bytes, path_str);
             return bin_parse(&bytes)
                 .map_err(|err| anyhow::anyhow!("Failed to decode {}: {}", target_name, err));
         }
@@ -240,7 +239,6 @@ async fn find_internal_bin_in_entries<R: futures_io::AsyncRead + Unpin>(
 pub async fn parse_internal_bin_and_meta_from_tarball<R: AsyncBufRead>(
     input: R,
 ) -> anyhow::Result<(TestReport, VersionedBundle)> {
-    println!("a");
     let zstd_decoder = ZstdDecoder::new(Box::pin(input));
     let archive = Archive::new(zstd_decoder);
     let mut entries = archive.entries()?;

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -417,8 +417,6 @@ mod tests {
             original_path: full_bin_path.to_str().unwrap().to_string(),
             original_path_rel: None,
             path: bin_path,
-            owners: Vec::new(),
-            team: None,
             ..Default::default()
         });
         let meta = create_bundle_meta(bundled_file.clone());

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -294,8 +294,14 @@ describe("context-js", () => {
   it("decompresses and parses internal.bin", async () => {
     expect.hasAssertions();
 
+    const uploadMeta = generateBundleMeta();
+    const metaInfoJson = JSON.stringify(
+      uploadMeta,
+      bundleMetaJsonSerializer,
+      2,
+    );
     const readableStream = await compressAndUploadMeta({
-      metaInfoJson: "{}",
+      metaInfoJson,
       includeInternalBin: RUBY_INTERNAL_BIN,
     });
 
@@ -403,14 +409,20 @@ describe("context-js", () => {
 
     await expect(
       parse_internal_bin_and_meta_from_tarball(readableStream),
-    ).rejects.toThrow('Files not found in tarball: ["internal.bin"]');
+    ).rejects.toThrow("No internal.bin file found in the tarball");
   });
 
   it("correctly gets and sets variant", async () => {
     expect.hasAssertions();
 
+    const uploadMeta = generateBundleMeta();
+    const metaInfoJson = JSON.stringify(
+      uploadMeta,
+      bundleMetaJsonSerializer,
+      2,
+    );
     const readableStream = await compressAndUploadMeta({
-      metaInfoJson: "{}",
+      metaInfoJson,
       includeInternalBin: VARIANT_INTERNAL_BIN,
     });
 

--- a/context-py/tests/test_parse_compressed_bundle.py
+++ b/context-py/tests/test_parse_compressed_bundle.py
@@ -10,7 +10,7 @@ from botocore.response import StreamingBody
 
 
 def base_meta() -> typing.Any:
-    return {
+    value: typing.Any = {
         "version": "1",
         "bundle_upload_id": "59c8ddd9-0a00-4b56-9eea-ef0d60ebcb79",
         "cli_version": "cargo=0.5.11 git=7e5824fa365c63a2d4b38020762be17f4edd6425 rustc=1.80.0-nightly",
@@ -75,6 +75,7 @@ def base_meta() -> typing.Any:
         "group_is_quarantined": None,
         "quarantined_tests": [],
     }
+    return value
 
 
 def create_stream_from_meta(


### PR DESCRIPTION
Switches over to using the path in the meta_json to find the internal bin file. This does end up loading the whole tarball into memory in order to check for files.