### PR TITLE
Upload Python test results to Trunk

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -205,7 +205,8 @@ jobs:
              --org-url-slug trunk-staging-org \
              --token ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }} \
              --test-process-exit-code ${{ steps.extract.outputs.test-step-outcome }} \
-             --test-collection-id 2tYJWMu7
+             --test-collection-id 2tYJWMu7 \
+             --variant ${{ matrix.platform.target }}
 
       - name: Upload results to prod using built CLI
         shell: bash
@@ -217,7 +218,8 @@ jobs:
             --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
             --org-url-slug trunk \
             --token ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }} \
-            --test-collection-id EWhNPVic
+            --test-collection-id EWhNPVic \
+            --variant ${{ matrix.platform.target }}
 
   trunk_check_runner:
     name: Trunk Check runner [linux]

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -141,6 +141,7 @@ jobs:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           api-address: https://api.trunk-staging.io
           test-collection-id: 6E6WINjl
+          variant: ${{ matrix.platform.target }}
 
       - name: Upload x86_64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64') && github.event_name != 'pull_request'"
@@ -150,6 +151,7 @@ jobs:
           org-url-slug: trunk
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           test-collection-id: 68IdP3pq
+          variant: ${{ matrix.platform.target }}
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'aarch64') }}
@@ -180,6 +182,7 @@ jobs:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           api-address: https://api.trunk-staging.io
           test-collection-id: 6E6WINjl
+          variant: ${{ matrix.platform.target }}
 
       - name: Upload aarch64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64') && github.event_name != 'pull_request'"
@@ -189,6 +192,7 @@ jobs:
           org-url-slug: trunk
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           test-collection-id: 68IdP3pq
+          variant: ${{ matrix.platform.target }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -130,7 +130,7 @@ jobs:
           source .venv/bin/activate
           uv pip install -r requirements-dev.txt
           uv pip install context-py --find-links ../dist --force-reinstall
-          pytest --cov
+          pytest --cov --junitxml=junit.xml
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'aarch64') }}
@@ -150,7 +150,26 @@ jobs:
             source .venv/bin/activate
             uv pip install -r requirements-dev.txt
             uv pip install context-py --find-links ../dist --force-reinstall
-            pytest --cov
+            pytest --cov --junitxml=junit.xml
+
+      - name: Upload test results to staging
+        if: "!cancelled()"
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: context-py/junit.xml
+          org-url-slug: trunk-staging-org
+          token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          api-address: https://api.trunk-staging.io
+          test-collection-id: 6E6WINjl
+
+      - name: Upload test results to prod
+        if: "!cancelled() && github.event_name != 'pull_request'"
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: context-py/junit.xml
+          org-url-slug: trunk
+          token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
+          test-collection-id: 68IdP3pq
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload x86_64 test results to staging
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64')"
-        uses: trunk-io/analytics-uploader@v2
+        uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: context-py/junit.xml
           org-url-slug: trunk-staging-org
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload x86_64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64') && github.event_name != 'pull_request'"
-        uses: trunk-io/analytics-uploader@v2
+        uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: context-py/junit.xml
           org-url-slug: trunk
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload aarch64 test results to staging
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64')"
-        uses: trunk-io/analytics-uploader@v2
+        uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: context-py/junit.xml
           org-url-slug: trunk-staging-org
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload aarch64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64') && github.event_name != 'pull_request'"
-        uses: trunk-io/analytics-uploader@v2
+        uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: context-py/junit.xml
           org-url-slug: trunk

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -132,6 +132,25 @@ jobs:
           uv pip install context-py --find-links ../dist --force-reinstall
           pytest --cov --junitxml=junit.xml
 
+      - name: Upload x86_64 test results to staging
+        if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64')"
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: context-py/junit.xml
+          org-url-slug: trunk-staging-org
+          token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          api-address: https://api.trunk-staging.io
+          test-collection-id: 6E6WINjl
+
+      - name: Upload x86_64 test results to prod
+        if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64') && github.event_name != 'pull_request'"
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: context-py/junit.xml
+          org-url-slug: trunk
+          token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
+          test-collection-id: 68IdP3pq
+
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'aarch64') }}
         uses: uraimo/run-on-arch-action@v2
@@ -152,8 +171,8 @@ jobs:
             uv pip install context-py --find-links ../dist --force-reinstall
             pytest --cov --junitxml=junit.xml
 
-      - name: Upload test results to staging
-        if: "!cancelled()"
+      - name: Upload aarch64 test results to staging
+        if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64')"
         uses: trunk-io/analytics-uploader@v2
         with:
           junit-paths: context-py/junit.xml
@@ -162,8 +181,8 @@ jobs:
           api-address: https://api.trunk-staging.io
           test-collection-id: 6E6WINjl
 
