### PR TITLE
(Chore): Cleanup bazel labels

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -32,7 +32,7 @@ lint:
     - black@26.5.1
     - checkov@3.3.1
     - clippy@SYSTEM
-    - eslint@10.4.1
+    - eslint@9.39.2!
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0

--- a/bundle/src/files.rs
+++ b/bundle/src/files.rs
@@ -194,7 +194,14 @@ pub struct FileSetTestRunnerReport {
     #[cfg_attr(feature = "wasm", tsify(type = "number"))]
     #[serde(default, with = "ts_milliseconds")]
     pub resolved_end_time_epoch_ms: DateTime<Utc>,
-    /// Added in v0.10.5. Populated when parsing from BEP, not from junit globs
+    /// Deprecated. Use `bazel_run_information.label` on test case runs and
+    /// `bazel_build_information.label` on test results in `internal.bin` instead.
+    /// Retained for backward-compatible `meta.json` deserialization only; not written on new bundles.
+    #[deprecated(
+        since = "0.13.2",
+        note = "use bazel_run_information.label or bazel_build_information.label from internal.bin"
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_label: Option<String>,
 }
 
@@ -208,7 +215,7 @@ impl FileSetTestRunnerReport {
         resolved_status: TestRunnerReportStatus,
         resolved_start_time_epoch_ms: DateTime<Utc>,
         resolved_end_time_epoch_ms: DateTime<Utc>,
-        resolved_label: Option<String>,
+        #[allow(deprecated)] resolved_label: Option<String>,
     ) -> Self {
         Self {
             resolved_status,
@@ -225,7 +232,7 @@ impl From<TestRunnerReport> for FileSetTestRunnerReport {
             resolved_status: test_runner_report.status,
             resolved_start_time_epoch_ms: test_runner_report.start_time,
             resolved_end_time_epoch_ms: test_runner_report.end_time,
-            resolved_label: test_runner_report.label,
+            resolved_label: None,
         }
     }
 }
@@ -236,7 +243,6 @@ impl From<FileSetTestRunnerReport> for TestRunnerReport {
             status: test_runner_report.resolved_status,
             start_time: test_runner_report.resolved_start_time_epoch_ms,
             end_time: test_runner_report.resolved_end_time_epoch_ms,
-            label: test_runner_report.resolved_label,
         }
     }
 }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -26,14 +26,13 @@ use context::{
     junit::{
         bindings::BindingsReport,
         junit_path::JunitReportFileWithTestRunnerReport,
-        parser::{IntoTestCaseRunsOptions, JunitParser},
+        parser::{IntoTestCaseRunsOptions, JunitParser, TestRunnerConfig},
         validator::{JunitReportValidation, validate},
     },
     repo::{BundleRepo, RepoUrlParts},
 };
 use github_actions::extract_github_external_id;
 use lazy_static::lazy_static;
-use proto::test_context::test_run::test_case_run::TestRunnerInformation;
 use proto::test_context::test_run::{
     BazelAttemptNumber, BazelBuildInformation, BazelRunInformation, TestBuildResult, TestReport,
     TestResult, UploaderMetadata,
@@ -380,6 +379,24 @@ fn get_build_result_from_bep(bep_result: &BepParseResult, label: &str) -> BuildR
     }
 }
 
