### PR TITLE
(Improvement): Capture richer rspec exception details

### DIFF
--- a/rspec-trunk-flaky-tests/README.md
+++ b/rspec-trunk-flaky-tests/README.md
@@ -104,7 +104,7 @@ require 'trunk_spec_helper'
 
 ### Environment Variables
 
-For a complete list of environment variables that the gem accepts, see [`lib/trunk_spec_helper.rb`](lib/trunk_spec_helper.rb). The gem uses the same environment variables as the Trunk Analytics CLI for configuration overrides.
+For a complete list of environment variables that the gem accepts, see [`lib/trunk_spec_helper.rb`](lib/trunk_spec_helper.rb). The gem uses the same environment variables as the Trunk Analytics CLI for configuration overrides. `TRUNK_ORG_URL_SLUG` and `TRUNK_API_TOKEN` must be set to activate the plugin.
 
 #### `TRUNK_LOCAL_UPLOAD_DIR` (Experimental)
 

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -225,7 +225,12 @@ def format_exception_backtrace(exception, example)
     depth += 1
   end
 
-  lines.join("\n")
+  result = lines.join("\n")
+  # The exception presenter may choke on MultipleExceptionError, such as errors in before
+  # and after hooks, so we fall back to the legacy formatter
+  return legacy_format_exception_backtrace(exception) if result.strip.empty?
+
+  result
 rescue StandardError
   legacy_format_exception_backtrace(exception)
 end
@@ -247,6 +252,7 @@ def legacy_format_exception_message(exception)
   end
 end
 
+# trunk-ignore(rubocop/Metrics/MethodLength)
 def legacy_format_exception_backtrace(exception)
   case exception
   when RSpec::Core::MultipleExceptionError
@@ -260,34 +266,6 @@ def legacy_format_exception_backtrace(exception)
   else
     exception.backtrace&.join("\n") || ''
   end
-end
-
-# When a field exceeds the size limit, drop characters from the middle and keep
-# both ends. The head usually carries the exception class/message and the tail
-# usually carries the project-local frames; either alone is much less useful.
-# trunk-ignore(rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)
-def truncate_middle(text, max_size)
-  return text if text.nil? || text.length <= max_size
-
-  truncated_count = text.length - max_size
-  marker = "\n... [truncated #{truncated_count} characters from middle] ...\n"
-  budget = max_size - marker.length
-  return text[0, max_size] if budget <= 0
-
-  head_size = budget / 2
-  tail_size = budget - head_size
-
-  head = text[0, head_size]
-  tail = text[-tail_size, tail_size] || ''
-
-  if (idx = head.rindex("\n"))
-    head = head[0, idx]
-  end
-  if (idx = tail.index("\n"))
-    tail = tail[(idx + 1)..-1] || ''
-  end
-
-  head + marker + tail
 end
 
 # TrunkAnalyticsListener is a class that is used to listen to the execution of the Example class
@@ -331,11 +309,11 @@ class TrunkAnalyticsListener
     failure_message = ''
     backtrace = ''
     if exception
-      failure_message = format_exception_message(exception, example)
-      backtrace = format_exception_backtrace(exception, example)
+      failure_message = format_exception_message(exception, example).strip
+      backtrace = format_exception_backtrace(exception, example).strip
     end
-    failure_message = truncate_middle(failure_message, MAX_TEXT_FIELD_SIZE)
-    backtrace = truncate_middle(backtrace, MAX_TEXT_FIELD_SIZE)
+    failure_message = failure_message[0...MAX_TEXT_FIELD_SIZE] if failure_message.length > MAX_TEXT_FIELD_SIZE
+    backtrace = backtrace[0...MAX_TEXT_FIELD_SIZE] if backtrace.length > MAX_TEXT_FIELD_SIZE
     # TODO: should we use concatenated string or alias when auto-generated description?
     name = example.full_description
     file = escape(example.metadata[:file_path])

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -30,6 +30,7 @@
 #   DISABLE_RSPEC_TRUNK_FLAKY_TESTS - Set to 'true' to completely disable Trunk
 #
 require 'rspec/core'
+require 'rspec/core/formatters/exception_presenter'
 require 'time'
 require 'rspec_trunk_flaky_tests'
 
@@ -186,10 +187,59 @@ module RSpec
   end
 end
 
