### PR TITLE
(Feat): Add backtrace collection for rspec

### DIFF
--- a/proto/proto/test_context.proto
+++ b/proto/proto/test_context.proto
@@ -24,7 +24,9 @@ message LineNumber {
 }
 
 message TestOutput {
+  // Typically the full message, including backtrace if applicable
   string text = 1;
+  // Typically the short failure message
   string message = 2;
   string system_out = 3;
   string system_err = 4;

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -189,6 +189,8 @@ end
 # TrunkAnalyticsListener is a class that is used to listen to the execution of the Example class
 # it generates and submits the final test reports
 class TrunkAnalyticsListener
+  MAX_TEXT_FIELD_SIZE = 8_000
+
   def initialize
     @testreport = $test_report
   end
@@ -221,8 +223,15 @@ class TrunkAnalyticsListener
 
   # trunk-ignore(rubocop/Metrics/CyclomaticComplexity,rubocop/Metrics/AbcSize,rubocop/Metrics/MethodLength)
   def add_test_case(example)
-    failure_message = example.exception.to_s if example.exception
-    failure_message = example.metadata[:quarantined_exception].to_s if example.metadata[:quarantined_exception]
+    exception = example.exception || example.metadata[:quarantined_exception]
+    failure_message = ''
+    backtrace = ''
+    if exception
+      failure_message = exception.to_s
+      backtrace = exception.backtrace.join("\n") if exception.backtrace && !exception.backtrace.empty?
+    end
+    failure_message = failure_message[0...MAX_TEXT_FIELD_SIZE] if failure_message.length > MAX_TEXT_FIELD_SIZE
+    backtrace = backtrace[0...MAX_TEXT_FIELD_SIZE] if backtrace.length > MAX_TEXT_FIELD_SIZE
     # TODO: should we use concatenated string or alias when auto-generated description?
     name = example.full_description
     file = escape(example.metadata[:file_path])
@@ -247,7 +256,7 @@ class TrunkAnalyticsListener
     parent_name = example.example_group.metadata[:description]
     parent_name = parent_name.empty? ? 'rspec' : parent_name
     @testreport.add_test(id, name, classname, file, parent_name, line, status, attempt_number,
-                         started_at, finished_at, failure_message || '', is_quarantined)
+                         started_at, finished_at, failure_message || '', backtrace || '', is_quarantined)
   end
 end
 

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -727,7 +727,8 @@ impl MutTestReport {
         attempt_number: i32,
         started_at: i64,
         finished_at: i64,
-        output: String,
+        failure_text: String,
+        backtrace: String,
         is_quarantined: bool,
     ) {
         let mut test = TestCaseRun::default();
@@ -779,11 +780,11 @@ impl MutTestReport {
         };
         test.finished_at = Some(test_finished_at);
         // trunk-ignore(clippy/deprecated)
-        test.status_output_message = output.clone();
+        test.status_output_message = failure_text.clone();
         if status != Status::Success {
             test.test_output = Some(TestOutput {
-                text: output,
-                message: "".into(),
+                text: backtrace,
+                message: failure_text,
                 system_out: "".into(),
                 system_err: "".into(),
             });
@@ -828,7 +829,7 @@ pub fn ruby_init(ruby: &magnus::Ruby) -> Result<(), magnus::Error> {
     test_report.define_singleton_method("new", magnus::function!(MutTestReport::new, 3))?;
     test_report.define_method("to_s", magnus::method!(MutTestReport::to_string, 0))?;
     test_report.define_method("publish", magnus::method!(MutTestReport::publish, 0))?;
-    test_report.define_method("add_test", magnus::method!(MutTestReport::add_test, 12))?;
+    test_report.define_method("add_test", magnus::method!(MutTestReport::add_test, 13))?;
     test_report.define_method("try_save", magnus::method!(MutTestReport::try_save, 1))?;
     test_report.define_method(
         "is_quarantined",

--- a/test_report/tests/report.rs
+++ b/test_report/tests/report.rs
@@ -100,6 +100,7 @@ async fn publish_test_report() {
             1000,
             1001,
             "test-message".into(),
+            "test-backtrace".into(),
             false,
         );
         // call this twice to later validate we only send one request
@@ -129,6 +130,7 @@ async fn publish_test_report() {
             1000,
             1001,
             "test-message".into(),
+            "test-backtrace".into(),
             true,
         );
         let result = test_report.publish();
@@ -270,8 +272,8 @@ async fn publish_test_report() {
     assert_eq!(
         test_case_run.test_output,
         Some(TestOutput {
-            text: "test-message".into(),
-            message: "".into(),
+            text: "test-backtrace".into(),
+            message: "test-message".into(),
             system_out: "".into(),
             system_err: "".into(),
         })
@@ -369,6 +371,7 @@ async fn test_environment_variable_overrides() {
             1000,
             1001,
             "test-message".into(),
+            "test-backtrace".into(),
             false,
         );
         let result = test_report.publish();
@@ -500,6 +503,7 @@ async fn test_variant_priority_constructor_over_env() {
             1000,
             1001,
             "test-message".into(),
+            "test-backtrace".into(),
             false,
         );
         let result = test_report.publish();


### PR DESCRIPTION
We got a user request to include richer failure information from the rspec gem, including backtraces.

I've done the following:
1. Move the message that we were capturing to failure_message to match what we usually see in other junit reporters
2. Capture the backtrace if it's present and wire it into failure_text, which usually includes the backtrace in other junit reporters
3. Truncate both to 8000 characters, which is what we limit internally (but also just to avoid inflating bundle sizes).

I ran the above on an example [Capybara](https://github.com/teamcapybara/capybara) repo and got the following:

```json
      "test_case_runs": [
        {
          "id": "",
          "name": "Full page example (scrolling) Full page test",
          "classname": "spec.capybara_spec",
          "file": "./spec/capybara_spec.rb",
          "parent_name": "Full page example (scrolling)",
          "line": 15,
          "status": 2,
          "attempt_number": 0,
          "started_at": "2026-04-17T04:41:57Z",
          "finished_at": "2026-04-17T04:41:57Z",
          "status_output_message": "session not created: Chrome instance exited. Examine ChromeDriver verbose log to determine the cause.",
          "is_quarantined": false,
          "codeowners": [],
          "attempt_index": {
            "number": 0
          },
          "line_number": {
            "number": 15
          },
          "test_output": {
            "text": "/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/response.rb:63:in 'Selenium::WebDriver::Remote::Response#add_cause'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/response.rb:41:in 'Selenium::WebDriver::Remote::Response#error'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/response.rb:52:in 'Selenium::WebDriver::Remote::Response#assert_ok'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/response.rb:34:in 'Selenium::WebDriver::Remote::Response#initialize'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/http/common.rb:135:in 'Selenium::WebDriver::Remote::Http::Common#create_response'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/http/default.rb:103:in 'Selenium::WebDriver::Remote::Http::Default#request'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/http/common.rb:70:in 'Selenium::WebDriver::Remote::Http::Common#call'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/bridge.rb:633:in 'Selenium::WebDriver::Remote::Bridge#execute'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/remote/bridge.rb:76:in 'Selenium::WebDriver::Remote::Bridge#create_session'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/common/driver.rb:325:in 'block in Selenium::WebDriver::Driver#create_bridge'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/common/driver.rb:324:in 'Kernel#tap'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/common/driver.rb:324:in 'Selenium::WebDriver::Driver#create_bridge'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/common/driver.rb:73:in 'Selenium::WebDriver::Driver#initialize'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/chrome/driver.rb:35:in 'block in Selenium::WebDriver::Chrome::Driver#initialize'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/common/local_driver.rb:31:in 'Selenium::WebDriver::LocalDriver#initialize_local_driver'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/chrome/driver.rb:34:in 'Selenium::WebDriver::Chrome::Driver#initialize'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver/common/driver.rb:47:in 'Selenium::WebDriver::Driver.for'\n/home/tyler/.gem/gems/selenium-webdriver-4.43.0/lib/selenium/webdriver.rb:88:in 'Selenium::WebDriver.for'\n/home/tyler/.gem/gems/capybara-3.40.0/lib/capybara/selenium/driver.rb:75:in 'Capybara::Selenium::Driver#browser'\n/home/tyler/.gem/gems/eyes_capybara-6.6.29/lib/applitools/capybara/driver.rb:13:in 'Applitools::Selenium::Capybara::Driver#browser'\n/home/tyler/.gem/gems/eyes_capybara-6.6.29/lib/applitools/capybara/driver.rb:8:in 'Applitools::Selenium::Capybara::Driver#driver_for_eyes'\n/home/tyler/.gem/gems/eyes_capybara-6.6.29/lib/applitools/capybara/driver.rb:32:in 'Capybara::Session#driver_for_eyes'\n/home/tyler/.gem/gems/eyes_selenium-6.12.29/lib/applitools/selenium/selenium_eyes.rb:24:in 'Applitools::Selenium::SeleniumEyes.eyes_driver'\n/home/tyler/.gem/gems/eyes_core-6.10.2/lib/applitools/core/universal_eyes_open.rb:29:in 'Applitools::UniversalEyesOpen#universal_open'\n/home/tyler/.gem/gems/eyes_selenium-6.12.29/lib/applitools/selenium/selenium_eyes.rb:149:in 'Applitools::Selenium::SeleniumEyes#open'\n/home/tyler/.gem/gems/eyes_selenium-6.12.29/lib/applitools/selenium/concerns/selenium_eyes.rb:108:in 'Applitools::Selenium::Concerns::SeleniumEyes#test'\n/snap/ruby/447/lib/ruby/4.0.0/delegate.rb:88:in 'Delegator#method_missing'\n/home/tyler/repos/RSpec-Capybara-example/spec/capybara_spec.rb:18:in 'block (2 levels) in <top (required)>'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:263:in 'BasicObject#instance_exec'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:263:in 'block in RSpec::Core::Example#run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in 'block in RSpec::Core::Example#with_around_and_singleton_context_hooks'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in 'block in RSpec::Core::Example#with_around_example_hooks'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in 'block in RSpec::Core::Hooks::HookCollections#run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:626:in 'block in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:178:in 'RSpec::Trunk#run'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:148:in 'RSpec::Core::Example::Procsy#run_with_trunk'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:629:in 'RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in 'RSpec::Core::Hooks::HookCollections#run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in 'RSpec::Core::Example#with_around_example_hooks'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in 'RSpec::Core::Example#with_around_and_singleton_context_hooks'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:259:in 'RSpec::Core::Example#run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:653:in 'block in RSpec::Core::ExampleGroup.run_examples'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:649:in 'Array#map'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:649:in 'RSpec::Core::ExampleGroup.run_examples'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:614:in 'RSpec::Core::ExampleGroup.run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in 'block (3 levels) in RSpec::Core::Runner#run_specs'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in 'Array#map'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in 'block (2 levels) in RSpec::Core::Runner#run_specs'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/configuration.rb:2097:in 'RSpec::Core::Configuration#with_suite_hooks'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:116:in 'block in RSpec::Core::Runner#run_specs'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/reporter.rb:74:in 'RSpec::Core::Reporter#report'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:115:in 'RSpec::Core::Runner#run_specs'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:89:in 'RSpec::Core::Runner#run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:71:in 'RSpec::Core::Runner.run'\n/home/tyler/.gem/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:45:in 'RSpec::Core::Runner.invoke'\n/home/tyler/.gem/gems/rspec-core-3.13.6/exe/rspec:4:in '<top (required)>'\n/snap/ruby/447/lib/ruby/4.0.0/rubygems.rb:303:in 'Kernel#load'\n/snap/ruby/447/lib/ruby/4.0.0/rubygems.rb:303:in 'Gem.activate_and_load_bin_path'\n/home/tyler/.gem/bin/rspec:25:in '<top (required)>'\n/snap/ruby/447/lib/ruby/4.0.0/bundler/cli/exec.rb:61:in 'Kernel.load'\n/snap/ruby/447/lib/ruby/4.0.0",
            "message": "session not created: Chrome instance exited. Examine ChromeDriver verbose log to determine the cause.",
            "system_out": "",
            "system_err": ""
          },
          "test_runner_information": null
        },
```