+fn bazel_run_information_from_bep_xml(
+    label: &str,
+    xml_file: &context::bazel_bep::common::BepXMLFile,
+) -> BazelRunInformation {
+    BazelRunInformation {
+        label: label.to_string(),
+        attempt_number: xml_file.attempt,
+        started_at: xml_file.start_time.map(|time| prost_wkt_types::Timestamp {
+            seconds: time.timestamp(),
+            nanos: time.timestamp_subsec_nanos() as i32,
+        }),
+        finished_at: xml_file.end_time.map(|time| prost_wkt_types::Timestamp {
+            seconds: time.timestamp(),
+            nanos: time.timestamp_subsec_nanos() as i32,
+        }),
+    }
+}
+
 pub fn generate_internal_file_from_bep(
     bep_result: &BepParseResult,
     temp_dir: &TempDir,
@@ -418,36 +435,22 @@ pub fn generate_internal_file_from_bep(
                         continue;
                     };
 
-                    let mut xml_test_case_runs =
-                        junit_parser.into_test_case_runs(IntoTestCaseRunsOptions {
+                    let bazel_run_information =
+                        bazel_run_information_from_bep_xml(&label, xml_file);
+
+                    test_case_runs.extend(junit_parser.into_test_case_runs(
+                        IntoTestCaseRunsOptions {
                             org_slug,
                             repo,
                             codeowners,
                             quarantined_test_ids,
                             variant: variant.as_deref().unwrap_or(""),
-                            bazel_label: use_bazel_target_for_codeowners.then_some(label.as_str()),
-                        });
-                    xml_test_case_runs.iter_mut().for_each(|test_case_run| {
-                        test_case_run.test_runner_information = Some(
-                            TestRunnerInformation::BazelRunInformation(BazelRunInformation {
-                                label: label.clone(),
-                                attempt_number: xml_file.attempt,
-                                started_at: xml_file.start_time.map(|time| {
-                                    prost_wkt_types::Timestamp {
-                                        seconds: time.timestamp(),
-                                        nanos: time.timestamp_subsec_nanos() as i32,
-                                    }
-                                }),
-                                finished_at: xml_file.end_time.map(|time| {
-                                    prost_wkt_types::Timestamp {
-                                        seconds: time.timestamp(),
-                                        nanos: time.timestamp_subsec_nanos() as i32,
-                                    }
-                                }),
+                            test_runner_config: Some(TestRunnerConfig::Bazel {
+                                bazel_run_information: &bazel_run_information,
+                                use_bazel_target_for_codeowners,
                             }),
-                        );
-                    });
-                    test_case_runs.extend(xml_test_case_runs);
+                        },
+                    ));
                 }
             }
         } else {
@@ -466,6 +469,13 @@ pub fn generate_internal_file_from_bep(
                         continue;
                     };
 
+                    let bazel_run_information = BazelRunInformation {
+                        label: label.clone(),
+                        attempt_number: 0,
+                        started_at: None,
+                        finished_at: None,
+                    };
+
                     test_case_runs.extend(junit_parser.into_test_case_runs(
                         IntoTestCaseRunsOptions {
                             org_slug,
@@ -473,7 +483,10 @@ pub fn generate_internal_file_from_bep(
                             codeowners,
                             quarantined_test_ids,
                             variant: variant.as_deref().unwrap_or(""),
-                            bazel_label: use_bazel_target_for_codeowners.then_some(label.as_str()),
+                            test_runner_config: Some(TestRunnerConfig::Bazel {
+                                bazel_run_information: &bazel_run_information,
+                                use_bazel_target_for_codeowners,
+                            }),
                         },
                     ));
                 }
@@ -512,7 +525,6 @@ pub fn generate_internal_file(
     org_slug: &String,
     repo: &RepoUrlParts,
     quarantined_test_ids: &[String],
-    use_bazel_target_for_codeowners: bool,
 ) -> anyhow::Result<(
     BundledFile,
     BTreeMap<String, anyhow::Result<JunitReportValidation>>,
@@ -546,23 +558,16 @@ pub fn generate_internal_file(
                         continue;
                     };
 
-                    test_case_runs.extend(
-                        junit_parser.into_test_case_runs(IntoTestCaseRunsOptions {
+                    test_case_runs.extend(junit_parser.into_test_case_runs(
+                        IntoTestCaseRunsOptions {
                             org_slug,
                             repo,
                             codeowners,
                             quarantined_test_ids,
                             variant: variant.as_deref().unwrap_or(""),
-                            bazel_label: use_bazel_target_for_codeowners
-                                .then(|| {
-                                    file_set
-                                        .test_runner_report
-                                        .as_ref()
-                                        .and_then(|r| r.resolved_label.as_deref())
-                                })
-                                .flatten(),
-                        }),
-                    );
+                            test_runner_config: None,
+                        },
+                    ));
                 }
             }
         }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -380,11 +380,11 @@ fn get_build_result_from_bep(bep_result: &BepParseResult, label: &str) -> BuildR
 }
 
 fn bazel_run_information_from_bep_xml(
-    label: &str,
+    label: String,
     xml_file: &context::bazel_bep::common::BepXMLFile,
 ) -> BazelRunInformation {
     BazelRunInformation {
-        label: label.to_string(),
+        label,
         attempt_number: xml_file.attempt,
         started_at: xml_file.start_time.map(|time| prost_wkt_types::Timestamp {
             seconds: time.timestamp(),
@@ -436,7 +436,7 @@ pub fn generate_internal_file_from_bep(
                     };
 
                     let bazel_run_information =
-                        bazel_run_information_from_bep_xml(&label, xml_file);
+                        bazel_run_information_from_bep_xml(label.clone(), xml_file);
 
                     test_case_runs.extend(junit_parser.into_test_case_runs(
                         IntoTestCaseRunsOptions {
@@ -446,7 +446,7 @@ pub fn generate_internal_file_from_bep(
                             quarantined_test_ids,
                             variant: variant.as_deref().unwrap_or(""),
                             test_runner_config: Some(TestRunnerConfig::Bazel {
-                                bazel_run_information: &bazel_run_information,
+                                bazel_run_information,
                                 use_bazel_target_for_codeowners,
                             }),
                         },
@@ -484,7 +484,7 @@ pub fn generate_internal_file_from_bep(
                             quarantined_test_ids,
                             variant: variant.as_deref().unwrap_or(""),
                             test_runner_config: Some(TestRunnerConfig::Bazel {
-                                bazel_run_information: &bazel_run_information,
+                                bazel_run_information,
                                 use_bazel_target_for_codeowners,
                             }),
                         },

--- a/cli/src/upload_command.rs
+++ b/cli/src/upload_command.rs
@@ -532,7 +532,6 @@ pub async fn run_upload(
             &upload_args.org_url_slug,
             &quarantine_context.repo,
             &quarantined_test_ids,
-            upload_args.use_bazel_target_for_codeowners,
         )
     };
     let validations = if let Ok((internal_bundled_file, junit_validations)) = internal_bundled_file

--- a/cli/src/validate_command.rs
+++ b/cli/src/validate_command.rs
@@ -1010,7 +1010,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:27:27.605Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/bazel_pnpm:test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1025,7 +1024,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:29:32.853Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/cc:hello_test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1040,7 +1038,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:32:34.697Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/ts_proto:test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1055,7 +1052,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:32:34.797Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/ts_grpc:test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1070,7 +1066,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:33:01.806Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/cdk:lib_typecheck_test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1085,7 +1080,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:33:17.945Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/prisma/app:test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1100,7 +1094,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:35:19.361Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/cc_grpc:client_test".into()),
                 }),
             },
             JunitReportFileWithTestRunnerReport {
@@ -1115,7 +1108,6 @@ mod tests {
                     end_time: DateTime::parse_from_rfc3339("2025-05-16T19:35:19.383Z")
                         .unwrap()
                         .to_utc(),
-                    label: Some("//trunk/hello_world/cc_grpc:server_test".into()),
                 }),
             },
         ];

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -378,25 +378,25 @@ async fn upload_bundle_using_bep() {
     let report = report.test_results.first().unwrap();
     assert_eq!(report.test_case_runs.len(), 500);
     assert!(report.test_build_information.is_some());
-    let test_build_information = match report.test_build_information.as_ref() {
+    let test_build_information = assert_matches!(
+        report.test_build_information.as_ref(),
         Some(
             proto::test_context::test_run::test_result::TestBuildInformation::BazelBuildInformation(
                 bazel_build_information,
             ),
-        ) => bazel_build_information,
-        _ => panic!("Expected BazelBuildInformation"),
-    };
+        ) => bazel_build_information
+    );
     assert_eq!(test_build_information.label, "//path:test");
 
     let test_case_run = &report.test_case_runs[0];
-    let bazel_run_information = match test_case_run.test_runner_information.as_ref() {
+    let bazel_run_information = assert_matches!(
+        test_case_run.test_runner_information.as_ref(),
         Some(
             proto::test_context::test_run::test_case_run::TestRunnerInformation::BazelRunInformation(
                 bazel_run_information,
             ),
-        ) => bazel_run_information,
-        _ => panic!("Expected BazelRunInformation"),
-    };
+        ) => bazel_run_information
+    );
     assert_eq!(bazel_run_information.label, "//path:test");
     assert!(test_case_run.id.is_empty());
     assert!(!test_case_run.name.is_empty());
