### PR TITLE
Upgrade manylinux container from 2_17 to 2_28

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -53,13 +53,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
-      # aarch64 builds use cross-compilation, so stub_gen must run on host (x86_64)
-      # x86_64 builds run stub_gen inside container to avoid glibc mismatch
       - name: Setup Rust & Cargo
-        if: matrix.platform.target == 'aarch64'
         uses: ./.github/actions/setup_rust_cargo
       - name: Generate Python stubs
-        if: matrix.platform.target == 'aarch64'
         run: cargo run --bin stub_gen --manifest-path context-py/Cargo.toml --no-default-features
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -67,23 +63,18 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ./context-py/Cargo.toml
           manylinux: auto
-          # Required version in order to support Glue
-          container: "2_17"
+          # manylinux_2_28 provides glibc 2.28 which is compatible with ubuntu-latest
+          container: "2_28"
           before-script-linux: |
             # Needed for `openssl-sys`:
             # https://docs.rs/openssl/latest/openssl/
-            if [ -f /usr/bin/yum ]; then
-              # quay.io/pypa/manylinux2014_x86_64:latest
-              /usr/bin/yum -y upgrade
-              /usr/bin/yum -y install perl-IPC-Cmd perl-List-MoreUtils openssl-devel python3-pip unzip
-              /usr/bin/ln -s /usr/bin/pip3 /usr/bin/pip
-              # Generate Python stubs inside x86_64 container to avoid glibc mismatch
-              cargo run --bin stub_gen --manifest-path context-py/Cargo.toml --no-default-features
-            elif [ -f /usr/bin/apt ]; then
-              # ghcr.io/rust-cross/manylinux2014-cross:aarch64
-              # Note: stub_gen already ran on host for aarch64 (can't run aarch64 binary here)
-              /usr/bin/apt update
-              /usr/bin/apt install -y pkg-config libssl-dev unzip
+            if command -v yum &> /dev/null; then
+              # manylinux_2_28 x86_64 (AlmaLinux 8)
+              yum -y install perl-IPC-Cmd openssl-devel python3-pip unzip
+            elif command -v apt &> /dev/null; then
+              # manylinux_2_28 cross-compile (aarch64)
+              apt update
+              apt install -y pkg-config libssl-dev unzip
             fi
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Updates the manylinux container from `2_17` (manylinux2014, glibc 2.17) to `2_28` (manylinux_2_28, glibc 2.28).

This also removes the stub_gen workaround from #1067 since it's no longer needed with the newer container.

## Problem
GitHub recently updated `ubuntu-latest` runners with a newer glibc. The old manylinux2014 container has glibc 2.17 which can't run binaries built on ubuntu-latest, causing:

```
/lib64/libc.so.6: version `GLIBC_2.34' not found
```

## Solution
Upgrade to manylinux_2_28 which has glibc 2.28, compatible with ubuntu-latest. This is simpler than the conditional stub_gen workaround.

## Breaking Change
This drops support for systems that require manylinux2014 (e.g., AWS Glue).

## Test plan
- [ ] Verify pyo3 linux builds pass for both x86_64 and aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)