### PR TITLE
(Fix): Strip ansi colors from rspec exceptions

### DIFF
--- a/.github/actions/test_ruby_gem_uploads/Gemfile
+++ b/.github/actions/test_ruby_gem_uploads/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'rspec'
+gem 'coderay'
 gem 'knapsack_pro'
 gem 'rake'
 gem 'rake-compiler'

--- a/.github/actions/test_ruby_gem_uploads/Gemfile.lock
+++ b/.github/actions/test_ruby_gem_uploads/Gemfile.lock
@@ -1,0 +1,52 @@
+PATH
+  remote: ../../../rspec-trunk-flaky-tests
+  specs:
+    rspec_trunk_flaky_tests (0.0.0)
+      rb_sys (= 0.9.124)
+      rspec-core (> 3.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.3)
+    diff-lcs (1.6.2)
+    knapsack_pro (10.0.0)
+      rake
+      thor (~> 1.4)
+    logger (1.7.0)
+    rake (13.4.2)
+    rake-compiler (1.3.1)
+      rake
+    rake-compiler-dock (1.11.0)
+    rb_sys (0.9.124)
+      rake-compiler-dock (= 1.11.0)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    thor (1.5.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  coderay
+  knapsack_pro
+  logger
+  rake
+  rake-compiler
+  rspec
+  rspec_trunk_flaky_tests!
+
+BUNDLED WITH
+   2.5.23

--- a/.github/actions/test_ruby_gem_uploads/spec/test_spec.rb
+++ b/.github/actions/test_ruby_gem_uploads/spec/test_spec.rb
@@ -4,7 +4,17 @@ def square(val)
   val * val
 end
 
+ANSI_ESCAPE_PATTERN = /(?:\e[@-Z\\-_]|\e\[[0-?]*[ -\/]*[@-~])/.freeze
+
 describe 'simple_test' do
+  around do |example|
+    original_color_mode = RSpec.configuration.color_mode
+    RSpec.configuration.color_mode = :on
+    example.run
+  ensure
+    RSpec.configuration.color_mode = original_color_mode
+  end
+
   [1, 2, 3].each do |i|
     it do
       expect(square(i)).to eq(i * i)

--- a/.github/actions/test_ruby_gem_uploads/spec/test_spec.rb
+++ b/.github/actions/test_ruby_gem_uploads/spec/test_spec.rb
@@ -4,8 +4,6 @@ def square(val)
   val * val
 end
 
-ANSI_ESCAPE_PATTERN = /(?:\e[@-Z\\-_]|\e\[[0-?]*[ -\/]*[@-~])/.freeze
-
 describe 'simple_test' do
   around do |example|
     original_color_mode = RSpec.configuration.color_mode

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -54,7 +54,7 @@ class String
   end
 end
 
-ANSI_ESCAPE_PATTERN = /(?:\e[@-Z\\-_]|\e\[[0-?]*[ -\/]*[@-~])/.freeze
+ANSI_ESCAPE_PATTERN = %r{(?:\e[@-Z\\-_]|\e\[[0-?]*[ -/]*[@-~])}
 
 def escape(str)
   str.dump[1..-2]
@@ -215,7 +215,7 @@ rescue StandardError
   legacy_format_exception_message(exception)
 end
 
-# trunk-ignore(rubocop/Metrics/MethodLength)
+# trunk-ignore(rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)
 def format_exception_backtrace(exception, example)
   return '' unless exception
 
@@ -258,7 +258,7 @@ def legacy_format_exception_message(exception)
   end
 end
 
-# trunk-ignore(rubocop/Metrics/MethodLength)
+# trunk-ignore(rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)
 def legacy_format_exception_backtrace(exception)
   case exception
   when RSpec::Core::MultipleExceptionError

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -54,8 +54,14 @@ class String
   end
 end
 
+ANSI_ESCAPE_PATTERN = /(?:\e[@-Z\\-_]|\e\[[0-?]*[ -\/]*[@-~])/.freeze
+
 def escape(str)
   str.dump[1..-2]
+end
+
+def strip_ansi_codes(text)
+  text.to_s.gsub(ANSI_ESCAPE_PATTERN, '')
 end
 
 # Knapsack example detector instantiates all test cases in order to determine how to shard them
@@ -204,7 +210,7 @@ def format_exception_message(exception, example)
   return '' unless exception
 
   presenter = RSpec::Core::Formatters::ExceptionPresenter.new(exception, example)
-  presenter.fully_formatted(nil, PlainColorizer)
+  strip_ansi_codes(presenter.fully_formatted(nil, PlainColorizer))
 rescue StandardError
   legacy_format_exception_message(exception)
 end
@@ -230,7 +236,7 @@ def format_exception_backtrace(exception, example)
   # and after hooks, so we fall back to the legacy formatter
   return legacy_format_exception_backtrace(exception) if result.strip.empty?
 
-  result
+  strip_ansi_codes(result)
 rescue StandardError
   legacy_format_exception_backtrace(exception)
 end
@@ -246,9 +252,9 @@ def legacy_format_exception_message(exception)
   case exception
   when RSpec::Core::MultipleExceptionError
     messages = exception.all_exceptions.map { |e| "#{e.class}: #{e.message}" }
-    "#{exception.class}: #{messages.join(' | ')}"
+    strip_ansi_codes("#{exception.class}: #{messages.join(' | ')}")
   else
-    exception.to_s
+    strip_ansi_codes(exception.to_s)
   end
 end
 
@@ -256,15 +262,15 @@ end
 def legacy_format_exception_backtrace(exception)
   case exception
   when RSpec::Core::MultipleExceptionError
-    exception.all_exceptions.map do |e|
+    strip_ansi_codes(exception.all_exceptions.map do |e|
       if e.backtrace && !e.backtrace.empty?
         "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
       else
         "#{e.class}: #{e.message}"
       end
-    end.join("\n\n")
+    end.join("\n\n"))
   else
-    exception.backtrace&.join("\n") || ''
+    strip_ansi_codes(exception.backtrace&.join("\n") || '')
   end
 end
 


### PR DESCRIPTION
The recent changes to use the native rspec `RSpec::Core::Formatters::ExceptionPresenter` were an improvement, but we got a report that it was including ANSI color codes. I was able to repro iff `RSpec.configuration.color_mode = :on` is set.

Additionally,
> We had to strip ANSI codes at the final serialization boundary because PlainColorizer only stops ExceptionPresenter from adding color in its wrap(...) step. RSpec can still inject ANSI earlier when it syntax-highlights the Failure/Error: source snippet, and that path is controlled by global RSpec color settings plus CodeRay, not by our custom colorizer. Since those escapes can already be embedded by the time we format test_output.message and test_output.text, the only reliable fix is to sanitize the final stored strings.

i.e. stripping the codes this way is the safest approach. I was able to repro and verify the fix. Meta note that we're getting to the point where we need a bit more code organization for the rspec gem. I will undertake that when the next fix comes up