@@ -773,29 +773,28 @@ async fn upload_bundle_success_status_code() {
     let bin = fs::read(tar_extract_directory.join(&internal_bundled_file.path)).unwrap();
     let report = proto::test_context::test_run::TestReport::decode(&*bin).unwrap();
     let test_result = report.test_results.first().unwrap();
-    let test_build_information = match test_result.test_build_information.as_ref() {
+    let test_build_information = assert_matches!(
+        test_result.test_build_information.as_ref(),
         Some(
             proto::test_context::test_run::test_result::TestBuildInformation::BazelBuildInformation(
                 bazel_build_information,
             ),
-        ) => bazel_build_information,
-        _ => panic!("Expected BazelBuildInformation"),
-    };
+        ) => bazel_build_information
+    );
     assert_eq!(
         test_build_information.label,
         "//trunk/hello_world/cc:hello_test"
     );
-    let bazel_run_information = match test_result.test_case_runs[0]
-        .test_runner_information
-        .as_ref()
-    {
+    let bazel_run_information = assert_matches!(
+        test_result.test_case_runs[0]
+            .test_runner_information
+            .as_ref(),
         Some(
             proto::test_context::test_run::test_case_run::TestRunnerInformation::BazelRunInformation(
                 bazel_run_information,
             ),
-        ) => bazel_run_information,
-        _ => panic!("Expected BazelRunInformation"),
-    };
+        ) => bazel_run_information
+    );
     assert_eq!(
         bazel_run_information.label,
         "//trunk/hello_world/cc:hello_test"
@@ -982,29 +981,28 @@ async fn upload_bundle_success_preceding_failure() {
     let bin = fs::read(tar_extract_directory.join(&internal_bundled_file.path)).unwrap();
     let report = proto::test_context::test_run::TestReport::decode(&*bin).unwrap();
     let test_result = report.test_results.first().unwrap();
-    let test_build_information = match test_result.test_build_information.as_ref() {
+    let test_build_information = assert_matches!(
+        test_result.test_build_information.as_ref(),
         Some(
             proto::test_context::test_run::test_result::TestBuildInformation::BazelBuildInformation(
                 bazel_build_information,
             ),
-        ) => bazel_build_information,
-        _ => panic!("Expected BazelBuildInformation"),
-    };
+        ) => bazel_build_information
+    );
     assert_eq!(
         test_build_information.label,
         "//trunk/hello_world/cc:hello_test"
     );
-    let bazel_run_information = match test_result.test_case_runs[0]
-        .test_runner_information
-        .as_ref()
-    {
+    let bazel_run_information = assert_matches!(
+        test_result.test_case_runs[0]
+            .test_runner_information
+            .as_ref(),
         Some(
             proto::test_context::test_run::test_case_run::TestRunnerInformation::BazelRunInformation(
                 bazel_run_information,
             ),
-        ) => bazel_run_information,
-        _ => panic!("Expected BazelRunInformation"),
-    };
+        ) => bazel_run_information
+    );
     assert_eq!(
         bazel_run_information.label,
         "//trunk/hello_world/cc:hello_test"

--- a/cli/tests/upload.rs
+++ b/cli/tests/upload.rs
@@ -358,10 +358,6 @@ async fn upload_bundle_using_bep() {
                 .abs()
                     <= TimeDelta::milliseconds(1)
             );
-            assert_eq!(
-                test_runner_report.resolved_label,
-                Some("//path:test".to_string())
-            );
         });
 
     let mut bazel_bep_parser = BazelBepParser::new(tar_extract_directory.join("bazel_bep.json"));
