### PR TITLE
(Chore): Store additional CircleCI env vars

### DIFF
--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -132,6 +132,10 @@ pub const ENVS_TO_GET: &[&str] = &[
     "CIRCLE_USERNAME",
     "CIRCLE_WORKFLOW_ID",
     "CIRCLE_WORKFLOW_JOB_ID",
+    "CIRCLE_NODE_INDEX",
+    "CIRCLE_NODE_TOTAL",
+    "CIRCLE_PIPELINE_ID",
+    "CIRCLE_PIPELINE_NUMBER", // not a built-in but is common practice
     // Buildkite
     "BUILDKITE",
     "BUILDKITE_BRANCH",

--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -486,7 +486,31 @@ impl<'a> CIInfoParser<'a> {
     }
 
     fn parse_circleci(&mut self) {
-        self.ci_info.job_url = self.get_env_var("CIRCLE_BUILD_URL");
+        let build_url = self.get_env_var("CIRCLE_BUILD_URL");
+        self.ci_info.job_url = match build_url.as_deref() {
+            Some(url) if url.starts_with("https://circleci.com/gh/") => {
+                if let (
+                    Some((org, repo)),
+                    Some(pipeline_id),
+                    Some(workflow_id),
+                    Some(build_num),
+                    Some(node_index),
+                ) = (
+                    circleci_gh_org_repo_from_build_url(url),
+                    self.get_env_var("CIRCLE_PIPELINE_ID"),
+                    self.get_env_var("CIRCLE_WORKFLOW_ID"),
+                    self.get_env_var("CIRCLE_BUILD_NUM"),
+                    self.get_env_var("CIRCLE_NODE_INDEX"),
+                ) {
+                    Some(format!(
+                        "https://app.circleci.com/pipelines/github/{org}/{repo}/{pipeline_id}/workflows/{workflow_id}/jobs/{build_num}/parallel-runs/{node_index}"
+                    ))
+                } else {
+                    build_url
+                }
+            }
+            _ => build_url,
+        };
         self.ci_info.branch = self.get_env_var("CIRCLE_BRANCH");
         self.ci_info.pr_number = self.parse_pr_number(self.get_env_var("CIRCLE_PR_NUMBER"));
         self.ci_info.actor = self.get_env_var("CIRCLE_USERNAME");
@@ -705,6 +729,21 @@ pub fn clean_branch(branch: &str) -> String {
         .replace("origin/", "");
 
     return String::from(safe_truncate_string::<MAX_BRANCH_NAME_SIZE, _>(&new_branch));
+}
+
+/// Default `CIRCLE_BUILD_URL` for GitHub projects:
+/// `https://circleci.com/gh/{org}/{repo}/{build_num}`.
+/// Reference: https://discuss.circleci.com/t/circle-build-url-environment-variable-changing-for-projects-that-use-github-app-gitlab/49980/7
+fn circleci_gh_org_repo_from_build_url(url: &str) -> Option<(&str, &str)> {
+    const PREFIX: &str = "https://circleci.com/gh/";
+    let path = url.strip_prefix(PREFIX)?.split('?').next()?;
+    let path = path.trim_end_matches('/');
+    let mut segments = path.split('/').filter(|s| !s.is_empty());
+    let org = segments.next()?;
+    let repo = segments.next()?;
+    // Require the trailing build-number segment present in real CircleCI URLs.
+    segments.next()?;
+    Some((org, repo))
 }
 
 /// Characters that need to be percent-encoded in URL path segments

--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -1330,6 +1330,69 @@ fn test_simple_circleci() {
 }
 
 #[test]
+fn test_circleci_app_job_url_for_github_hosted_build() {
+    let branch = String::from("main");
+    let build_url = String::from("https://circleci.com/gh/acme/widget/42");
+    let pipeline_id = String::from("00000000-0000-4000-8000-000000000001");
+    let workflow_id = String::from("00000000-0000-4000-8000-000000000002");
+
+    let env_vars = EnvVars::from_iter(vec![
+        (String::from("CIRCLECI"), String::from("true")),
+        (String::from("CIRCLE_BRANCH"), String::from(&branch)),
+        (String::from("CIRCLE_BUILD_URL"), String::from(&build_url)),
+        // https://discuss.circleci.com/t/circle-build-url-environment-variable-changing-for-projects-that-use-github-app-gitlab/49980/7
+        // Job URL must use org/repo from CIRCLE_BUILD_URL, not these:
+        (
+            String::from("CIRCLE_PROJECT_USERNAME"),
+            String::from("wrong-org"),
+        ),
+        (
+            String::from("CIRCLE_PROJECT_REPONAME"),
+            String::from("wrong-repo"),
+        ),
+        (
+            String::from("CIRCLE_PIPELINE_ID"),
+            String::from(&pipeline_id),
+        ),
+        (
+            String::from("CIRCLE_WORKFLOW_ID"),
+            String::from(&workflow_id),
+        ),
+        (String::from("CIRCLE_BUILD_NUM"), String::from("42")),
+        (String::from("CIRCLE_NODE_INDEX"), String::from("0")),
+    ]);
+
+    let mut env_parser = EnvParser::new();
+    env_parser.parse(&env_vars, &[], None);
+
+    let ci_info = env_parser.into_ci_info_parser().unwrap().info_ci_info();
+
+    let expected_job_url = format!(
+        "https://app.circleci.com/pipelines/github/acme/widget/{pipeline_id}/workflows/{workflow_id}/jobs/42/parallel-runs/0"
+    );
+
+    pretty_assertions::assert_eq!(
+        ci_info,
+        CIInfo {
+            platform: CIPlatform::CircleCI,
+            job_url: Some(expected_job_url),
+            branch: Some(branch),
+            branch_class: Some(BranchClass::None),
+            pr_number: None,
+            actor: None,
+            committer_name: None,
+            committer_email: None,
+            author_name: None,
+            author_email: None,
+            commit_message: None,
+            title: None,
+            workflow: Some(workflow_id),
+            job: None,
+        }
+    );
+}
+
+#[test]
 fn test_circleci_pr() {
     let branch = String::from("feature/add-feature");
     let build_url = String::from("https://circleci.com/gh/my-org/my-repo/456");


### PR DESCRIPTION
Include additional CircleCI env vars to form full job URLs.

We'll need a repo version bump for ingestion to pick up the URL changes.

Most of this is informed by:
- [Env vars](https://circleci.com/docs/reference/variables/#built-in-environment-variables)
- [Announcement of URL format and distinctions between GH App and OAuth](https://discuss.circleci.com/t/circle-build-url-environment-variable-changing-for-projects-that-use-github-app-gitlab/49980/7)
- [Discussion on pipeline number](https://discuss.circleci.com/t/link-to-build-or-at-least-tag/43501/4)

For reference, a quick example is:
- A `${CIRCLE_BUILD_URL}` will be something like `https://circleci.com/gh/healthie/web/${CIRCLE_BUILD_NUM}`
- When you navigate there, you get redirected to `https://app.circleci.com/pipelines/github/healthie/web/${pipeline-number}/workflows/${CIRCLE_WORKFLOW_ID}/jobs/${CIRCLE_BUILD_NUM}`, which can be extended with `/parallel-runs/${CIRCLE_NODE_INDEX}`
- From my own testing, it looks like `pipeline-number` (number, usually set via config like below) is also substitutable with `${CIRCLE_PIPELINE_ID}` (uuid)


```yaml
jobs:
  my-job:
    environment:
      PIPELINE_NUMBER: << pipeline.number >>
```