### PR TITLE
Fix ruby gem release by disabling bundler frozen mode

### DIFF
--- a/.github/actions/validate_ruby_platform_gem/action.yml
+++ b/.github/actions/validate_ruby_platform_gem/action.yml
@@ -1,0 +1,47 @@
+name: Validate Ruby Platform Gem
+description: Build and validate the pure ruby platform gem (fallback stub)
+
+inputs:
+  working-directory:
+    description: Directory containing the gem
+    default: rspec-trunk-flaky-tests
+
+runs:
+  using: composite
+  steps:
+    - name: Build ruby platform gem
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        # Disable frozen mode since the gemspec version may have been updated after bundle install
+        bundle config set frozen false
+        bundle exec rake ruby_gem
+
+    - name: Validate ruby platform gem
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euxo pipefail
+        GEM_FILE=$(ls pkg/rspec_trunk_flaky_tests-*.gem)
+        echo "Built gem: ${GEM_FILE}"
+
+        # Must not have a platform suffix (e.g. -x86_64-linux)
+        if echo "${GEM_FILE}" | grep -qE '-(x86_64|aarch64|arm64)-(linux|darwin)\.gem$'; then
+          echo "ERROR: Gem has a platform suffix, expected pure ruby gem"
+          exit 1
+        fi
+
+        # Validate gem metadata via ruby
+        ruby -e "require 'rubygems/package'
+          spec = Gem::Package.new('${GEM_FILE}').spec
+          abort 'ERROR: platform is not ruby' unless spec.platform.to_s == 'ruby'
+          abort 'ERROR: should have no extensions' unless spec.extensions.empty?
+          abort 'ERROR: should not depend on rb_sys' if spec.dependencies.any? { |d| d.name == 'rb_sys' }
+          files = spec.files
+          abort 'ERROR: should not include native source' if files.any? { |f| f.end_with?('.rs') }
+          abort 'ERROR: missing lib/*.rb' unless files.any? { |f| f.start_with?('lib/') && f.end_with?('.rb') }
+          puts 'Ruby platform gem validated successfully:'
+          puts \"  platform=#{spec.platform}\"
+          puts \"  extensions=#{spec.extensions}\"
+          puts \"  files=#{files.join(', ')}\"
+        "

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -53,9 +53,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
+      # aarch64 builds use cross-compilation, so stub_gen must run on host (x86_64)
+      # x86_64 builds run stub_gen inside container to avoid glibc mismatch
       - name: Setup Rust & Cargo
+        if: matrix.platform.target == 'aarch64'
         uses: ./.github/actions/setup_rust_cargo
       - name: Generate Python stubs
+        if: matrix.platform.target == 'aarch64'
         run: cargo run --bin stub_gen --manifest-path context-py/Cargo.toml --no-default-features
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -73,8 +77,11 @@ jobs:
               /usr/bin/yum -y upgrade
               /usr/bin/yum -y install perl-IPC-Cmd perl-List-MoreUtils openssl-devel python3-pip unzip
               /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
+              # Generate Python stubs inside x86_64 container to avoid glibc mismatch
+              cargo run --bin stub_gen --manifest-path context-py/Cargo.toml --no-default-features
             elif [ -f /usr/bin/apt ]; then
               # ghcr.io/rust-cross/manylinux2014-cross:aarch64
+              # Note: stub_gen already ran on host for aarch64 (can't run aarch64 binary here)
               /usr/bin/apt update
               /usr/bin/apt install -y pkg-config libssl-dev unzip
             fi

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -42,7 +42,7 @@ jobs:
           stable-ruby-versions: |
             exclude: [head]
   cross-gem:
-    name: Build gem for ${{ matrix.platform }}
+    name: ${{ matrix.platform == 'ruby' && 'Validate ruby platform gem' || format('Build gem for {0}', matrix.platform) }}
     runs-on: ubuntu-latest
     needs: ci-data
     strategy:
@@ -101,7 +101,10 @@ jobs:
       - name: Build pure ruby gem
         if: matrix.platform == 'ruby'
         working-directory: rspec-trunk-flaky-tests
-        run: bundle exec rake ruby_gem
+        run: |
+          # Disable frozen mode since the gemspec version was updated after bundle install
+          bundle config set frozen false
+          bundle exec rake ruby_gem
 
       - name: Validate ruby platform gem
         if: matrix.platform == 'ruby'

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -98,43 +98,9 @@ jobs:
           working-directory: rspec-trunk-flaky-tests
           ruby-versions: 3.0,3.1,3.2,3.3,3.4,4.0
 
-      - name: Build pure ruby gem
-        if: matrix.platform == 'ruby'
-        working-directory: rspec-trunk-flaky-tests
-        run: |
-          # Disable frozen mode since the gemspec version was updated after bundle install
-          bundle config set frozen false
-          bundle exec rake ruby_gem
-
       - name: Validate ruby platform gem
         if: matrix.platform == 'ruby'
-        working-directory: rspec-trunk-flaky-tests
-        shell: bash
-        run: |
-          set -euxo pipefail
-          GEM_FILE=$(ls pkg/rspec_trunk_flaky_tests-*.gem)
-          echo "Built gem: ${GEM_FILE}"
-
-          # Must not have a platform suffix (e.g. -x86_64-linux)
-          if echo "${GEM_FILE}" | grep -qE '-(x86_64|aarch64|arm64)-(linux|darwin)\.gem$'; then
-            echo "ERROR: Gem has a platform suffix, expected pure ruby gem"
-            exit 1
-          fi
-
-          # Validate gem metadata via ruby
-          ruby -e "require 'rubygems/package'
-            spec = Gem::Package.new('${GEM_FILE}').spec
-            abort 'ERROR: platform is not ruby' unless spec.platform.to_s == 'ruby'
-            abort 'ERROR: should have no extensions' unless spec.extensions.empty?
-            abort 'ERROR: should not depend on rb_sys' if spec.dependencies.any? { |d| d.name == 'rb_sys' }
-            files = spec.files
-            abort 'ERROR: should not include native source' if files.any? { |f| f.end_with?('.rs') }
-            abort 'ERROR: missing lib/*.rb' unless files.any? { |f| f.start_with?('lib/') && f.end_with?('.rb') }
-            puts 'Ruby platform gem validated successfully:'
-            puts \"  platform=#{spec.platform}\"
-            puts \"  extensions=#{spec.extensions}\"
-            puts \"  files=#{files.join(', ')}\"
-          "
+        uses: ./.github/actions/validate_ruby_platform_gem
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,3 +35,7 @@ jobs:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
           TRUNK_ORG_URL_SLUG: trunk-staging-org
           TRUNK_API_TOKEN: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+
+      - name: Validate ruby platform gem
+        if: "!cancelled()"
+        uses: ./.github/actions/validate_ruby_platform_gem


### PR DESCRIPTION
## Summary
- Creates a reusable `validate_ruby_platform_gem` action that builds and validates the pure ruby fallback gem
- Fixes the `release_ruby_gem.yml` workflow by disabling bundler frozen mode before building
- Renames the job from "Build gem for ruby" to "Validate ruby platform gem"
- Adds validation to `ruby.yml` to catch issues on PRs (not just at release time)

## Error fixed
```
The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set (Bundler::ProductionError)
```

## Changes
- New: `.github/actions/validate_ruby_platform_gem/action.yml`
- Modified: `.github/workflows/release_ruby_gem.yml` (uses new action)
- Modified: `.github/workflows/ruby.yml` (adds validation step)

## Test plan
- [ ] Merge and verify `ruby.yml` runs validation on this PR
- [ ] Re-run the release workflow with `0.12.9-beta.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)