@@ -393,6 +389,15 @@ async fn upload_bundle_using_bep() {
     assert_eq!(test_build_information.label, "//path:test");
 
     let test_case_run = &report.test_case_runs[0];
+    let bazel_run_information = match test_case_run.test_runner_information.as_ref() {
+        Some(
+            proto::test_context::test_run::test_case_run::TestRunnerInformation::BazelRunInformation(
+                bazel_run_information,
+            ),
+        ) => bazel_run_information,
+        _ => panic!("Expected BazelRunInformation"),
+    };
+    assert_eq!(bazel_run_information.label, "//path:test");
     assert!(test_case_run.id.is_empty());
     assert!(!test_case_run.name.is_empty());
     assert!(!test_case_run.classname.is_empty());
@@ -762,11 +767,39 @@ async fn upload_bundle_success_status_code() {
                     .abs()
                     <= TimeDelta::milliseconds(1)
             );
-            assert_eq!(
-                test_runner_report.resolved_label,
-                Some("//trunk/hello_world/cc:hello_test".to_string())
-            );
         });
+
+    let internal_bundled_file = bundle_meta.internal_bundled_file.as_ref().unwrap();
+    let bin = fs::read(tar_extract_directory.join(&internal_bundled_file.path)).unwrap();
+    let report = proto::test_context::test_run::TestReport::decode(&*bin).unwrap();
+    let test_result = report.test_results.first().unwrap();
+    let test_build_information = match test_result.test_build_information.as_ref() {
+        Some(
+            proto::test_context::test_run::test_result::TestBuildInformation::BazelBuildInformation(
+                bazel_build_information,
+            ),
+        ) => bazel_build_information,
+        _ => panic!("Expected BazelBuildInformation"),
+    };
+    assert_eq!(
+        test_build_information.label,
+        "//trunk/hello_world/cc:hello_test"
+    );
+    let bazel_run_information = match test_result.test_case_runs[0]
+        .test_runner_information
+        .as_ref()
+    {
+        Some(
+            proto::test_context::test_run::test_case_run::TestRunnerInformation::BazelRunInformation(
+                bazel_run_information,
+            ),
+        ) => bazel_run_information,
+        _ => panic!("Expected BazelRunInformation"),
+    };
+    assert_eq!(
+        bazel_run_information.label,
+        "//trunk/hello_world/cc:hello_test"
+    );
 
     // HINT: View CLI output with `cargo test -- --nocapture`
     println!("{assert}");
@@ -943,11 +976,39 @@ async fn upload_bundle_success_preceding_failure() {
                     .abs()
                     <= TimeDelta::milliseconds(1)
             );
-            assert_eq!(
-                test_runner_report.resolved_label,
-                Some("//trunk/hello_world/cc:hello_test".to_string())
-            );
         });