-def format_exception_message(exception)
+# PlainColorizer is a no-op colorizer passed to RSpec's ExceptionPresenter so the
+# formatted output is plain text suitable for storage and the web UI.
+module PlainColorizer
+  module_function
+
+  def wrap(text, _code_or_symbol)
+    text
+  end
+end
+
+# Defer to RSpec's own ExceptionPresenter so the failure_message field matches
+# what users see in their RSpec console output (Failure/Error: <source line>,
+# the exception class and message, and any "Caused by:" chain).
+def format_exception_message(exception, example)
+  return '' unless exception
+
+  presenter = RSpec::Core::Formatters::ExceptionPresenter.new(exception, example)
+  presenter.fully_formatted(nil, PlainColorizer)
+rescue StandardError
+  legacy_format_exception_message(exception)
+end
+
+# trunk-ignore(rubocop/Metrics/MethodLength)
+def format_exception_backtrace(exception, example)
+  return '' unless exception
+
+  lines = exception_backtrace_lines(exception, example)
+
+  cause = exception.cause
+  depth = 0
+  while cause && depth < 10
+    lines << ''
+    lines << "Caused by: #{cause.class}: #{cause.message}"
+    lines.concat(exception_backtrace_lines(cause, example))
+    cause = cause.cause
+    depth += 1
+  end
+
+  lines.join("\n")
+rescue StandardError
+  legacy_format_exception_backtrace(exception)
+end
+
+def exception_backtrace_lines(exception, example)
+  presenter = RSpec::Core::Formatters::ExceptionPresenter.new(exception, example)
+  Array(presenter.formatted_backtrace)
+rescue StandardError
+  Array(exception.backtrace)
+end
+
+def legacy_format_exception_message(exception)
   case exception
   when RSpec::Core::MultipleExceptionError
-    # MultipleExceptionError contains multiple exceptions in @exceptions array
     messages = exception.all_exceptions.map { |e| "#{e.class}: #{e.message}" }
     "#{exception.class}: #{messages.join(' | ')}"
   else
@@ -197,22 +247,47 @@ def format_exception_message(exception)
   end
 end
 
-# trunk-ignore(rubocop/Metrics/MethodLength)
-def format_exception_backtrace(exception)
+def legacy_format_exception_backtrace(exception)
   case exception
   when RSpec::Core::MultipleExceptionError
-    # Collect backtraces from all nested exceptions
-    backtraces = exception.all_exceptions.map do |e|
+    exception.all_exceptions.map do |e|
       if e.backtrace && !e.backtrace.empty?
         "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
       else
         "#{e.class}: #{e.message}"
       end
-    end
-    backtraces.join("\n\n")
+    end.join("\n\n")
   else
     exception.backtrace&.join("\n") || ''
   end
+end
+
+# When a field exceeds the size limit, drop characters from the middle and keep
+# both ends. The head usually carries the exception class/message and the tail
+# usually carries the project-local frames; either alone is much less useful.
+# trunk-ignore(rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)
+def truncate_middle(text, max_size)
+  return text if text.nil? || text.length <= max_size
+
+  truncated_count = text.length - max_size
+  marker = "\n... [truncated #{truncated_count} characters from middle] ...\n"
+  budget = max_size - marker.length
+  return text[0, max_size] if budget <= 0
+
+  head_size = budget / 2
+  tail_size = budget - head_size
+
+  head = text[0, head_size]
+  tail = text[-tail_size, tail_size] || ''
+
+  if (idx = head.rindex("\n"))
+    head = head[0, idx]
+  end
+  if (idx = tail.index("\n"))
+    tail = tail[(idx + 1)..-1] || ''
+  end
+
+  head + marker + tail
 end
 
 # TrunkAnalyticsListener is a class that is used to listen to the execution of the Example class
@@ -256,11 +331,11 @@ class TrunkAnalyticsListener
     failure_message = ''
     backtrace = ''
     if exception
-      failure_message = format_exception_message(exception)
-      backtrace = format_exception_backtrace(exception)
+      failure_message = format_exception_message(exception, example)
+      backtrace = format_exception_backtrace(exception, example)
     end
-    failure_message = failure_message[0...MAX_TEXT_FIELD_SIZE] if failure_message.length > MAX_TEXT_FIELD_SIZE
-    backtrace = backtrace[0...MAX_TEXT_FIELD_SIZE] if backtrace.length > MAX_TEXT_FIELD_SIZE
+    failure_message = truncate_middle(failure_message, MAX_TEXT_FIELD_SIZE)
+    backtrace = truncate_middle(backtrace, MAX_TEXT_FIELD_SIZE)
     # TODO: should we use concatenated string or alias when auto-generated description?
     name = example.full_description
     file = escape(example.metadata[:file_path])


