### PR TITLE
(Chore): Attach test-collection-short-id to staging uploads

### DIFF
--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -90,7 +90,8 @@ runs:
         --org-url-slug trunk-staging-org \
         --xcresult-path smoke-test/swift/TestResults.xcresult \
         --token ${{ inputs.staging-api-token }} \
-        --test-process-exit-code $EXIT_CODE
+        --test-process-exit-code $EXIT_CODE \
+        --test-collection-short-id z2dzjLHm
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
@@ -104,7 +105,8 @@ runs:
         ./${{ inputs.cli-binary-location }} upload \
         --org-url-slug trunk-staging-org \
         --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
-        --token ${{ inputs.staging-api-token }}
+        --token ${{ inputs.staging-api-token }} \
+        --test-collection-short-id z2dzjLHm
 
     - name: Upload to staging with public repo id
       id: staging-upload-public-repo-id
@@ -136,7 +138,8 @@ runs:
         --org-url-slug trunk-staging-org \
         --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
         --token ${{ inputs.staging-api-token }} \
-        --variant smoke-test-variant
+        --variant smoke-test-variant \
+        --test-collection-short-id z2dzjLHm
         EXIT_CODE=$?
         if [ $EXIT_CODE -eq 0 ]; then
           echo "ERROR: Expected upload with variant to fail, but it succeeded"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -204,7 +204,8 @@ jobs:
              --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
              --org-url-slug trunk-staging-org \
              --token ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }} \
-             --test-process-exit-code ${{ steps.extract.outputs.test-step-outcome }}
+             --test-process-exit-code ${{ steps.extract.outputs.test-step-outcome }} \
+             --test-collection-short-id 2tYJWMu7
 
       - name: Upload results to prod using built CLI
         shell: bash


### PR DESCRIPTION
## Summary
- Add `--test-collection-short-id 2tYJWMu7` to the PR-CI staging upload in `.github/workflows/pull_request.yml` so analytics-cli's own JUnit results land in the right staging collection.
- Add `--test-collection-short-id z2dzjLHm` to the three smoke-test staging uploads in `.github/actions/perform_smoke_test/action.yaml` (Swift xcresult, baseline junit, and variant) so smoke-test runs land in their own collection.
- Skip the flag on uploads that pass `--repo-url` (the `flake-farm-staging-fork-prs` public-repo-id upload and the GitLab smoke test), since those represent data from other repos.

## Test plan
- [x] Verify CI PR run uploads to staging show up under the `2tYJWMu7` test collection.
- [ ] Verify main-branch smoke-test runs show up under the `z2dzjLHm` test collection.
- [ ] Confirm public-repo-id and GitLab smoke-test uploads remain unchanged in staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)