+
+    let internal_bundled_file = bundle_meta.internal_bundled_file.as_ref().unwrap();
+    let bin = fs::read(tar_extract_directory.join(&internal_bundled_file.path)).unwrap();
+    let report = proto::test_context::test_run::TestReport::decode(&*bin).unwrap();
+    let test_result = report.test_results.first().unwrap();
+    let test_build_information = match test_result.test_build_information.as_ref() {
+        Some(
+            proto::test_context::test_run::test_result::TestBuildInformation::BazelBuildInformation(
+                bazel_build_information,
+            ),
+        ) => bazel_build_information,
+        _ => panic!("Expected BazelBuildInformation"),
+    };
+    assert_eq!(
+        test_build_information.label,
+        "//trunk/hello_world/cc:hello_test"
+    );
+    let bazel_run_information = match test_result.test_case_runs[0]
+        .test_runner_information
+        .as_ref()
+    {
+        Some(
+            proto::test_context::test_run::test_case_run::TestRunnerInformation::BazelRunInformation(
+                bazel_run_information,
+            ),
+        ) => bazel_run_information,
+        _ => panic!("Expected BazelRunInformation"),
+    };
+    assert_eq!(
+        bazel_run_information.label,
+        "//trunk/hello_world/cc:hello_test"
+    );
 
     // HINT: View CLI output with `cargo test -- --nocapture`
     println!("{assert}");

--- a/context-js/tests/parse_compressed_bundle.test.ts
+++ b/context-js/tests/parse_compressed_bundle.test.ts
@@ -62,7 +62,6 @@ const generateBundleMeta = () =>
           .subtract(5, "minute")
           .valueOf(),
         resolved_end_time_epoch_ms: dayjs.utc().subtract(2, "minute").valueOf(),
-        resolved_label: null,
       },
       {
         file_set_type: "Junit",
@@ -259,11 +258,6 @@ const createExpectedVersionedBundle = (
           ...(typeof fileSet.resolved_end_time_epoch_ms === "undefined"
             ? {
                 resolved_end_time_epoch_ms: 0,
-              }
-            : {}),
-          ...(typeof fileSet.resolved_label === "undefined"
-            ? {
-                resolved_label: null,
               }
             : {}),
         };

--- a/context-py/tests/test_parse_meta.py
+++ b/context-py/tests/test_parse_meta.py
@@ -190,6 +190,8 @@ def test_parse_meta_valid():
         == resolved_time_epoch_ms
     )
     assert bundle_meta.base_props.file_sets[4].test_runner_report is not None
+    # resolved_label is deprecated and not written on new bundles; this verifies
+    # backward-compatible deserialization of historical meta.json.
     assert (
         bundle_meta.base_props.file_sets[4].test_runner_report.resolved_label
         == resolved_label

--- a/context/src/bazel_bep/binary_parser.rs
+++ b/context/src/bazel_bep/binary_parser.rs
@@ -75,7 +75,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:27:27.605Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/bazel_pnpm:test".into())
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -90,7 +89,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:29:32.853Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc:hello_test".into()),
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -105,7 +103,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:32:34.697Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/ts_proto:test".into()),
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -120,7 +117,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:32:34.797Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/ts_grpc:test".into()),
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -135,7 +131,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:33:01.806Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cdk:lib_typecheck_test".into()),
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -150,7 +145,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:33:17.945Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/prisma/app:test".into()),
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -165,7 +159,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:35:19.361Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc_grpc:client_test".into()),
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -180,7 +173,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2025-05-16T19:35:19.383Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc_grpc:server_test".into()),
                     })
                 }
             ]