-      - name: Upload test results to prod
-        if: "!cancelled() && github.event_name != 'pull_request'"
+      - name: Upload aarch64 test results to prod
+        if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64') && github.event_name != 'pull_request'"
         uses: trunk-io/analytics-uploader@v2
         with:
           junit-paths: context-py/junit.xml

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -139,9 +139,10 @@ jobs:
           junit-paths: context-py/junit.xml
           org-url-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-          api-address: https://api.trunk-staging.io
           test-collection-id: 6E6WINjl
           variant: ${{ matrix.platform.target }}
+        env:
+          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Upload x86_64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64') && github.event_name != 'pull_request'"
@@ -152,6 +153,8 @@ jobs:
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           test-collection-id: 68IdP3pq
           variant: ${{ matrix.platform.target }}
+        env:
+          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
 
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'aarch64') }}
@@ -180,9 +183,10 @@ jobs:
           junit-paths: context-py/junit.xml
           org-url-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-          api-address: https://api.trunk-staging.io
           test-collection-id: 6E6WINjl
           variant: ${{ matrix.platform.target }}
+        env:
+          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Upload aarch64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64') && github.event_name != 'pull_request'"
@@ -193,6 +197,8 @@ jobs:
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           test-collection-id: 68IdP3pq
           variant: ${{ matrix.platform.target }}
+        env:
+          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -113,6 +113,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust & Cargo
+        uses: ./.github/actions/setup_rust_cargo
+
+      - name: Build CLI
+        run: cargo build -p trunk-analytics-cli
+
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
@@ -134,25 +140,25 @@ jobs:
 
       - name: Upload x86_64 test results to staging
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64')"
-        uses: trunk-io/analytics-uploader@main
-        with:
-          junit-paths: context-py/junit.xml
-          org-url-slug: trunk-staging-org
-          token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-          test-collection-id: 6E6WINjl
-          variant: ${{ matrix.platform.target }}
+        run: |
+          ./target/debug/trunk-analytics-cli upload \
+            --junit-paths context-py/junit.xml \
+            --org-url-slug trunk-staging-org \
+            --token ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }} \
+            --test-collection-id 6E6WINjl \
+            --variant ${{ matrix.platform.target }}
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Upload x86_64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64') && github.event_name != 'pull_request'"
-        uses: trunk-io/analytics-uploader@main
-        with:
-          junit-paths: context-py/junit.xml
-          org-url-slug: trunk
-          token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
-          test-collection-id: 68IdP3pq
-          variant: ${{ matrix.platform.target }}
+        run: |
+          ./target/debug/trunk-analytics-cli upload \
+            --junit-paths context-py/junit.xml \
+            --org-url-slug trunk \
+            --token ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }} \
+            --test-collection-id 68IdP3pq \
+            --variant ${{ matrix.platform.target }}
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
 
@@ -178,25 +184,25 @@ jobs:
 
       - name: Upload aarch64 test results to staging
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64')"
-        uses: trunk-io/analytics-uploader@main
-        with:
-          junit-paths: context-py/junit.xml
-          org-url-slug: trunk-staging-org
-          token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-          test-collection-id: 6E6WINjl
-          variant: ${{ matrix.platform.target }}
+        run: |
+          ./target/debug/trunk-analytics-cli upload \
+            --junit-paths context-py/junit.xml \
+            --org-url-slug trunk-staging-org \
+            --token ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }} \
+            --test-collection-id 6E6WINjl \
+            --variant ${{ matrix.platform.target }}
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Upload aarch64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64') && github.event_name != 'pull_request'"
-        uses: trunk-io/analytics-uploader@main
-        with:
-          junit-paths: context-py/junit.xml
-          org-url-slug: trunk
-          token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
-          test-collection-id: 68IdP3pq
-          variant: ${{ matrix.platform.target }}
+        run: |
+          ./target/debug/trunk-analytics-cli upload \
+            --junit-paths context-py/junit.xml \
+            --org-url-slug trunk \
+            --token ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }} \
+            --test-collection-id 68IdP3pq \
+            --variant ${{ matrix.platform.target }}
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
 

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -293,7 +293,7 @@ def test_parse_and_dump_meta_roundtrip():
         },
         "schema": "V0_5_29",
         "tags": [],
-        "test_collection_short_id": None,
+        "test_collection_id": None,
         "test_command": None,
         "upload_time_epoch": 1721095230,
         "use_uncloned_repo": None,
@@ -302,7 +302,7 @@ def test_parse_and_dump_meta_roundtrip():
 
     valid_meta_str = json.dumps(valid_meta, sort_keys=True)
     expected_meta = dict(valid_meta)
-    expected_meta.pop("test_collection_short_id")
+    expected_meta.pop("test_collection_id")
     expected_meta_str = json.dumps(expected_meta, sort_keys=True)
     bundle_meta = parse_meta(valid_meta_str.encode())
     assert (


### PR DESCRIPTION
## Summary
- Adds `--junitxml=junit.xml` to both x86_64 and aarch64 pytest invocations in `pyo3.yml`
- Uploads results to staging (`6E6WINjl`) on every run
- Uploads results to prod (`68IdP3pq`) on non-PR runs (main + tags + workflow_dispatch)

## Test plan
- [ ] Verify junit.xml is generated and upload steps succeed in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)