### PR TITLE
fix(circleci): omit workflow field since CircleCI has no human-readable workflow name

### DIFF
--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -527,7 +527,6 @@ impl<'a> CIInfoParser<'a> {
             });
         self.ci_info.actor = self.get_env_var("CIRCLE_USERNAME");
 
-        self.ci_info.workflow = self.get_env_var("CIRCLE_WORKFLOW_NAME");
         self.ci_info.job = self.get_env_var("CIRCLE_JOB");
     }
 

--- a/context/src/env/parser.rs
+++ b/context/src/env/parser.rs
@@ -527,7 +527,7 @@ impl<'a> CIInfoParser<'a> {
             });
         self.ci_info.actor = self.get_env_var("CIRCLE_USERNAME");
 
-        self.ci_info.workflow = self.get_env_var("CIRCLE_WORKFLOW_ID");
+        self.ci_info.workflow = self.get_env_var("CIRCLE_WORKFLOW_NAME");
         self.ci_info.job = self.get_env_var("CIRCLE_JOB");
     }
 

--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -1282,7 +1282,7 @@ fn test_simple_circleci() {
         (String::from("CIRCLE_BUILD_NUM"), String::from("6")),
         (String::from("CIRCLE_BUILD_URL"), String::from(&build_url)),
         (
-            String::from("CIRCLE_WORKFLOW_ID"),
+            String::from("CIRCLE_WORKFLOW_NAME"),
             String::from(&workflow_id),
         ),
         (
@@ -1406,7 +1406,7 @@ fn test_circleci_pr() {
         (String::from("CIRCLE_BRANCH"), String::from(&branch)),
         (String::from("CIRCLE_BUILD_URL"), String::from(&build_url)),
         (
-            String::from("CIRCLE_WORKFLOW_ID"),
+            String::from("CIRCLE_WORKFLOW_NAME"),
             String::from(&workflow_id),
         ),
         (String::from("CIRCLE_JOB"), String::from(&job_name)),

--- a/context/tests/env.rs
+++ b/context/tests/env.rs
@@ -1265,7 +1265,6 @@ fn test_bitbucket_missing_job_url_vars() {
 fn test_simple_circleci() {
     let branch = String::from("circleci-project-setup");
     let build_url = String::from("https://circleci.com/gh/trunk-io/trunk2/6");
-    let workflow_id = String::from("5a984496-cf63-4f63-b315-5776a3186d4b");
     let job_name = String::from("unit-tests");
     let username = String::from("mmatheson");
 
@@ -1281,10 +1280,6 @@ fn test_simple_circleci() {
         (String::from("CIRCLE_USERNAME"), String::from(&username)),
         (String::from("CIRCLE_BUILD_NUM"), String::from("6")),
         (String::from("CIRCLE_BUILD_URL"), String::from(&build_url)),
-        (
-            String::from("CIRCLE_WORKFLOW_NAME"),
-            String::from(&workflow_id),
-        ),
         (
             String::from("CIRCLE_REPOSITORY_URL"),
             String::from("git@github.com:trunk-io/trunk2.git"),
@@ -1323,7 +1318,7 @@ fn test_simple_circleci() {
             author_email: None,
             commit_message: None,
             title: None,
-            workflow: Some(workflow_id),
+            workflow: None,
             job: Some(job_name),
         }
     );
@@ -1386,7 +1381,7 @@ fn test_circleci_app_job_url_for_github_hosted_build() {
             author_email: None,
             commit_message: None,
             title: None,
-            workflow: Some(workflow_id),
+            workflow: None,
             job: None,
         }
     );
@@ -1396,7 +1391,6 @@ fn test_circleci_app_job_url_for_github_hosted_build() {
 fn test_circleci_pr() {
     let branch = String::from("feature/add-feature");
     let build_url = String::from("https://circleci.com/gh/my-org/my-repo/456");
-    let workflow_id = String::from("workflow-def-456");
     let job_name = String::from("build-and-test");
     let username = String::from("janedoe");
     let pr_number = 42;
@@ -1405,10 +1399,6 @@ fn test_circleci_pr() {
         (String::from("CIRCLECI"), String::from("true")),
         (String::from("CIRCLE_BRANCH"), String::from(&branch)),
         (String::from("CIRCLE_BUILD_URL"), String::from(&build_url)),
-        (
-            String::from("CIRCLE_WORKFLOW_NAME"),
-            String::from(&workflow_id),
-        ),
         (String::from("CIRCLE_JOB"), String::from(&job_name)),
         (String::from("CIRCLE_USERNAME"), String::from(&username)),
         (String::from("CIRCLE_PR_NUMBER"), pr_number.to_string()),
@@ -1434,7 +1424,7 @@ fn test_circleci_pr() {
             author_email: None,
             commit_message: None,
             title: None,
-            workflow: Some(workflow_id),
+            workflow: None,
             job: Some(job_name),
         }
     );
@@ -1483,7 +1473,7 @@ fn test_circleci_pull_request_url_fallback() {
             author_email: None,
             commit_message: None,
             title: None,
-            workflow: Some(workflow_id),
+            workflow: None,
             job: Some(job_name),
         }
     );


### PR DESCRIPTION
## Problem

The **Job Run** column on the uploads page was displaying a raw UUID for CircleCI customers instead of a human-readable name. For example:

```
03e6d2b6-93c4-4f61-9edb-6bb3cc32f663 - feature-tests ↗
```

## Root Cause

`parse_circleci()` was setting `ci_info.workflow` from `CIRCLE_WORKFLOW_ID`, which is always a UUID. Unlike GitHub Actions (`GITHUB_WORKFLOW`) or Semaphore (`SEMAPHORE_PROJECT_NAME`), CircleCI has no built-in environment variable for a human-readable workflow name.

## Fix

Remove the `ci_info.workflow` assignment from `parse_circleci()`. The `workflow` field is left as `None`, so the Job Run column displays just the job name (e.g., `feature-tests ↗`) without a UUID prefix.

`CIRCLE_WORKFLOW_ID` is still used to construct the `job_url` — that is unchanged.

## Safety: downstream usages of `ci_info.workflow`

We searched both the `trunk` and `trunk2` repos for all usages of the `workflow` field to verify this change is safe:

**Storage** — `workflow` is stored as a nullable/defaulted column in two places: `bundle_meta.workflow` (Postgres) and `flaky_tests.upload_summary.workflow` (ClickHouse). Neither has an index, unique constraint, or foreign key on this column.

**Display** — The primary consumer is the Job Run column, assembled as `[workflow, jobName].filter(Boolean).join(" - ")` (`quarantining.ts`). With `workflow: None`, CircleCI jobs will display as `feature-tests ↗` instead of `{uuid} - feature-tests ↗`, which is the desired behavior.

**Outdated CLI version detection** — `getOutdatedVersionSources()` in `upload.ts` groups upload sources by `workflow + jobName` to detect stale CLI versions. Setting `workflow` to `None` means CircleCI sources group by job name alone. The UUID was meaningless as a grouping key, so this is an improvement.

**Proto** — `BundleUpload.workflow` is declared as `optional string` in the flaky tests service proto. An absent/null value is valid.

No filtering, sorting, deduplication, or indexing logic depends on `workflow` being populated for CircleCI specifically.

## Testing

All 32 env tests pass. 4 CircleCI-specific tests updated to assert `workflow: None`.