--- a/context/src/bazel_bep/common.rs
+++ b/context/src/bazel_bep/common.rs
@@ -120,7 +120,7 @@ impl BepParseResult {
                                 Some(Id::TestSummary(id)),
                             ) => {
                                 if let Result::Ok(test_runner_report) =
-                                    TestRunnerReport::try_from(test_summary)
+                                    TestRunnerReport::try_from(test_summary.clone())
                                 {
                                     acc.test_runner_reports
                                         .insert(id.label.clone(), test_runner_report);
@@ -281,10 +281,10 @@ impl BepParseResult {
     }
 }
 
-impl TryFrom<&TestSummary> for TestRunnerReport {
+impl TryFrom<TestSummary> for TestRunnerReport {
     type Error = anyhow::Error;
 
-    fn try_from(test_summary: &TestSummary) -> Result<Self> {
+    fn try_from(test_summary: TestSummary) -> Result<Self> {
         Ok(Self {
             status: TestRunnerReportStatus::try_from(test_summary.overall_status())?,
             start_time: test_summary

--- a/context/src/bazel_bep/common.rs
+++ b/context/src/bazel_bep/common.rs
@@ -120,10 +120,7 @@ impl BepParseResult {
                                 Some(Id::TestSummary(id)),
                             ) => {
                                 if let Result::Ok(test_runner_report) =
-                                    TestRunnerReport::try_from(&LabelledTestSummary {
-                                        test_summary,
-                                        label: Some(id.label.clone()),
-                                    })
+                                    TestRunnerReport::try_from(test_summary)
                                 {
                                     acc.test_runner_reports
                                         .insert(id.label.clone(), test_runner_report);
@@ -284,21 +281,13 @@ impl BepParseResult {
     }
 }
 
-struct LabelledTestSummary<'a> {
-    test_summary: &'a TestSummary,
-    label: Option<String>,
-}
-
-impl<'a> TryFrom<&LabelledTestSummary<'a>> for TestRunnerReport {
+impl TryFrom<&TestSummary> for TestRunnerReport {
     type Error = anyhow::Error;
 
-    fn try_from(wrapped_test_summary: &LabelledTestSummary) -> Result<Self> {
+    fn try_from(test_summary: &TestSummary) -> Result<Self> {
         Ok(Self {
-            status: TestRunnerReportStatus::try_from(
-                wrapped_test_summary.test_summary.overall_status(),
-            )?,
-            start_time: wrapped_test_summary
-                .test_summary
+            status: TestRunnerReportStatus::try_from(test_summary.overall_status())?,
+            start_time: test_summary
                 .first_start_time
                 .clone()
                 .ok_or(anyhow::anyhow!("No start time"))
@@ -306,8 +295,7 @@ impl<'a> TryFrom<&LabelledTestSummary<'a>> for TestRunnerReport {
                     DateTime::try_from(ts)
                         .map_err(|e| anyhow::anyhow!("Failed to convert start time: {}", e))
                 })?,
-            end_time: wrapped_test_summary
-                .test_summary
+            end_time: test_summary
                 .last_stop_time
                 .clone()
                 .ok_or(anyhow::anyhow!("No end time"))
@@ -315,7 +303,6 @@ impl<'a> TryFrom<&LabelledTestSummary<'a>> for TestRunnerReport {
                     DateTime::try_from(ts)
                         .map_err(|e| anyhow::anyhow!("Failed to convert end time: {}", e))
                 })?,
-            label: wrapped_test_summary.label.clone(),
         })
     }
 }

--- a/context/src/bazel_bep/parser.rs
+++ b/context/src/bazel_bep/parser.rs
@@ -215,7 +215,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2024-12-02T20:27:17.627Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc:hello_test".into())
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -228,7 +227,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2024-12-02T20:50:02.100Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc_grpc:client_test".into())
                     })
                 }
             ]
@@ -259,7 +257,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2024-12-17T04:10:55.466Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc:hello_test".into())
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -272,7 +269,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2024-12-17T04:10:55.466Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc:hello_test".into())
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -285,7 +281,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2024-12-17T04:10:55.466Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc:hello_test".into())
                     })
                 },
                 JunitReportFileWithTestRunnerReport {
@@ -298,7 +293,6 @@ mod tests {
                         end_time: DateTime::parse_from_rfc3339("2024-12-17T04:10:56.383Z")
                             .unwrap()
                             .into(),
-                        label: Some("//trunk/hello_world/cc_grpc:client_test".into())
                     })
                 }
             ]

--- a/context/src/junit/bindings/report.rs
+++ b/context/src/junit/bindings/report.rs
@@ -573,7 +573,7 @@ mod tests {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 2);
 

--- a/context/src/junit/junit_path.rs
+++ b/context/src/junit/junit_path.rs
@@ -38,7 +38,6 @@ pub struct TestRunnerReport {
     pub status: TestRunnerReportStatus,
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,
-    pub label: Option<String>,
 }
 
 /// Encapsulates the glob path for a junit and, if applicable, the flakiness already

--- a/context/src/junit/parser.rs
+++ b/context/src/junit/parser.rs
@@ -9,7 +9,8 @@ use codeowners::CodeOwners;
 use prost::Message;
 use prost_wkt_types::Timestamp;
 use proto::test_context::test_run::{
-    AttemptNumber, CodeOwner, LineNumber, TestCaseRun, TestCaseRunStatus, TestOutput,
+    AttemptNumber, BazelRunInformation, CodeOwner, LineNumber, TestCaseRun, TestCaseRunStatus,
+    TestOutput, test_case_run::TestRunnerInformation,
 };
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
@@ -141,13 +142,21 @@ enum CurrentReportState {
 }
 
 #[derive(Debug, Clone)]
+pub enum TestRunnerConfig<'a> {
+    Bazel {
+        bazel_run_information: &'a BazelRunInformation,
+        use_bazel_target_for_codeowners: bool,
+    },
+}
+
+#[derive(Debug, Clone)]
 pub struct IntoTestCaseRunsOptions<'a> {
     pub org_slug: &'a str,
     pub repo: &'a RepoUrlParts,
     pub codeowners: Option<&'a CodeOwners>,
     pub quarantined_test_ids: &'a [String],
     pub variant: &'a str,
-    pub bazel_label: Option<&'a str>,
+    pub test_runner_config: Option<TestRunnerConfig<'a>>,
 }
 
 #[derive(Debug, Clone)]
