### PR TITLE
Write test collection bundle metadata into uploads

### DIFF
--- a/api/src/message.rs
+++ b/api/src/message.rs
@@ -3,67 +3,57 @@ use context::repo::RepoUrlParts;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateBundleUploadRequest {
     pub repo: RepoUrlParts,
-    #[serde(rename = "orgUrlSlug")]
     pub org_url_slug: String,
-    #[serde(rename = "clientVersion")]
     pub client_version: String,
-    #[serde(rename = "remoteUrls")]
     pub remote_urls: Vec<String>,
-    #[serde(rename = "externalId")]
     pub external_id: Option<String>,
-    #[serde(rename = "testCollectionShortId")]
     pub test_collection_short_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateBundleUploadResponse {
     pub id: String,
-    #[serde(rename = "idV2")]
     pub id_v2: String,
     pub url: String,
     pub key: String,
-    #[serde(rename = "testCollectionBundleMetaId")]
     pub test_collection_bundle_meta_id: Option<String>,
-    #[serde(rename = "testCollectionBundleMetaCreatedAt")]
     pub test_collection_bundle_meta_created_at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct GetQuarantineConfigResponse {
-    #[serde(rename = "isDisabled")]
     pub is_disabled: bool,
     #[serde(rename = "testIds")]
     pub quarantined_tests: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct GetQuarantineConfigRequest {
     pub repo: RepoUrlParts,
-    #[serde(rename = "remoteUrls")]
     pub remote_urls: Vec<String>,
-    #[serde(rename = "orgUrlSlug")]
     pub org_url_slug: String,
-    #[serde(rename = "testIdentifiers")]
     pub test_identifiers: Vec<Test>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateBundleUploadIntentRequest {
     pub repo: RepoUrlParts,
-    #[serde(rename = "orgUrlSlug")]
     pub org_url_slug: String,
-    #[serde(rename = "clientVersion")]
     pub client_version: String,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateBundleUploadIntentResponse {
     pub repo: RepoUrlParts,
-    #[serde(rename = "orgUrlSlug")]
     pub org_url_slug: String,
-    #[serde(rename = "clientVersion")]
     pub client_version: String,
 }
 

--- a/api/src/message.rs
+++ b/api/src/message.rs
@@ -13,6 +13,8 @@ pub struct CreateBundleUploadRequest {
     pub remote_urls: Vec<String>,
     #[serde(rename = "externalId")]
     pub external_id: Option<String>,
+    #[serde(rename = "testCollectionShortId")]
+    pub test_collection_short_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
@@ -22,6 +24,10 @@ pub struct CreateBundleUploadResponse {
     pub id_v2: String,
     pub url: String,
     pub key: String,
+    #[serde(rename = "testCollectionBundleMetaId")]
+    pub test_collection_bundle_meta_id: Option<String>,
+    #[serde(rename = "testCollectionBundleMetaCreatedAt")]
+    pub test_collection_bundle_meta_created_at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone, Deserialize, Default)]

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -207,6 +207,10 @@ pub struct BundleMetaV0_7_8 {
     #[serde(flatten)]
     pub debug_props: BundleMetaDebugProps,
     pub bundle_upload_id_v2: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_collection_bundle_meta_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_collection_bundle_meta_created_at: Option<String>,
     pub variant: Option<String>,
     pub internal_bundled_file: Option<BundledFile>,
     pub failed_tests: Vec<Test>,

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 
 pub const META_VERSION: &str = "1";
-// 0.5.29 was first version to include bundle_upload_id and serves as the base
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
@@ -38,6 +37,7 @@ pub struct TestCollectionProps {
     pub bundle_meta_created_at: String,
 }
 
+// 0.5.29 was first version to include bundle_upload_id and serves as the base
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -39,7 +39,6 @@ pub struct TestCollectionProps {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(from = "BundleMetaBasePropsSerde")]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct BundleMetaBaseProps {
@@ -59,67 +58,6 @@ pub struct BundleMetaBaseProps {
     pub quarantined_tests: Vec<Test>,
     pub codeowners: Option<CodeOwners>,
     pub use_uncloned_repo: Option<bool>,
-}
-
-#[derive(Debug, Deserialize)]
-struct BundleMetaBasePropsSerde {
-    pub version: String,
-    pub cli_version: String,
-    pub org: String,
-    #[serde(rename = "test_collection_short_id")]
-    pub test_collection_short_id: Option<String>,
-    #[serde(rename = "test_collection_bundle_meta_id")]
-    pub test_collection_bundle_meta_id: Option<String>,
-    #[serde(rename = "test_collection_bundle_meta_created_at")]
-    pub test_collection_bundle_meta_created_at: Option<String>,
-    pub repo: BundleRepo,
-    pub bundle_upload_id: String,
-    pub tags: Vec<CustomTag>,
-    pub file_sets: Vec<FileSet>,
-    pub envs: HashMap<String, String>,
-    pub upload_time_epoch: u64,
-    pub test_command: Option<String>,
-    pub os_info: Option<String>,
-    pub quarantined_tests: Vec<Test>,
-    pub codeowners: Option<CodeOwners>,
-    pub use_uncloned_repo: Option<bool>,
-}
-
-impl From<BundleMetaBasePropsSerde> for BundleMetaBaseProps {
-    fn from(raw: BundleMetaBasePropsSerde) -> Self {
-        let test_collection = match (
-            raw.test_collection_short_id,
-            raw.test_collection_bundle_meta_id,
-            raw.test_collection_bundle_meta_created_at,
-        ) {
-            (Some(short_id), Some(bundle_meta_id), Some(bundle_meta_created_at)) => {
-                Some(TestCollectionProps {
-                    short_id,
-                    bundle_meta_id,
-                    bundle_meta_created_at,
-                })
-            }
-            _ => None,
-        };
-
-        BundleMetaBaseProps {
-            version: raw.version,
-            cli_version: raw.cli_version,
-            org: raw.org,
-            test_collection,
-            repo: raw.repo,
-            bundle_upload_id: raw.bundle_upload_id,
-            tags: raw.tags,
-            file_sets: raw.file_sets,
-            envs: raw.envs,
-            upload_time_epoch: raw.upload_time_epoch,
-            test_command: raw.test_command,
-            os_info: raw.os_info,
-            quarantined_tests: raw.quarantined_tests,
-            codeowners: raw.codeowners,
-            use_uncloned_repo: raw.use_uncloned_repo,
-        }
-    }
 }
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]

--- a/bundle/src/bundle_meta.rs
+++ b/bundle/src/bundle_meta.rs
@@ -29,11 +29,25 @@ pub const META_VERSION: &str = "1";
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
+pub struct TestCollectionProps {
+    #[serde(rename = "test_collection_short_id")]
+    pub short_id: String,
+    #[serde(rename = "test_collection_bundle_meta_id")]
+    pub bundle_meta_id: String,
+    #[serde(rename = "test_collection_bundle_meta_created_at")]
+    pub bundle_meta_created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(from = "BundleMetaBasePropsSerde")]
+#[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct BundleMetaBaseProps {
     pub version: String,
     pub cli_version: String,
     pub org: String,
-    pub test_collection_short_id: Option<String>,
+    #[serde(flatten, default)]
+    pub test_collection: Option<TestCollectionProps>,
     pub repo: BundleRepo,
     pub bundle_upload_id: String,
     pub tags: Vec<CustomTag>,
@@ -45,6 +59,67 @@ pub struct BundleMetaBaseProps {
     pub quarantined_tests: Vec<Test>,
     pub codeowners: Option<CodeOwners>,
     pub use_uncloned_repo: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BundleMetaBasePropsSerde {
+    pub version: String,
+    pub cli_version: String,
+    pub org: String,
+    #[serde(rename = "test_collection_short_id")]
+    pub test_collection_short_id: Option<String>,
+    #[serde(rename = "test_collection_bundle_meta_id")]
+    pub test_collection_bundle_meta_id: Option<String>,
+    #[serde(rename = "test_collection_bundle_meta_created_at")]
+    pub test_collection_bundle_meta_created_at: Option<String>,
+    pub repo: BundleRepo,
+    pub bundle_upload_id: String,
+    pub tags: Vec<CustomTag>,
+    pub file_sets: Vec<FileSet>,
+    pub envs: HashMap<String, String>,
+    pub upload_time_epoch: u64,
+    pub test_command: Option<String>,
+    pub os_info: Option<String>,
+    pub quarantined_tests: Vec<Test>,
+    pub codeowners: Option<CodeOwners>,
+    pub use_uncloned_repo: Option<bool>,
+}
+
+impl From<BundleMetaBasePropsSerde> for BundleMetaBaseProps {
+    fn from(raw: BundleMetaBasePropsSerde) -> Self {
+        let test_collection = match (
+            raw.test_collection_short_id,
+            raw.test_collection_bundle_meta_id,
+            raw.test_collection_bundle_meta_created_at,
+        ) {
+            (Some(short_id), Some(bundle_meta_id), Some(bundle_meta_created_at)) => {
+                Some(TestCollectionProps {
+                    short_id,
+                    bundle_meta_id,
+                    bundle_meta_created_at,
+                })
+            }
+            _ => None,
+        };
+
+        BundleMetaBaseProps {
+            version: raw.version,
+            cli_version: raw.cli_version,
+            org: raw.org,
+            test_collection,
+            repo: raw.repo,
+            bundle_upload_id: raw.bundle_upload_id,
+            tags: raw.tags,
+            file_sets: raw.file_sets,
+            envs: raw.envs,
+            upload_time_epoch: raw.upload_time_epoch,
+            test_command: raw.test_command,
+            os_info: raw.os_info,
+            quarantined_tests: raw.quarantined_tests,
+            codeowners: raw.codeowners,
+            use_uncloned_repo: raw.use_uncloned_repo,
+        }
+    }
 }
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "pyo3", gen_stub_pyclass, pyclass(get_all))]
@@ -207,10 +282,6 @@ pub struct BundleMetaV0_7_8 {
     #[serde(flatten)]
     pub debug_props: BundleMetaDebugProps,
     pub bundle_upload_id_v2: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub test_collection_bundle_meta_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub test_collection_bundle_meta_created_at: Option<String>,
     pub variant: Option<String>,
     pub internal_bundled_file: Option<BundledFile>,
     pub failed_tests: Vec<Test>,

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -392,8 +392,6 @@ mod tests {
         BundleMeta {
             junit_props: BundleMetaJunitProps::default(),
             bundle_upload_id_v2: String::with_capacity(0),
-            test_collection_bundle_meta_id: None,
-            test_collection_bundle_meta_created_at: None,
             debug_props: BundleMetaDebugProps {
                 command_line: String::with_capacity(0),
             },
@@ -401,7 +399,7 @@ mod tests {
             base_props: BundleMetaBaseProps {
                 version: META_VERSION.to_string(),
                 org: "org".to_string(),
-                test_collection_short_id: None,
+                test_collection: None,
                 repo: repo.clone(),
                 cli_version: "0.0.1".to_string(),
                 bundle_upload_id: "00".to_string(),

--- a/bundle/src/bundler.rs
+++ b/bundle/src/bundler.rs
@@ -392,6 +392,8 @@ mod tests {
         BundleMeta {
             junit_props: BundleMetaJunitProps::default(),
             bundle_upload_id_v2: String::with_capacity(0),
+            test_collection_bundle_meta_id: None,
+            test_collection_bundle_meta_created_at: None,
             debug_props: BundleMetaDebugProps {
                 command_line: String::with_capacity(0),
             },

--- a/bundle/tests/test_collection_props_test.rs
+++ b/bundle/tests/test_collection_props_test.rs
@@ -66,3 +66,15 @@ fn omits_test_collection_fields_when_absent() {
     let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
     assert_eq!(reparsed.test_collection, None);
 }
+
+#[test]
+fn ignores_null_test_collection_short_id() {
+    let mut value = serde_json::to_value(build_base_props(None)).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert(String::from("test_collection_short_id"), serde_json::Value::Null);
+
+    let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
+    assert_eq!(reparsed.test_collection, None);
+}

--- a/bundle/tests/test_collection_props_test.rs
+++ b/bundle/tests/test_collection_props_test.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+
+use bundle::{BundleMetaBaseProps, TestCollectionProps};
+use context::repo::BundleRepo;
+use serde_json::json;
+
+fn build_base_props(test_collection: Option<TestCollectionProps>) -> BundleMetaBaseProps {
+    BundleMetaBaseProps {
+        version: String::from("1"),
+        cli_version: String::from("trunk-analytics-cli test"),
+        org: String::from("test-org"),
+        test_collection,
+        repo: BundleRepo::default(),
+        bundle_upload_id: String::from("bundle-upload-id"),
+        tags: vec![],
+        file_sets: vec![],
+        envs: HashMap::new(),
+        upload_time_epoch: 0,
+        test_command: None,
+        os_info: None,
+        quarantined_tests: vec![],
+        codeowners: None,
+        use_uncloned_repo: None,
+    }
+}
+
+#[test]
+fn serializes_test_collection_props_as_flattened_fields() {
+    let base_props = build_base_props(Some(TestCollectionProps {
+        short_id: String::from("tc_123"),
+        bundle_meta_id: String::from("82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc"),
+        bundle_meta_created_at: String::from("2026-05-10T12:34:56.000Z"),
+    }));
+
+    let value = serde_json::to_value(&base_props).unwrap();
+    let object = value.as_object().unwrap();
+
+    assert_eq!(object.get("test_collection"), None);
+    assert_eq!(
+        object.get("test_collection_short_id"),
+        Some(&json!("tc_123"))
+    );
+    assert_eq!(
+        object.get("test_collection_bundle_meta_id"),
+        Some(&json!("82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc"))
+    );
+    assert_eq!(
+        object.get("test_collection_bundle_meta_created_at"),
+        Some(&json!("2026-05-10T12:34:56.000Z"))
+    );
+
+    let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
+    assert_eq!(reparsed.test_collection, base_props.test_collection);
+}
+
+#[test]
+fn deserializes_partial_legacy_test_collection_fields_as_none() {
+    let mut value = serde_json::to_value(build_base_props(None)).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert(String::from("test_collection_short_id"), json!("tc_123"));
+
+    let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
+    assert_eq!(reparsed.test_collection, None);
+}

--- a/bundle/tests/test_collection_props_test.rs
+++ b/bundle/tests/test_collection_props_test.rs
@@ -52,15 +52,3 @@ fn serializes_test_collection_props_as_flattened_fields() {
     let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
     assert_eq!(reparsed.test_collection, base_props.test_collection);
 }
-
-#[test]
-fn deserializes_partial_legacy_test_collection_fields_as_none() {
-    let mut value = serde_json::to_value(build_base_props(None)).unwrap();
-    value
-        .as_object_mut()
-        .unwrap()
-        .insert(String::from("test_collection_short_id"), json!("tc_123"));
-
-    let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
-    assert_eq!(reparsed.test_collection, None);
-}

--- a/bundle/tests/test_collection_props_test.rs
+++ b/bundle/tests/test_collection_props_test.rs
@@ -70,10 +70,10 @@ fn omits_test_collection_fields_when_absent() {
 #[test]
 fn ignores_null_test_collection_short_id() {
     let mut value = serde_json::to_value(build_base_props(None)).unwrap();
-    value
-        .as_object_mut()
-        .unwrap()
-        .insert(String::from("test_collection_short_id"), serde_json::Value::Null);
+    value.as_object_mut().unwrap().insert(
+        String::from("test_collection_short_id"),
+        serde_json::Value::Null,
+    );
 
     let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
     assert_eq!(reparsed.test_collection, None);

--- a/bundle/tests/test_collection_props_test.rs
+++ b/bundle/tests/test_collection_props_test.rs
@@ -52,3 +52,17 @@ fn serializes_test_collection_props_as_flattened_fields() {
     let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
     assert_eq!(reparsed.test_collection, base_props.test_collection);
 }
+
+#[test]
+fn omits_test_collection_fields_when_absent() {
+    let value = serde_json::to_value(build_base_props(None)).unwrap();
+    let object = value.as_object().unwrap();
+
+    assert_eq!(object.get("test_collection"), None);
+    assert_eq!(object.get("test_collection_short_id"), None);
+    assert_eq!(object.get("test_collection_bundle_meta_id"), None);
+    assert_eq!(object.get("test_collection_bundle_meta_created_at"), None);
+
+    let reparsed: BundleMetaBaseProps = serde_json::from_value(value).unwrap();
+    assert_eq!(reparsed.test_collection, None);
+}

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -13,7 +13,7 @@ use api::{client::ApiClient, message::CreateBundleUploadResponse};
 use bundle::{
     BundleMeta, BundleMetaBaseProps, BundleMetaDebugProps, BundleMetaJunitProps, BundledFile,
     FileSet, FileSetBuilder, FileSetType, INTERNAL_BIN_FILENAME, META_VERSION,
-    QuarantineBulkTestStatus, bin_parse,
+    QuarantineBulkTestStatus, TestCollectionProps, bin_parse,
 };
 use codeowners::{CodeOwners, OwnersSource};
 use constants::{ENVS_TO_GET, TRUNK_PR_NUMBER_ENV};
@@ -118,7 +118,7 @@ pub fn gather_initial_test_context(
         bazel_bep_path,
         test_reports,
         org_url_slug,
-        test_collection_short_id,
+        test_collection_short_id: _test_collection_short_id,
         repo_root,
         repo_url,
         repo_head_sha,
@@ -165,12 +165,10 @@ pub fn gather_initial_test_context(
         junit_props: BundleMetaJunitProps::default(),
         debug_props,
         bundle_upload_id_v2: String::with_capacity(0),
-        test_collection_bundle_meta_id: None,
-        test_collection_bundle_meta_created_at: None,
         base_props: BundleMetaBaseProps {
             version: META_VERSION.to_string(),
             org: org_url_slug,
-            test_collection_short_id,
+            test_collection: None,
             repo,
             cli_version: format!(
                 "cargo={} git={} rustc={}",
@@ -798,6 +796,7 @@ pub async fn gather_exit_code_and_quarantined_tests_context(
 
 pub async fn gather_upload_id_context(
     meta: &mut BundleMeta,
+    requested_test_collection_short_id: Option<String>,
     api_client: &ApiClient,
     dry_run: bool,
 ) -> anyhow::Result<CreateBundleUploadResponse> {
@@ -812,16 +811,25 @@ pub async fn gather_upload_id_context(
             client_version: format!("trunk-analytics-cli {}", meta.base_props.cli_version),
             remote_urls: vec![meta.base_props.repo.repo_url.clone()],
             external_id,
-            test_collection_short_id: meta.base_props.test_collection_short_id.clone(),
+            test_collection_short_id: requested_test_collection_short_id.clone(),
         })
         .await?;
     meta.base_props.bundle_upload_id.clone_from(&upload.id);
     meta.bundle_upload_id_v2.clone_from(&upload.id_v2);
-    if meta.base_props.test_collection_short_id.is_some() {
-        meta.test_collection_bundle_meta_id = upload.test_collection_bundle_meta_id.clone();
-        meta.test_collection_bundle_meta_created_at =
-            upload.test_collection_bundle_meta_created_at.clone();
-    }
+    meta.base_props.test_collection = match (
+        requested_test_collection_short_id,
+        upload.test_collection_bundle_meta_id.clone(),
+        upload.test_collection_bundle_meta_created_at.clone(),
+    ) {
+        (Some(short_id), Some(bundle_meta_id), Some(bundle_meta_created_at)) => {
+            Some(TestCollectionProps {
+                short_id,
+                bundle_meta_id,
+                bundle_meta_created_at,
+            })
+        }
+        _ => None,
+    };
     Ok(upload)
 }
 

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -118,7 +118,6 @@ pub fn gather_initial_test_context(
         bazel_bep_path,
         test_reports,
         org_url_slug,
-        test_collection_short_id: _test_collection_short_id,
         repo_root,
         repo_url,
         repo_head_sha,

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -165,6 +165,8 @@ pub fn gather_initial_test_context(
         junit_props: BundleMetaJunitProps::default(),
         debug_props,
         bundle_upload_id_v2: String::with_capacity(0),
+        test_collection_bundle_meta_id: None,
+        test_collection_bundle_meta_created_at: None,
         base_props: BundleMetaBaseProps {
             version: META_VERSION.to_string(),
             org: org_url_slug,
@@ -810,10 +812,16 @@ pub async fn gather_upload_id_context(
             client_version: format!("trunk-analytics-cli {}", meta.base_props.cli_version),
             remote_urls: vec![meta.base_props.repo.repo_url.clone()],
             external_id,
+            test_collection_short_id: meta.base_props.test_collection_short_id.clone(),
         })
         .await?;
     meta.base_props.bundle_upload_id.clone_from(&upload.id);
     meta.bundle_upload_id_v2.clone_from(&upload.id_v2);
+    if meta.base_props.test_collection_short_id.is_some() {
+        meta.test_collection_bundle_meta_id = upload.test_collection_bundle_meta_id.clone();
+        meta.test_collection_bundle_meta_created_at =
+            upload.test_collection_bundle_meta_created_at.clone();
+    }
     Ok(upload)
 }
 

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -502,6 +502,7 @@ pub async fn run_upload(
     tracing::info!("Uploading test results...");
     let upload_bundle_result = upload_bundle(
         &mut meta,
+        upload_args.test_collection_short_id.clone(),
         &api_client,
         bep_result,
         quarantine_context.exit_code,
@@ -576,12 +577,19 @@ pub async fn run_upload(
 
 async fn upload_bundle(
     meta: &mut BundleMeta,
+    requested_test_collection_short_id: Option<String>,
     api_client: &ApiClient,
     bep_result: Option<BepParseResult>,
     exit_code: i32,
     dry_run: bool,
 ) -> anyhow::Result<(PathBuf, TempDir)> {
-    let upload_result = gather_upload_id_context(meta, api_client, dry_run).await;
+    let upload_result = gather_upload_id_context(
+        meta,
+        requested_test_collection_short_id,
+        api_client,
+        dry_run,
+    )
+    .await;
 
     let (
         bundle_temp_file,

--- a/cli/tests/test.rs
+++ b/cli/tests/test.rs
@@ -301,6 +301,12 @@ async fn quarantining_resets_fail_code() {
                     id_v2: String::from("test-bundle-upload-id-v2"),
                     url: format!("{host}/s3upload"),
                     key: String::from("unused"),
+                    test_collection_bundle_meta_id: Some(String::from(
+                        "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
+                    )),
+                    test_collection_bundle_meta_created_at: Some(String::from(
+                        "2026-05-10T12:34:56.000Z",
+                    )),
                 }))
             }
         },
@@ -355,6 +361,12 @@ async fn quarantining_not_active_when_disable_quarantining_set() {
                     id_v2: String::from("test-bundle-upload-id-v2"),
                     url: format!("{host}/s3upload"),
                     key: String::from("unused"),
+                    test_collection_bundle_meta_id: Some(String::from(
+                        "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
+                    )),
+                    test_collection_bundle_meta_created_at: Some(String::from(
+                        "2026-05-10T12:34:56.000Z",
+                    )),
                 }))
             }
         },
@@ -410,6 +422,12 @@ async fn quarantining_not_active_when_disable_true_but_use_true() {
                     id_v2: String::from("test-bundle-upload-id-v2"),
                     url: format!("{host}/s3upload"),
                     key: String::from("unused"),
+                    test_collection_bundle_meta_id: Some(String::from(
+                        "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
+                    )),
+                    test_collection_bundle_meta_created_at: Some(String::from(
+                        "2026-05-10T12:34:56.000Z",
+                    )),
                 }))
             }
         },

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -58,6 +58,8 @@ async fn upload_bundle() {
     let assert = command_builder
         .command()
         .env("GITHUB_EXTERNAL_ID", "test-external-id-123")
+        .arg("--test-collection-short-id")
+        .arg("tc_123")
         .assert()
         // should fail due to quarantine and succeed without quarantining
         .failure();
@@ -108,6 +110,10 @@ async fn upload_bundle() {
     assert!(upload_request.client_version.contains(" git="));
     assert!(upload_request.client_version.contains(" rustc="));
     assert!(upload_request.external_id.is_some());
+    assert_eq!(
+        upload_request.test_collection_short_id,
+        Some(String::from("tc_123"))
+    );
 
     let tar_extract_directory =
         assert_matches!(requests_iter.next().unwrap(), RequestPayload::S3Upload(d) => d);
@@ -149,6 +155,7 @@ async fn upload_bundle() {
         "your.email@example.com"
     );
     assert_eq!(base_props.bundle_upload_id, "test-bundle-upload-id");
+    assert_eq!(base_props.test_collection_short_id, Some(String::from("tc_123")));
     assert_eq!(base_props.tags, &[]);
     assert_eq!(base_props.file_sets.len(), 1);
     assert_eq!(junit_props.num_files, 1);
@@ -165,6 +172,15 @@ async fn upload_bundle() {
     assert!(base_props.os_info.is_some());
     assert!(base_props.quarantined_tests.is_empty());
     assert_eq!(bundle_meta.failed_tests.len(), failure_count);
+    assert_eq!(bundle_meta.bundle_upload_id_v2, "test-bundle-upload-id-v2");
+    assert_eq!(
+        bundle_meta.test_collection_bundle_meta_id,
+        Some(String::from("82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc"))
+    );
+    assert_eq!(
+        bundle_meta.test_collection_bundle_meta_created_at,
+        Some(String::from("2026-05-10T12:34:56.000Z"))
+    );
     assert_eq!(
         base_props.codeowners,
         Some(CodeOwners {
@@ -220,10 +236,14 @@ async fn upload_bundle() {
     assert_eq!(test_case_run.codeowners[0].name, "@user");
     assert_eq!(test_case_run.codeowners[1].name, "@user2");
 
+    let mut expected_command_args = command_builder.build_args();
+    expected_command_args.extend([
+        String::from("--test-collection-short-id"),
+        String::from("tc_123"),
+    ]);
     assert!(
         debug_props.command_line.ends_with(
-            &command_builder
-                .build_args()
+            &expected_command_args
                 .join(" ")
                 .replace("test-token", "")
                 .replace("--token", "")
@@ -265,6 +285,9 @@ async fn upload_bundle_using_bep() {
     let bundle_meta: BundleMeta = serde_json::from_reader(meta_json).unwrap();
 
     assert!(!bundle_meta.base_props.file_sets.is_empty());
+    assert_eq!(bundle_meta.base_props.test_collection_short_id, None);
+    assert_eq!(bundle_meta.test_collection_bundle_meta_id, None);
+    assert_eq!(bundle_meta.test_collection_bundle_meta_created_at, None);
     bundle_meta
         .base_props
         .file_sets
@@ -1016,6 +1039,12 @@ async fn quarantines_tests_regardless_of_upload() {
                     id_v2: String::from("test-bundle-upload-id-v2"),
                     url: format!("{host}/s3upload"),
                     key: String::from("unused"),
+                    test_collection_bundle_meta_id: Some(String::from(
+                        "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
+                    )),
+                    test_collection_bundle_meta_created_at: Some(String::from(
+                        "2026-05-10T12:34:56.000Z",
+                    )),
                 })
                 .into_response()
             }
@@ -1629,6 +1658,12 @@ async fn do_not_quarantines_tests_when_quarantine_disabled_set() {
                         id_v2: String::from("test-bundle-upload-id-v2"),
                         url: format!("{host}/s3upload"),
                         key: String::from("unused"),
+                        test_collection_bundle_meta_id: Some(String::from(
+                            "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
+                        )),
+                        test_collection_bundle_meta_created_at: Some(String::from(
+                            "2026-05-10T12:34:56.000Z",
+                        )),
                     }))
                 }
             };

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -11,7 +11,7 @@ use assert_matches::assert_matches;
 use axum::body::{Body, Bytes};
 use axum::response::IntoResponse;
 use axum::{Json, extract::State, http::StatusCode, response::Response};
-use bundle::{BundleMeta, FileSetType, INTERNAL_BIN_FILENAME};
+use bundle::{BundleMeta, FileSetType, INTERNAL_BIN_FILENAME, TestCollectionProps};
 use chrono::{DateTime, TimeDelta};
 use clap::Parser;
 mod common;
@@ -156,8 +156,12 @@ async fn upload_bundle() {
     );
     assert_eq!(base_props.bundle_upload_id, "test-bundle-upload-id");
     assert_eq!(
-        base_props.test_collection_short_id,
-        Some(String::from("tc_123"))
+        base_props.test_collection,
+        Some(TestCollectionProps {
+            short_id: String::from("tc_123"),
+            bundle_meta_id: String::from("82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc"),
+            bundle_meta_created_at: String::from("2026-05-10T12:34:56.000Z"),
+        })
     );
     assert_eq!(base_props.tags, &[]);
     assert_eq!(base_props.file_sets.len(), 1);
@@ -176,14 +180,6 @@ async fn upload_bundle() {
     assert!(base_props.quarantined_tests.is_empty());
     assert_eq!(bundle_meta.failed_tests.len(), failure_count);
     assert_eq!(bundle_meta.bundle_upload_id_v2, "test-bundle-upload-id-v2");
-    assert_eq!(
-        bundle_meta.test_collection_bundle_meta_id,
-        Some(String::from("82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc"))
-    );
-    assert_eq!(
-        bundle_meta.test_collection_bundle_meta_created_at,
-        Some(String::from("2026-05-10T12:34:56.000Z"))
-    );
     assert_eq!(
         base_props.codeowners,
         Some(CodeOwners {
@@ -288,9 +284,7 @@ async fn upload_bundle_using_bep() {
     let bundle_meta: BundleMeta = serde_json::from_reader(meta_json).unwrap();
 
     assert!(!bundle_meta.base_props.file_sets.is_empty());
-    assert_eq!(bundle_meta.base_props.test_collection_short_id, None);
-    assert_eq!(bundle_meta.test_collection_bundle_meta_id, None);
-    assert_eq!(bundle_meta.test_collection_bundle_meta_created_at, None);
+    assert_eq!(bundle_meta.base_props.test_collection, None);
     bundle_meta
         .base_props
         .file_sets
@@ -374,6 +368,78 @@ async fn upload_bundle_using_bep() {
 
     // HINT: View CLI output with `cargo test -- --nocapture`
     println!("{assert}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upload_bundle_without_canonical_test_collection_metadata_keeps_bundle_group_empty() {
+    let temp_dir = tempdir().unwrap();
+    generate_mock_git_repo(&temp_dir);
+    generate_mock_valid_junit_xmls(&temp_dir);
+    generate_mock_codeowners(&temp_dir);
+
+    let mut mock_server_builder = MockServerBuilder::new();
+    mock_server_builder.set_create_bundle_handler(
+        |State(state): State<SharedMockServerState>,
+         Json(create_bundle_upload_request): Json<CreateBundleUploadRequest>| async move {
+            state
+                .requests
+                .lock()
+                .unwrap()
+                .push(RequestPayload::CreateBundleUpload(
+                    create_bundle_upload_request,
+                ));
+
+            let host = &state.host;
+            Ok::<Json<CreateBundleUploadResponse>, String>(Json(CreateBundleUploadResponse {
+                id: String::from("test-bundle-upload-id"),
+                id_v2: String::from("test-bundle-upload-id-v2"),
+                url: format!("{host}/s3upload"),
+                key: String::from("unused"),
+                test_collection_bundle_meta_id: None,
+                test_collection_bundle_meta_created_at: None,
+            }))
+        },
+    );
+    let state = mock_server_builder.spawn_mock_server().await;
+
+    CommandBuilder::upload(temp_dir.path(), state.host.clone())
+        .command()
+        .arg("--test-collection-short-id")
+        .arg("tc_123")
+        .assert()
+        .failure();
+
+    let requests = state.requests.lock().unwrap().clone();
+    let upload_request = requests
+        .into_iter()
+        .find_map(|request| match request {
+            RequestPayload::CreateBundleUpload(upload_request) => Some(upload_request),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(
+        upload_request.test_collection_short_id,
+        Some(String::from("tc_123"))
+    );
+
+    let tar_extract_directory = state
+        .requests
+        .lock()
+        .unwrap()
+        .clone()
+        .into_iter()
+        .find_map(|request| match request {
+            RequestPayload::S3Upload(path) => Some(path),
+            _ => None,
+        })
+        .unwrap();
+
+    let file = fs::File::open(tar_extract_directory.join("meta.json")).unwrap();
+    let reader = BufReader::new(file);
+    let bundle_meta: BundleMeta = serde_json::from_reader(reader).unwrap();
+
+    assert_eq!(bundle_meta.base_props.test_collection, None);
+    assert_eq!(bundle_meta.bundle_upload_id_v2, "test-bundle-upload-id-v2");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -155,7 +155,10 @@ async fn upload_bundle() {
         "your.email@example.com"
     );
     assert_eq!(base_props.bundle_upload_id, "test-bundle-upload-id");
-    assert_eq!(base_props.test_collection_short_id, Some(String::from("tc_123")));
+    assert_eq!(
+        base_props.test_collection_short_id,
+        Some(String::from("tc_123"))
+    );
     assert_eq!(base_props.tags, &[]);
     assert_eq!(base_props.file_sets.len(), 1);
     assert_eq!(junit_props.num_files, 1);

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -127,6 +127,7 @@ const generateBundleMeta = (): TestBundleMeta => ({
   use_uncloned_repo: null,
   upload_time_epoch: faker.number.int(),
   tags: [],
+  test_collection_short_id: null,
   test_command: faker.hacker.verb(),
 });
 

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -15,6 +15,7 @@ import {
   VersionedBundle,
   TestRunnerReportStatus,
   FileSet,
+  BundleMetaBaseProps,
 } from "../pkg/context_js";
 
 // eslint-disable-next-line vitest/require-hook
@@ -31,105 +32,111 @@ type RecursiveOmit<T, K extends PropertyKey> = T extends unknown[]
         : T[P];
     };
 
-type TestBundleMeta = Omit<RecursiveOmit<VersionedBundle, "free">, "schema">;
+type OmitWasmUtils<T> = RecursiveOmit<T, "free" | SymbolConstructor["dispose"]>;
 
-const generateBundleMeta = (): TestBundleMeta => ({
-  version: "1",
-  bundle_upload_id: faker.string.uuid(),
-  cli_version: faker.system.semver(),
-  envs: {
-    RUNNER_OS: "Linux",
-    GITHUB_REF: "refs/heads/main",
-  },
-  file_sets: [
-    {
-      file_set_type: "Junit",
-      files: [
-        {
-          original_path: "/abs/path/junit.xml",
-          original_path_rel: "junit.xml",
-          path: "0.xml",
-          owners: ["owner"],
-          team: "team",
-        },
-      ],
-      glob: "**/*.xml",
-      resolved_status: "Passed",
-      resolved_start_time_epoch_ms: dayjs.utc().subtract(5, "minute").valueOf(),
-      resolved_end_time_epoch_ms: dayjs.utc().subtract(2, "minute").valueOf(),
-      resolved_label: null,
+const generateBundleMeta = () =>
+  ({
+    version: "1",
+    bundle_upload_id: faker.string.uuid(),
+    cli_version: faker.system.semver(),
+    envs: {
+      RUNNER_OS: "Linux",
+      GITHUB_REF: "refs/heads/main",
     },
-    {
-      file_set_type: "Junit",
-      files: [
-        {
-          original_path: "/abs/path/junit.xml",
-          original_path_rel: "junit.xml",
-          path: "0.xml",
-          owners: ["owner"],
-          team: "team",
-        },
-      ],
-      glob: "**/*.xml",
-      resolved_status: "Passed",
+    file_sets: [
+      {
+        file_set_type: "Junit",
+        files: [
+          {
+            original_path: "/abs/path/junit.xml",
+            original_path_rel: "junit.xml",
+            path: "0.xml",
+            owners: ["owner"],
+            team: "team",
+          },
+        ],
+        glob: "**/*.xml",
+        resolved_status: "Passed",
+        resolved_start_time_epoch_ms: dayjs
+          .utc()
+          .subtract(5, "minute")
+          .valueOf(),
+        resolved_end_time_epoch_ms: dayjs.utc().subtract(2, "minute").valueOf(),
+        resolved_label: null,
+      },
+      {
+        file_set_type: "Junit",
+        files: [
+          {
+            original_path: "/abs/path/junit.xml",
+            original_path_rel: "junit.xml",
+            path: "0.xml",
+            owners: ["owner"],
+            team: "team",
+          },
+        ],
+        glob: "**/*.xml",
+        resolved_status: "Passed",
+      },
+      {
+        file_set_type: "Junit",
+        files: [
+          {
+            original_path: "/abs/path/junit.xml",
+            original_path_rel: "junit.xml",
+            path: "0.xml",
+            owners: ["owner"],
+            team: "team",
+          },
+        ],
+        glob: "**/*.xml",
+        // NOTE: This is intentional to test backwards compatibility with old bundles
+        resolved_status: null as unknown as TestRunnerReportStatus,
+      },
+      {
+        file_set_type: "Junit",
+        files: [
+          {
+            original_path: "/abs/path/junit.xml",
+            original_path_rel: "junit.xml",
+            path: "0.xml",
+            owners: ["owner"],
+            team: "team",
+          },
+        ],
+        glob: "**/*.xml",
+      },
+    ],
+    org: faker.company.name(),
+    os_info: process.platform,
+    quarantined_tests: [],
+    codeowners: {
+      path: faker.system.filePath(),
     },
-    {
-      file_set_type: "Junit",
-      files: [
-        {
-          original_path: "/abs/path/junit.xml",
-          original_path_rel: "junit.xml",
-          path: "0.xml",
-          owners: ["owner"],
-          team: "team",
-        },
-      ],
-      glob: "**/*.xml",
-      // NOTE: This is intentional to test backwards compatibility with old bundles
-      resolved_status: null as unknown as TestRunnerReportStatus,
-    },
-    {
-      file_set_type: "Junit",
-      files: [
-        {
-          original_path: "/abs/path/junit.xml",
-          original_path_rel: "junit.xml",
-          path: "0.xml",
-          owners: ["owner"],
-          team: "team",
-        },
-      ],
-      glob: "**/*.xml",
-    },
-  ],
-  org: faker.company.name(),
-  os_info: process.platform,
-  quarantined_tests: [],
-  codeowners: {
-    path: faker.system.filePath(),
-  },
-  repo: {
-    repo_head_branch: faker.git.branch(),
-    repo_head_sha: faker.git.commitSha(),
-    repo_head_sha_short: faker.git.commitSha().slice(0, 7),
-    repo_head_author_email: faker.internet.email(),
-    repo_head_author_name: faker.person.fullName(),
-    repo_head_commit_message: faker.lorem.sentence(),
-    repo_head_commit_epoch: faker.number.bigInt(),
-    repo_root: faker.system.directoryPath(),
-    repo_url: faker.internet.url(),
     repo: {
-      host: "github.com",
-      owner: faker.company.name(),
-      name: faker.company.catchPhraseNoun(),
+      repo_head_branch: faker.git.branch(),
+      repo_head_sha: faker.git.commitSha(),
+      repo_head_sha_short: faker.git.commitSha().slice(0, 7),
+      repo_head_author_email: faker.internet.email(),
+      repo_head_author_name: faker.person.fullName(),
+      repo_head_commit_message: faker.lorem.sentence(),
+      repo_head_commit_epoch: faker.number.bigInt(),
+      repo_root: faker.system.directoryPath(),
+      repo_url: faker.internet.url(),
+      repo: {
+        host: "github.com",
+        owner: faker.company.name(),
+        name: faker.company.catchPhraseNoun(),
+      },
+      use_uncloned_repo: undefined,
     },
-  },
-  use_uncloned_repo: null,
-  upload_time_epoch: faker.number.int(),
-  tags: [],
-  test_collection_short_id: null,
-  test_command: faker.hacker.verb(),
-});
+    use_uncloned_repo: null,
+    upload_time_epoch: faker.number.int(),
+    tags: [],
+    // NOTE: This is intentional to test backwards compatibility with old bundles
+    test_collection_short_id: null as unknown as string,
+    test_command: faker.hacker.verb(),
+  }) as const satisfies OmitWasmUtils<BundleMetaBaseProps>;
 
 const bundleMetaJsonSerializer = (_key: unknown, value: unknown) =>
   typeof value === "bigint" ? Number(value) : value;
@@ -179,43 +186,54 @@ const compressAndUploadMeta = async ({
   return readableStream;
 };
 
-describe("context-js", () => {
-  type Versions = Pick<VersionedBundle, "schema">["schema"];
-  const versionTests: [Versions, Partial<VersionedBundle>][] = [
-    ["V0_5_29", {}],
-    [
-      "V0_5_34",
-      { num_tests: faker.number.int(100), num_files: faker.number.int(100) },
-    ],
-    [
-      "V0_6_2",
-      {
-        num_tests: faker.number.int(100),
-        num_files: faker.number.int(100),
-        command_line: "trunk-analytics-cli upload --token=***",
-      },
-    ],
-    [
-      "V0_7_7",
-      {
-        num_tests: faker.number.int(100),
-        num_files: faker.number.int(100),
-        command_line: "trunk-analytics-cli upload --token=***",
-        bundle_upload_id_v2: "SOME ID",
-        variant: null,
-        internal_bundled_file: null,
-      },
-    ],
-  ];
+const VERSION_TESTS = [
+  { schema: "V0_5_29", ...generateBundleMeta() },
+  {
+    schema: "V0_5_34",
+    ...generateBundleMeta(),
+    num_tests: faker.number.int(100),
+    num_files: faker.number.int(100),
+  },
+  {
+    schema: "V0_6_2",
+    ...generateBundleMeta(),
+    num_tests: faker.number.int(100),
+    num_files: faker.number.int(100),
+    command_line: "trunk-analytics-cli upload --token=***",
+  },
+  {
+    schema: "V0_7_7",
+    ...generateBundleMeta(),
+    num_tests: faker.number.int(100),
+    num_files: faker.number.int(100),
+    command_line: "trunk-analytics-cli upload --token=***",
+    bundle_upload_id_v2: "SOME ID",
+    variant: null,
+    internal_bundled_file: null,
+  },
+  {
+    schema: "V0_7_8",
+    ...generateBundleMeta(),
+    num_tests: faker.number.int(100),
+    num_files: faker.number.int(100),
+    command_line: "trunk-analytics-cli upload --token=***",
+    bundle_upload_id_v2: "SOME ID",
+    variant: null,
+    internal_bundled_file: null,
+    failed_tests: [],
+  },
+] as const satisfies VersionedBundle[];
 
-  const createExpectedVersionedBundle = (
-    schema: Versions,
-    uploadMeta: TestBundleMeta,
-  ) => {
-    const expectedMeta = {
-      schema,
-      ...uploadMeta,
-      file_sets: uploadMeta.file_sets.map((fileSet) => {
+const createExpectedVersionedBundle = (
+  bundleMeta: OmitWasmUtils<BundleMetaBaseProps>,
+) => {
+  const { repo: bundleMetaRepo, ...restBundleMeta } = bundleMeta;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { use_uncloned_repo: _, ...restBundleMetaRepo } = bundleMetaRepo;
+  const expectedMeta = {
+    ...restBundleMeta,
+    file_sets: restBundleMeta.file_sets.map(
+      (fileSet): OmitWasmUtils<FileSet> => {
         if (!("resolved_status" in fileSet)) {
           return fileSet;
         }
@@ -246,28 +264,39 @@ describe("context-js", () => {
               }
             : {}),
         };
-      }) as FileSet[],
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      upload_time_epoch: expect.any(Number),
-    };
-
+      },
+    ),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    expectedMeta.repo.repo_head_commit_epoch = expect.any(Number);
-    if (expectedMeta.test_collection_short_id === null) {
-      delete expectedMeta.test_collection_short_id;
-    }
-
-    return expectedMeta;
+    upload_time_epoch: expect.any(Number),
+    repo: {
+      ...restBundleMetaRepo,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      repo_head_commit_epoch: expect.any(Number),
+    },
   };
 
-  it.each(versionTests)(
+  // NOTE: This is intentional to test backwards compatibility with old bundles
+  if (
+    "test_collection_short_id" in expectedMeta &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    expectedMeta.test_collection_short_id === null
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { test_collection_short_id: __, ...restExpectedMeta } = expectedMeta;
+    return restExpectedMeta;
+  }
+
+  return expectedMeta;
+};
+
+describe("context-js", () => {
+  it.each(VERSION_TESTS)(
     "decompresses and parses meta.json %s",
-    async (schema, extras) => {
+    async (versionedBundle) => {
       expect.hasAssertions();
 
-      const uploadMeta = { ...generateBundleMeta(), ...extras };
       const metaInfoJson = JSON.stringify(
-        uploadMeta,
+        versionedBundle,
         bundleMetaJsonSerializer,
         2,
       );
@@ -277,7 +306,7 @@ describe("context-js", () => {
       });
 
       const res = await parse_meta_from_tarball(readableStream);
-      const expectedMeta = createExpectedVersionedBundle(schema, uploadMeta);
+      const expectedMeta = createExpectedVersionedBundle(versionedBundle);
 
       expect(res).toStrictEqual(expectedMeta);
     },
@@ -339,19 +368,18 @@ describe("context-js", () => {
   it("decompresses and parses both meta.json and internal.bin", async () => {
     expect.hasAssertions();
 
-    const uploadMeta = {
+    const versionedBundle = {
+      schema: "V0_7_7",
       ...generateBundleMeta(),
-      ...{
-        num_tests: faker.number.int(100),
-        num_files: faker.number.int(100),
-        command_line: "trunk-analytics-cli upload --token=***",
-        bundle_upload_id_v2: "SOME ID",
-        variant: "some-variant",
-        internal_bundled_file: null,
-      },
-    };
+      num_tests: faker.number.int(100),
+      num_files: faker.number.int(100),
+      command_line: "trunk-analytics-cli upload --token=***",
+      bundle_upload_id_v2: "SOME ID",
+      variant: "some-variant",
+      internal_bundled_file: null,
+    } as const satisfies VersionedBundle;
     const metaInfoJson = JSON.stringify(
-      uploadMeta,
+      versionedBundle,
       bundleMetaJsonSerializer,
       2,
     );
@@ -363,7 +391,7 @@ describe("context-js", () => {
     const { bindings_report, versioned_bundle } =
       await parse_internal_bin_and_meta_from_tarball(readableStream);
 
-    const expectedMeta = createExpectedVersionedBundle("V0_7_7", uploadMeta);
+    const expectedMeta = createExpectedVersionedBundle(versionedBundle);
 
     expect(versioned_bundle).toStrictEqual(expectedMeta);
 

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -127,7 +127,6 @@ const generateBundleMeta = (): TestBundleMeta => ({
   use_uncloned_repo: null,
   upload_time_epoch: faker.number.int(),
   tags: [],
-  test_collection_short_id: null,
   test_command: faker.hacker.verb(),
 });
 

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -253,6 +253,9 @@ describe("context-js", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     expectedMeta.repo.repo_head_commit_epoch = expect.any(Number);
+    if (expectedMeta.test_collection_short_id === null) {
+      delete expectedMeta.test_collection_short_id;
+    }
 
     return expectedMeta;
   };

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -293,6 +293,7 @@ def test_parse_and_dump_meta_roundtrip():
         },
         "schema": "V0_5_29",
         "tags": [],
+        "test_collection_short_id": None,
         "test_command": None,
         "upload_time_epoch": 1721095230,
         "use_uncloned_repo": None,

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -301,10 +301,13 @@ def test_parse_and_dump_meta_roundtrip():
     }
 
     valid_meta_str = json.dumps(valid_meta, sort_keys=True)
+    expected_meta = dict(valid_meta)
+    expected_meta.pop("test_collection_short_id")
+    expected_meta_str = json.dumps(expected_meta, sort_keys=True)
     bundle_meta = parse_meta(valid_meta_str.encode())
     assert (
         json.dumps(json.loads(bundle_meta.dump_json()), sort_keys=True)
-        == valid_meta_str
+        == expected_meta_str
     )
 
 

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -293,7 +293,6 @@ def test_parse_and_dump_meta_roundtrip():
         },
         "schema": "V0_5_29",
         "tags": [],
-        "test_collection_short_id": None,
         "test_command": None,
         "upload_time_epoch": 1721095230,
         "use_uncloned_repo": None,

--- a/test_utils/src/mock_server.rs
+++ b/test_utils/src/mock_server.rs
@@ -168,12 +168,8 @@ pub async fn create_bundle_handler(
         id_v2: String::from("test-bundle-upload-id-v2"),
         url: format!("{host}/s3upload"),
         key: String::from("unused"),
-        test_collection_bundle_meta_id: Some(String::from(
-            "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
-        )),
-        test_collection_bundle_meta_created_at: Some(String::from(
-            "2026-05-10T12:34:56.000Z",
-        )),
+        test_collection_bundle_meta_id: Some(String::from("82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc")),
+        test_collection_bundle_meta_created_at: Some(String::from("2026-05-10T12:34:56.000Z")),
     })
 }
 

--- a/test_utils/src/mock_server.rs
+++ b/test_utils/src/mock_server.rs
@@ -168,6 +168,12 @@ pub async fn create_bundle_handler(
         id_v2: String::from("test-bundle-upload-id-v2"),
         url: format!("{host}/s3upload"),
         key: String::from("unused"),
+        test_collection_bundle_meta_id: Some(String::from(
+            "82c6a6e5-f8ea-4d93-9a26-b8ab6ff8f6bc",
+        )),
+        test_collection_bundle_meta_created_at: Some(String::from(
+            "2026-05-10T12:34:56.000Z",
+        )),
     })
 }
 


### PR DESCRIPTION
## Summary
- send `testCollectionShortId` during upload init and accept prefixed canonical test-collection bundle metadata fields in the response
- write `test_collection_bundle_meta_id` and `test_collection_bundle_meta_created_at` into bundle metadata only for test-collection uploads
- update upload and mock-server tests for the new request and bundle fields

## Testing
- `cargo test -p trunk-analytics-cli upload_bundle -- --nocapture`