### PR TITLE
Update trunk.yaml: Rust and Ruby toolchain improvements

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,41 +2,41 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.8
+  version: 1.25.0
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.5
+      ref: v1.10.0
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
+    - rust@1.82.0
     - node@25.9.0
-    - python@3.10.8
-    - ruby@3.1.4
-    - rust@2025-06-30
+    - python@3.14.4
+    - ruby@4.0.5
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - rubocop@1.39.0
-    - actionlint@1.7.4
-    - bandit@1.7.10
-    - black@24.10.0
-    - checkov@3.2.296
-    - clippy@2025-06-30
-    - eslint@9.39.2
+    - rubocop@1.87.0
+    - actionlint@1.7.12
+    - bandit@1.9.4
+    - black@26.5.1
+    - checkov@3.2.532
+    - clippy@SYSTEM
+    - eslint@10.4.1
     - git-diff-check
-    - isort@5.13.2
-    - markdownlint@0.42.0
-    - osv-scanner@1.9.1
-    - prettier@3.3.3
-    - ruff@0.7.3
-    - rustfmt@2025-06-30
-    - taplo@0.9.3
-    - trufflehog@3.83.7
-    - yamllint@1.35.1
-    - pyright@1.1.389
+    - isort@8.0.1
+    - markdownlint@0.48.0
+    - osv-scanner@2.3.8
+    - prettier@3.8.3
+    - ruff@0.15.15
+    - cargo-fmt@SYSTEM
+    - taplo@0.10.0
+    - trufflehog@3.95.5
+    - yamllint@1.38.0
+    - pyright@1.1.410
   definitions:
     - name: eslint
       commands:
@@ -50,32 +50,27 @@ lint:
           target: .
           batch: false
     - name: clippy
-      runtime: rust
-      environment:
-        - name: PATH
-          list: ["${runtime}", "${env.PATH}"]
       commands:
         - name: lint
-          run:
-            cargo clippy --message-format json --locked --all-targets --all-features --
-            --cap-lints=warn --no-deps
-          output: clippy
-          target: ${parent_with(Cargo.toml)}
-          success_codes: [0, 101, 383]
-          run_from: ${target_directory}
-          disable_upstream: true
-    - name: rustfmt
-      runtime: rust
+          # Run clippy directly in CI using prepare-rs/action.yaml
+          run: cargo clippy --message-format json --locked --all-targets --all-features -- --cap-lints=warn --no-deps
+          run_when: [cli]
+          run_from: ${root_or_parent_with_regex(Cargo.lock)}
+    - name: cargo-fmt
       commands:
         - name: format
+          run: cargo fmt
+          # Run cargo fmt and check in CI using prepare-rs/action.yaml
+          run_when: [cli]
+          files: [rust]
+          run_from: ${root_or_parent_with_regex(Cargo.lock)}
           output: rewrite
-          read_output_from: stdout
-          stdin: true
-          success_codes: [0]
-          cache_results: false # sometimes caches an empty file for some reason
-          in_place: false
-          batch: false
-          run: rustfmt --edition=2024
+          batch: true
+          in_place: true
+          formatter: true
+          cache_results: false
+          sandbox_type: copy_targets
+          success_codes: [0, 1]
   ignore:
     - linters: [ALL]
       paths:
@@ -105,36 +100,14 @@ actions:
     - trunk-fmt-pre-commit
     - trunk-upgrade-available
 downloads:
-  - name: rust
+  - name: ruby-build
     downloads:
-      - os:
-          macos: apple-darwin
-          linux: unknown-linux-gnu
-        cpu:
-          x86_64: x86_64
-          arm_64: aarch64
-        url: https://static.rust-lang.org/dist/${version}/rust-nightly-${cpu}-${os}.tar.gz
-        strip_components: 2
-  - name: rust-src
-    downloads:
-      - url: https://static.rust-lang.org/dist/${version}/rust-src-nightly.tar.xz
+      - url: https://raw.githubusercontent.com/trunk-io/analytics-cli/main/.trunk/ruby-build.tar.gz
+        strip_components: 1
 tools:
-  disabled:
-    # To see why these are disabled, see
-    # https://trunk-io.slack.com/archives/C08AEDGMZNH/p1748962373354059
-    - rust-src
-    - rust
-  definitions:
-    - name: rust-src
-      download: rust-src
-      known_good_version: 2025-06-30
-      shims: [rust-src]
   runtimes:
     - ruby
     - node
   enabled:
-    - gh@2.62.0
-    - pnpm@10.33.2
-    # Update `RUST_SRC_PATH` path to `rust-src` if this is updated
-    # IfChange
-    # ThenChange .envrc
+    - gh@2.93.0
+    - pnpm@11.5.1

--- a/context-js/package.json
+++ b/context-js/package.json
@@ -26,14 +26,5 @@
     "typescript-eslint": "^8.53.1",
     "vitest": "^4.0.18",
     "wasm-pack": "^0.13.0"
-  },
-  "pnpm": {
-    "// NOTE: `wasm-pack` uses an insecure transitive `axios` dependency": "",
-    "overrides": {
-      "binary-install>axios": "0.30.2",
-      "form-data": "4.0.4",
-      "glob": "10.5.0",
-      "brace-expansion": "2.0.2"
-    }
   }
 }

--- a/context-js/pnpm-workspace.yaml
+++ b/context-js/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  esbuild: false
+  wasm-pack: false
+# NOTE: `wasm-pack` uses an insecure transitive `axios` dependency
+overrides:
+  "binary-install>axios": 0.30.2
+  "form-data": 4.0.4
+  "glob": 10.5.0
+  "brace-expansion": 2.0.2


### PR DESCRIPTION
## Summary

Stacked on #1112.

- **Rust**: Switch from hermetic nightly download to `SYSTEM`, with `cargo-fmt`/`clippy` using `run_when: [cli]` so they're skipped in CI (CI uses `prepare-rs/action.yaml` directly instead)
- **Ruby**: Switch from ruby-build (compiles from source, slow) to [jdx/ruby](https://github.com/jdx/ruby) pre-built binaries via the fake ruby-build wrapper added in #1112; bumps Ruby 3.1.4 → 4.0.5
- **rubocop**: Bump 1.39.0 → 1.87.0 alongside the Ruby upgrade
- **Everything else**: Bump all linter/tool versions to latest

## Test plan

- [x] `trunk tools install --verbose` completes with no failures
- [x] `trunk check` runs rubocop successfully on Ruby files
- [x] Rust linters (`clippy`, `cargo-fmt`) work locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)