### PR DESCRIPTION
## Summary

Improving what `rspec_trunk_flaky_tests` captures for failed examples so the data we report matches what users see in their RSpec console output.

- **`failure_message`** now delegates to `RSpec::Core::Formatters::ExceptionPresenter#fully_formatted` (with a no-op colorizer). That gives us the full `Failure/Error: <source line>` header, the exception class and message, and any `Caused by:` chain — instead of just `<class>: <message>`. Previously the source line and root-cause chain were silently dropped.
- **`backtrace`** uses RSpec's `formatted_backtrace` (which applies the configured backtrace cleaner) and walks `exception.cause` so each cause's backtrace is appended. This recovers the chained backtraces that Ruby exposes via `#cause` but that we were ignoring.
- The previous formatting paths are preserved as fallbacks (`legacy_format_exception_message` / `legacy_format_exception_backtrace`) and the new code rescues `StandardError` to fall back if a future RSpec API shift breaks anything, so we still return useful information.

<details><summary>Example</summary>

### RSpec

```txt
Failures:

  1) multiple_exception_error_test with before hook error and test failure test that would also fail
     Failure/Error: raise StandardError, 'Error in before hook'
     
     StandardError:
       Error in before hook
     # ./spec/multiple_exception_spec.rb:7:in `block (3 levels) in <top (required)>'
     # /home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:179:in `run'
     # /home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:149:in `run_with_trunk'
```

### Before

More often than not, this backtrace is not useful, and rspec itself natively prettifies/hides it. I did a brief audit of some of our customer traces, and I think this rspec native matching will be preferred. More details below on rollout...

```json
"test_output": {
  "text": "/home/tyler/repos/analytics-cli/.github/actions/test_ruby_gem_uploads/spec/multiple_exception_spec.rb:7:in `block (3 levels) in <top (required)>'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:365:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:529:in `block in run_owned_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:528:in `each'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:528:in `run_owned_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:615:in `block in run_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:614:in `reverse_each'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:614:in `run_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:484:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:505:in `run_before_example'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:261:in `block in run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in `block in run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:352:in `call'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:178:in `run'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:148:in `run_with_trunk'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:457:in `instance_exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:390:in `execute_with'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:352:in `call'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in `with_around_example_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:259:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:653:in `block in run_examples'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:649:in `map'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:649:in `run_examples'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:614:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in `block in run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in `map'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in `map'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:116:in `block in run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/reporter.rb:74:in `report'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:115:in `run_specs'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:89:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:71:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:45:in `invoke'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.6/exe/rspec:4:in `<top (required)>'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/bin/rspec:25:in `load'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/bin/rspec:25:in `<top (required)>'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:58:in `load'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:58:in `kernel_load'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:23:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli.rb:456:in `exec'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli.rb:35:in `dispatch'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/lib/bundler/cli.rb:29:in `start'\n/home/tyler/.cache/trunk/tools/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/bundler-2.5.23/exe/bundle:28:in `block ",
  "message": "Error in before hook",
  "system_out": "",
  "system_err": ""
},
```

### After

```json
"test_output": {
  "text": "./spec/multiple_exception_spec.rb:7:in `block (3 levels) in <top (required)>'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:179:in `run'\n/home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:149:in `run_with_trunk'",
  "message": "multiple_exception_error_test with before hook error and test failure test that would also fail\n  Failure/Error: raise StandardError, 'Error in before hook'\n\n  StandardError:\n    Error in before hook\n  # ./spec/multiple_exception_spec.rb:7:in `block (3 levels) in <top (required)>'\n  # /home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:179:in `run'\n  # /home/tyler/repos/analytics-cli/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb:149:in `run_with_trunk'",
  "system_out": "",
  "system_err": ""
},
```

</details> 

## Rollout

I plan to confirm this approach works with our end user via a beta release, and go from there. I will also proactively follow-up with our other rspec users to make sure this is not a regression for them. Note that embeddings summaries will certainly drift a bit.

## Test plan

- [x] Verify a test that fails with a plain assertion still produces a clean `failure_message` and `backtrace`.
- [x] Verify a test whose failure has a `cause` chain (e.g. an error raised from inside a rescue) shows the `Caused by:` block in `failure_message` and the cause's frames in `backtrace`.
- [x] Verify a test that fails with `RSpec::Core::MultipleExceptionError` (test failure plus an `after` hook failure) reports all sub-exceptions.

https://claude.ai/code/session_01BHRe4t7dxsGyoMVhLrf3CF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHRe4t7dxsGyoMVhLrf3CF)_