### PR TITLE
feat: add test collection short ID to upload metadata

### DIFF
--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -33,6 +33,7 @@ pub struct BundleMetaBaseProps {
     pub version: String,
     pub cli_version: String,
     pub org: String,
+    pub test_collection_short_id: Option<String>,
     pub repo: BundleRepo,
     pub bundle_upload_id: String,
     pub tags: Vec<CustomTag>,

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -399,6 +399,7 @@ mod tests {
             base_props: BundleMetaBaseProps {
                 version: META_VERSION.to_string(),
                 org: "org".to_string(),
+                test_collection_short_id: None,
                 repo: repo.clone(),
                 cli_version: "0.0.1".to_string(),
                 bundle_upload_id: "00".to_string(),

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -304,7 +304,6 @@ fn create_test_result(
 ) -> TestResult {
     TestResult {
         test_case_runs,
-        // trunk-ignore(clippy/deprecated)
         uploader_metadata: Some(UploaderMetadata {
             variant: variant.unwrap_or_default(),
             ..Default::default()

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -118,6 +118,7 @@ pub fn gather_initial_test_context(
         bazel_bep_path,
         test_reports,
         org_url_slug,
+        test_collection_short_id,
         repo_root,
         repo_url,
         repo_head_sha,
@@ -167,6 +168,7 @@ pub fn gather_initial_test_context(
         base_props: BundleMetaBaseProps {
             version: META_VERSION.to_string(),
             org: org_url_slug,
+            test_collection_short_id,
             repo,
             cli_version: format!(
                 "cargo={} git={} rustc={}",

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -73,6 +73,14 @@ pub struct UploadArgs {
     pub org_url_slug: String,
     #[arg(
         long,
+        env = constants::TRUNK_TEST_COLLECTION_SHORT_ID_ENV,
+        help = "Optional test collection short ID to attach to the uploaded bundle for collection-aware ingestion.",
+        required = false,
+        num_args = 1
+    )]
+    pub test_collection_short_id: Option<String>,
+    #[arg(
+        long,
         required = true,
         env = constants::TRUNK_API_TOKEN_ENV,
         help = "Organization token. Defaults to TRUNK_API_TOKEN env var."

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -496,7 +496,6 @@ pub async fn run_upload(
         .quarantine_results
         .clone();
 
-    // trunk-ignore(clippy/assigning_clones)
     meta.failed_tests = quarantine_context.failures.clone();
 
     let upload_started_at = chrono::Utc::now();

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -27,6 +27,7 @@ pub const TRUNK_API_CLIENT_RETRY_COUNT_ENV: &str = "TRUNK_API_CLIENT_RETRY_COUNT
 // Trunk CLI environment variable names for configuration overrides
 pub const TRUNK_API_TOKEN_ENV: &str = "TRUNK_API_TOKEN";
 pub const TRUNK_ORG_URL_SLUG_ENV: &str = "TRUNK_ORG_URL_SLUG";
+pub const TRUNK_TEST_COLLECTION_SHORT_ID_ENV: &str = "TRUNK_TEST_COLLECTION_SHORT_ID";
 pub const TRUNK_REPO_ROOT_ENV: &str = "TRUNK_REPO_ROOT";
 pub const TRUNK_REPO_URL_ENV: &str = "TRUNK_REPO_URL";
 pub const TRUNK_REPO_HEAD_SHA_ENV: &str = "TRUNK_REPO_HEAD_SHA";

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -127,6 +127,7 @@ const generateBundleMeta = (): TestBundleMeta => ({
   use_uncloned_repo: null,
   upload_time_epoch: faker.number.int(),
   tags: [],
+  test_collection_short_id: null,
   test_command: faker.hacker.verb(),
 });
 

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -288,9 +288,9 @@ describe("context-js", () => {
       includeInternalBin: RUBY_INTERNAL_BIN,
     });
 
-    await expect(
-      async () => await parse_meta_from_tarball(readableStream),
-    ).rejects.toThrow("missing field `version`");
+    await expect(parse_meta_from_tarball(readableStream)).rejects.toThrowError(
+      "missing field `version`",
+    );
   });
 
   it("decompresses and parses internal.bin", async () => {
@@ -411,7 +411,7 @@ describe("context-js", () => {
 
     await expect(
       parse_internal_bin_and_meta_from_tarball(readableStream),
-    ).rejects.toThrow("No internal.bin file found in the tarball");
+    ).rejects.toThrowError("No internal.bin file found in the tarball");
   });
 
   it("correctly gets and sets variant", async () => {

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -293,6 +293,7 @@ def test_parse_and_dump_meta_roundtrip():
         },
         "schema": "V0_5_29",
         "tags": [],
+        "test_collection_short_id": None,
         "test_command": None,
         "upload_time_epoch": 1721095230,
         "use_uncloned_repo": None,


### PR DESCRIPTION
## Overview

Add an optional test collection short ID to upload metadata and expose it through `trunk-analytics-cli upload`.

<details><summary>Details</summary>

This threads `test_collection_short_id` through bundle metadata construction, adds a CLI flag and env var, and updates the manual bundle fixture so downstream consumers can start inspecting bundle uploads for a specified collection.

</details>

## Testing

- `cargo test -p trunk-analytics-cli --no-run`

## Follow-up Work

- Wire the new metadata through bundle ingestion so collection-aware routing and dual-write behavior can be built on top of it.