@@ -216,7 +225,7 @@ impl JunitParser {
             repo,
             quarantined_test_ids,
             variant,
-            bazel_label,
+            test_runner_config,
         } = options;
         let mut test_case_runs = Vec::new();
         for report in self.reports {
@@ -360,8 +369,14 @@ impl JunitParser {
                     if codeowners.is_some() {
                         let codeowners_path = if !file.is_empty() {
                             Some(file.clone())
+                        } else if let Some(TestRunnerConfig::Bazel {
+                            bazel_run_information,
+                            use_bazel_target_for_codeowners: true,
+                        }) = test_runner_config
+                        {
+                            bazel_label_to_package_path(&bazel_run_information.label)
                         } else {
-                            bazel_label.and_then(bazel_label_to_package_path)
+                            None
                         };
                         if let Some(path) = codeowners_path {
                             let resolved: Option<Vec<String>> = codeowners
@@ -416,6 +431,17 @@ impl JunitParser {
                     test_case_run.line = line_number.unwrap_or_default();
                     // trunk-ignore(clippy/deprecated)
                     test_case_run.attempt_number = attempt_number.unwrap_or_default();
+
+                    if let Some(TestRunnerConfig::Bazel {
+                        bazel_run_information,
+                        ..
+                    }) = test_runner_config
+                    {
+                        test_case_run.test_runner_information =
+                            Some(TestRunnerInformation::BazelRunInformation(
+                                bazel_run_information.clone(),
+                            ));
+                    }
 
                     test_case_runs.push(test_case_run);
                 }
@@ -1147,7 +1173,7 @@ mod tests {
                 "",
             )],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 2);
         let test_case_run1 = &test_case_runs[0];
@@ -1241,7 +1267,7 @@ mod tests {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 1);
         let test_case_run = &test_case_runs[0];
@@ -1284,7 +1310,7 @@ mod tests {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 2);
 
@@ -1342,7 +1368,7 @@ mod tests {
                 "",
             )],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 2);
         let test_case_run1 = &test_case_runs[0];
@@ -1559,7 +1585,7 @@ mod tests {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
 
         assert_eq!(test_case_runs.len(), 1);
@@ -1628,7 +1654,7 @@ mod tests {
                     codeowners: None,
                     quarantined_test_ids: &[],
                     variant,
-                    bazel_label: None,
+                    test_runner_config: None,
                 });
 
         assert_eq!(test_case_runs_with_variant.len(), 1);
@@ -1650,7 +1676,7 @@ mod tests {
                 codeowners: None,
                 quarantined_test_ids: &[],
                 variant: "",
-                bazel_label: None,
+                test_runner_config: None,
             });
 
         assert_eq!(test_case_runs_no_variant.len(), 1);
@@ -1687,7 +1713,7 @@ mod tests {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 2);
 
@@ -1734,7 +1760,7 @@ mod tests {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         });
         assert_eq!(test_case_runs.len(), 1);
 

--- a/context/src/junit/parser.rs
+++ b/context/src/junit/parser.rs
@@ -142,9 +142,9 @@ enum CurrentReportState {
 }
 
 #[derive(Debug, Clone)]
-pub enum TestRunnerConfig<'a> {
+pub enum TestRunnerConfig {
     Bazel {
-        bazel_run_information: &'a BazelRunInformation,
+        bazel_run_information: BazelRunInformation,
         use_bazel_target_for_codeowners: bool,
     },
 }
@@ -156,7 +156,7 @@ pub struct IntoTestCaseRunsOptions<'a> {
     pub codeowners: Option<&'a CodeOwners>,
     pub quarantined_test_ids: &'a [String],
     pub variant: &'a str,
