### PR TITLE
fix(xcresult): support new 'Skip Message' test node type

### DIFF
--- a/xcresult/src/xcresult.rs
+++ b/xcresult/src/xcresult.rs
@@ -233,6 +233,17 @@ impl XCResult {
                     }
                 }
 
+                let skip_messages =
+                    Self::xcresult_skip_messages_to_strings(xcresult_test_case.children.as_slice());
+                if !skip_messages.is_empty() {
+                    if let TestCaseStatus::Skipped {
+                        ref mut message, ..
+                    } = test_case.status
+                    {
+                        *message = Some(skip_messages.join("\n").into())
+                    }
+                }
+
                 let test_reruns = Self::xcresult_repetitions_to_junit_test_reruns(
                     xcresult_test_case.children.as_slice(),
                 );
@@ -315,6 +326,14 @@ impl XCResult {
             .iter()
             .filter(|tn| matches!(tn.node_type, TestNodeType::FailureMessage))
             .map(|failure_message| String::from(&failure_message.name))
+            .collect()
+    }
+
+    fn xcresult_skip_messages_to_strings(test_nodes: &[TestNode]) -> Vec<String> {
+        test_nodes
+            .iter()
+            .filter(|tn| matches!(tn.node_type, TestNodeType::SkipMessage))
+            .map(|skip_message| String::from(&skip_message.name))
             .collect()
     }
 

--- a/xcresult/xcrun-xcresulttool-get-test-results-tests-json-schema.json
+++ b/xcresult/xcrun-xcresulttool-get-test-results-tests-json-schema.json
@@ -129,6 +129,7 @@
         "Repetition",
         "Test Case Run",
         "Failure Message",
+        "Skip Message",
         "Source Code Reference",
         "Attachment",
         "Expression",


### PR DESCRIPTION
## What
Add `Skip Message` to the `TestNodeType` enum in the xcresult test-results JSON schema.

## Why
Newer Xcode (26.x) `xcresulttool` emits a `Skip Message` child node (the `XCTSkip` reason, analogous to `Failure Message`) in the output of `xcrun xcresulttool get test-results tests`. `TestNodeType` is codegen'd by typify from this snapshotted schema and lacked that variant, so serde rejected the **entire** document and the whole `.xcresult` -> JUnit conversion failed:

```
failed to parse json from xcresulttool output: unknown variant `Skip Message`, expected one of `Test Plan`, ...
```

Any run containing a skipped test on a newer Xcode lost all of its xcresult-derived results (the `--xcresult-path` flow failed the whole upload; the glob flow silently dropped the bundle).

## Change
One-line schema add; `build.rs`/typify regenerates `#[serde(rename = "Skip Message")] SkipMessage`. Skipped tests are already handled via `TestResult::Skipped`, and all `TestNodeType` usages are non-exhaustive `matches!`/`filter`, so no match arms change. Verified with `cargo build -p xcresult`.

## Follow-ups (not in this PR)
- Add a regression fixture: an `.xcresult` with an XCTSkip'd test from the newer Xcode.
- Harden `TestNodeType` to tolerate unknown variants so future Apple schema drift degrades gracefully instead of dropping the whole upload.

Sentry: ANALYTICS-CLI-6W2 / ANALYTICS-CLI-6W3
