### PR TITLE
Normalize org_url_slug to lowercase

### DIFF
--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -68,7 +68,7 @@ pub struct UploadArgs {
         help = "Comma-separated list of glob patterns to test report files. Supports JUnit XML, Bazel BEP, and XCResult formats."
     )]
     pub test_reports: Vec<String>,
-    #[arg(long, env = constants::TRUNK_ORG_URL_SLUG_ENV, help = "Organization url slug.")]
+    #[arg(long, env = constants::TRUNK_ORG_URL_SLUG_ENV, value_parser = parse_org_url_slug, help = "Organization url slug.")]
     pub org_url_slug: String,
     #[arg(
         long,
@@ -270,6 +270,10 @@ fn parse_sha(s: &str) -> anyhow::Result<String> {
     }
 }
 
+fn parse_org_url_slug(s: &str) -> anyhow::Result<String> {
+    Ok(s.to_lowercase())
+}
+
 impl UploadArgs {
     pub fn new(
         token: String,
@@ -280,7 +284,7 @@ impl UploadArgs {
     ) -> Self {
         Self {
             junit_paths,
-            org_url_slug,
+            org_url_slug: org_url_slug.to_lowercase(),
             token,
             repo_root,
             allow_empty_test_results: true,


### PR DESCRIPTION
## Summary
This change ensures that the `org_url_slug` argument is consistently normalized to lowercase, both when parsed from command-line arguments and when constructed programmatically.

## Key Changes
- Added a new `parse_org_url_slug` value parser function that converts the input string to lowercase
- Applied the parser to the `org_url_slug` argument definition to automatically normalize CLI input
- Updated the `UploadArgs::new()` constructor to also normalize the `org_url_slug` parameter to lowercase for consistency

## Implementation Details
The normalization is now applied at two entry points:
1. **CLI argument parsing**: The `value_parser` attribute ensures any org_url_slug provided via command line is lowercased
2. **Programmatic construction**: The `UploadArgs::new()` method normalizes the parameter to handle cases where UploadArgs is constructed directly in code

This prevents inconsistencies and potential issues with organization URL slug comparisons or lookups that may be case-sensitive.

https://claude.ai/code/session_01Gn6ectQLY8ec7UwMP1xk6V