### PR TITLE
Fix pyo3 Linux wheel cache compatibility

### DIFF
--- a/.github/actions/setup_rust_cargo/action.yaml
+++ b/.github/actions/setup_rust_cargo/action.yaml
@@ -1,6 +1,12 @@
 name: Setup Rust & Cargo
 description: Setup Rust & Cargo
 
+inputs:
+  cache-key:
+    description: Additional rust-cache key for splitting caches between workflow variants.
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -16,3 +22,5 @@ runs:
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ inputs.cache-key }}

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -55,7 +55,10 @@ jobs:
           python-version: 3.13
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
+        with:
+          cache-key: pyo3-linux-${{ matrix.platform.target }}
       - name: Generate Python stubs
+        if: matrix.platform.target == 'aarch64'
         run: cargo run --bin stub_gen --manifest-path context-py/Cargo.toml --no-default-features
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -71,6 +74,8 @@ jobs:
             if command -v yum &> /dev/null; then
               # manylinux_2_28 x86_64 (AlmaLinux 8)
               yum -y install perl-IPC-Cmd openssl-devel python3-pip unzip
+              # Keep x86_64 stub generation on the same libc/toolchain as the wheel build.
+              cargo run --bin stub_gen --manifest-path context-py/Cargo.toml --no-default-features
             elif command -v apt &> /dev/null; then
               # manylinux_2_28 cross-compile (aarch64)
               apt update


### PR DESCRIPTION
## Summary
- split the rust-cache key for the pyo3 Linux workflow by target so x86_64 and aarch64 do not share one target cache
- run x86_64 `stub_gen` inside the manylinux_2_28 container so cached Rust artifacts match the wheel build libc environment
- keep aarch64 stub generation on the host path used by the cross build

## Testing
- `git diff --check -- .github/actions/setup_rust_cargo/action.yaml .github/workflows/pyo3.yml`
- local commit hook checks passed on modified files