-    pub test_runner_config: Option<TestRunnerConfig<'a>>,
+    pub test_runner_config: Option<TestRunnerConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -372,7 +372,7 @@ impl JunitParser {
                         } else if let Some(TestRunnerConfig::Bazel {
                             bazel_run_information,
                             use_bazel_target_for_codeowners: true,
-                        }) = test_runner_config
+                        }) = test_runner_config.as_ref()
                         {
                             bazel_label_to_package_path(&bazel_run_information.label)
                         } else {
@@ -435,7 +435,7 @@ impl JunitParser {
                     if let Some(TestRunnerConfig::Bazel {
                         bazel_run_information,
                         ..
-                    }) = test_runner_config
+                    }) = test_runner_config.as_ref()
                     {
                         test_case_run.test_runner_information =
                             Some(TestRunnerInformation::BazelRunInformation(

--- a/context/src/junit/validator.rs
+++ b/context/src/junit/validator.rs
@@ -279,7 +279,6 @@ fn trace_test_case_validation_issue(
         test_case_classname = ?test_case.classname,
         test_case_file_or_filepath = %file_or_filepath,
         test_case_time = ?test_case.time,
-        test_runner_label = test_runner_report.as_ref().and_then(|report| report.label.as_deref()),
         "junit testcase validation issue"
     );
 }

--- a/context/tests/junit.rs
+++ b/context/tests/junit.rs
@@ -401,7 +401,6 @@ fn validate_test_runner_report_overrides_timestamp() {
             end_time: start_time
                 .checked_add_signed(TimeDelta::minutes(1))
                 .unwrap(),
-            label: None,
         };
         let override_report_validation = junit::validator::validate(
             &BindingsReport::from(generated_report.clone()),
@@ -442,7 +441,6 @@ fn validate_test_runner_report_overrides_timestamp() {
             end_time: start_time
                 .checked_add_signed(TimeDelta::minutes(1))
                 .unwrap(),
-            label: None,
         };
         let bindings_report = BindingsReport::from(generated_report.clone());
         let bindings_validation = junit::validator::validate(
@@ -485,7 +483,6 @@ fn validate_test_runner_report_overrides_timestamp() {
             end_time: start_time
                 .checked_add_signed(TimeDelta::minutes(1))
                 .unwrap(),
-            label: None,
         };
         let bindings_report = BindingsReport::from(generated_report.clone());
         let bindings_validation = junit::validator::validate(
@@ -530,7 +527,6 @@ fn validate_test_runner_report_overrides_timestamp() {
             end_time: start_time
                 .checked_sub_signed(TimeDelta::minutes(1))
                 .unwrap(),
-            label: None,
         };
         let bindings_report = BindingsReport::from(generated_report.clone());
         let bindings_validation = junit::validator::validate(
@@ -561,7 +557,6 @@ fn validate_test_runner_report_overrides_timestamp() {
             end_time: start_time
                 .checked_add_signed(TimeDelta::minutes(1))
                 .unwrap(),
-            label: None,
         };
         let bindings_report = BindingsReport::from(generated_report.clone());
         let bindings_validation = junit::validator::validate(
@@ -606,7 +601,6 @@ fn validate_test_runner_report_overrides_timestamp() {
             status: TestRunnerReportStatus::Passed,
             start_time,
             end_time,
-            label: None,
         };
         let test_case_timestamp = end_time
             .checked_add_signed(TimeDelta::minutes(1))

--- a/xcresult/tests/xcresult.rs
+++ b/xcresult/tests/xcresult.rs
@@ -316,7 +316,7 @@ fn test_xcresult_to_bindings_report_with_id_and_timestamps() {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         })
         .into_iter()
         .map(BindingsTestCase::from)
@@ -409,7 +409,7 @@ fn test_xcresult_with_variant_id_generation() {
             codeowners: None,
             quarantined_test_ids: &[],
             variant: "",
-            bazel_label: None,
+            test_runner_config: None,
         })
         .into_iter()
         .map(BindingsTestCase::from)
@@ -429,7 +429,7 @@ fn test_xcresult_with_variant_id_generation() {
             codeowners: None,
             quarantined_test_ids: &[],
             variant,
-            bazel_label: None,
+            test_runner_config: None,
         })
         .into_iter()
         .map(BindingsTestCase::from)


### PR DESCRIPTION
This PR makes Bazel target labels canonical on `internal.bin` through `bazel_run_information` and `bazel_build_information`, and removes production use of the deprecated `file_sets.resolved_label` path.

**Codeowners and Bazel run info**

`IntoTestCaseRunsOptions` in `context/src/junit/parser.rs` now takes an optional `TestRunnerConfig::Bazel` instead of a separate `bazel_label` argument. When `--use-bazel-target-for-codeowners` is enabled, `into_test_case_runs` uses `bazel_run_information.label` as a fallback for codeowners lookup and sets `test_runner_information` on each test case in the same pass.

On the upload path, `generate_internal_file_from_bep` in `cli/src/context.rs` builds `BazelRunInformation` from BEP XML and passes `TestRunnerConfig::Bazel`. The non-BEP `generate_internal_file` path no longer reads `resolved_label` from `file_sets`.

**meta.json and BEP parsing**

We stopped writing Bazel labels into `meta.json`. `TestRunnerReport.label` was removed, new bundles always serialize `resolved_label` as empty/omitted, and the field is kept only so older bundles still deserialize. BEP parsing no longer populates labels on `TestRunnerReport`; `LabelledTestSummary` was replaced with `TryFrom<&TestSummary> for TestRunnerReport` in `context/src/bazel_bep/common.rs`.

Upload tests now assert labels and codeowners on decoded `internal.bin` rather than on `file_sets` in `meta.json`.

## Context

A bit of a history lesson. Originally when we added bazel support, we didn't have `internal.bin`, and we were parsing everything raw in ingestion. At the time I/we wired bazel labels through the `file_sets` in `meta.json`, and we reassociated those in the pipeline.

When we switched to `internal.bin`, we added `bazel_build_information` to the proto, but we left `file_sets` for backwards compatibility. The new ingestion copied over some of this behavior, as did https://github.com/trunk-io/analytics-cli/pull/1116. https://github.com/trunk-io/trunk2/pull/4239 fixes the ingestion gap, this PR fixes the codeowners piece and cleans things up.

Existing tests pass as applicable for integration tests and codeowners association.