### PR TITLE
(Chore): Add special rspec handling for multiple exceptions

### DIFF
--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -78,7 +78,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        bundle exec rspec spec/test_spec.rb --format documentation
+        bundle exec rspec spec/test_spec.rb spec/multiple_exception_spec.rb --format documentation
       env:
         TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
         TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}

--- a/.github/actions/test_ruby_gem_uploads/spec/multiple_exception_spec.rb
+++ b/.github/actions/test_ruby_gem_uploads/spec/multiple_exception_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# trunk-ignore(rubocop/Metrics/BlockLength)
+describe 'multiple_exception_error_test' do
+  context 'with before hook error and test failure' do
+    before do
+      raise StandardError, 'Error in before hook'
+    end
+
+    it 'test that would also fail' do
+      expect(true).to eq(false)
+    end
+  end
+
+  context 'with aggregate_failures creating multiple exceptions' do
+    it 'raises multiple exceptions' do
+      aggregate_failures do
+        expect(1).to eq(2)
+        expect(3).to eq(4)
+        expect(5).to eq(6)
+      end
+    end
+  end
+
+  context 'with before and after hook failures' do
+    before do
+      raise StandardError, 'Error in before hook'
+    end
+
+    after do
+      raise StandardError, 'Error in after hook'
+    end
+
+    it 'test execution with hook errors' do
+      expect(true).to eq(true)
+    end
+  end
+
+  context 'nested context with multiple failures' do
+    it 'multiple expectations that fail' do
+      aggregate_failures 'checking multiple conditions' do
+        expect(1).to eq(2)
+        expect('a').to eq('b')
+        expect([1, 2]).to eq([3, 4])
+        raise 'Additional error in test'
+      end
+    end
+  end
+end

--- a/rspec-trunk-flaky-tests/Cargo.lock
+++ b/rspec-trunk-flaky-tests/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -752,6 +753,7 @@ dependencies = [
  "bazel-bep",
  "chrono",
  "codeowners",
+ "constants",
  "gix",
  "lazy_static",
  "magnus",
@@ -2467,6 +2469,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -4956,10 +4967,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -186,6 +186,35 @@ module RSpec
   end
 end
 
+def format_exception_message(exception)
+  case exception
+  when RSpec::Core::MultipleExceptionError
+    # MultipleExceptionError contains multiple exceptions in @exceptions array
+    messages = exception.all_exceptions.map { |e| "#{e.class}: #{e.message}" }
+    "#{exception.class}: #{messages.join(' | ')}"
+  else
+    exception.to_s
+  end
+end
+
+# trunk-ignore(rubocop/Metrics/MethodLength)
+def format_exception_backtrace(exception)
+  case exception
+  when RSpec::Core::MultipleExceptionError
+    # Collect backtraces from all nested exceptions
+    backtraces = exception.all_exceptions.map do |e|
+      if e.backtrace && !e.backtrace.empty?
+        "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+      else
+        "#{e.class}: #{e.message}"
+      end
+    end
+    backtraces.join("\n\n")
+  else
+    exception.backtrace&.join("\n") || ''
+  end
+end
+
 # TrunkAnalyticsListener is a class that is used to listen to the execution of the Example class
 # it generates and submits the final test reports
 class TrunkAnalyticsListener
@@ -227,8 +256,8 @@ class TrunkAnalyticsListener
     failure_message = ''
     backtrace = ''
     if exception
-      failure_message = exception.to_s
-      backtrace = exception.backtrace.join("\n") if exception.backtrace && !exception.backtrace.empty?
+      failure_message = format_exception_message(exception)
+      backtrace = format_exception_backtrace(exception)
     end
     failure_message = failure_message[0...MAX_TEXT_FIELD_SIZE] if failure_message.length > MAX_TEXT_FIELD_SIZE
     backtrace = backtrace[0...MAX_TEXT_FIELD_SIZE] if backtrace.length > MAX_TEXT_FIELD_SIZE


### PR DESCRIPTION
[`RSpec::Core::MultipleExceptionError`](https://rspec.info/documentation/3.3/rspec-core/RSpec/Core/MultipleExceptionError.html) wraps multiple exceptions, and we were only surfacing its name. With this change, we report on all of its sub-exceptions.

<details><summary>New internal JSON output looks like</summary>

```json
"test_output": {
  "text": "StandardError: Error in before hook\n/home/tyler/repos/analytics-cli/.github/actions/test_ruby_gem_uploads/spec/multiple_exception_spec.rb:27:in `block (3 levels) in <top (required)>'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:365:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:529:in `block in run_owned_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:528:in `each'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:528:in `run_owned_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:615:in `block in run_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:614:in `reverse_each'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:614:in `run_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:484:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:505:in `run_before_example'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:261:in `block in run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in `block in run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:352:in `call'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:178:in `run'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:148:in `run_with_trunk'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:390:in `execute_with'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:352:in `call'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in `with_around_example_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:259:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:653:in `block in run_examples'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:649:in `map'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:649:in `run_examples'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:614:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in `block in run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in `map'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in `map'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:116:in `block in run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/reporter.rb:74:in `report'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:115:in `run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:89:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:71:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:45:in `invoke'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/exe/rspec:4:in `<top (required)>'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/bin/rspec:25:in `load'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/bin/rspec:25:in `<top (required)>'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:58:in `load'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:58:in `kernel_load'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:23:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli.rb:456:in `exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli.rb:35:in `dispatch'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli.rb:29:in `start'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bu",
  "message": "RSpec::Core::MultipleExceptionError: StandardError: Error in before hook | StandardError: Error in after hook",
  "system_out": "",
  "system_err": ""
},
```

</details> 