### PR TITLE
(Chore): Support XCode Beta 27

### DIFF
--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Setup Xcode 16
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16
+          xcode-version: 26.5.0
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
       - name: Generate Python stubs

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -167,17 +167,19 @@ jobs:
         platform:
           - runner: macos-latest
             target: x86_64
+            xcode-version: "26"
           - runner: macos-14
             target: aarch64
+            xcode-version: "16"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
-      - name: Setup Xcode 16
+      - name: Setup Xcode ${{ matrix.platform.xcode-version }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.5.0
+          xcode-version: ${{ matrix.platform.xcode-version }}
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
       - name: Generate Python stubs

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -167,19 +167,19 @@ jobs:
         platform:
           - runner: macos-latest
             target: x86_64
-            xcode-version: "26"
+            xcode_version: "26"
           - runner: macos-14
             target: aarch64
-            xcode-version: "16"
+            xcode_version: "16"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
-      - name: Setup Xcode ${{ matrix.platform.xcode-version }}
+      - name: Setup Xcode ${{ matrix.platform.xcode_version }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: ${{ matrix.platform.xcode-version }}
+          xcode-version: ${{ matrix.platform.xcode_version }}
       - name: Setup Rust & Cargo
         uses: ./.github/actions/setup_rust_cargo
       - name: Generate Python stubs

--- a/rspec-trunk-flaky-tests/.gitignore
+++ b/rspec-trunk-flaky-tests/.gitignore
@@ -3,3 +3,4 @@ lib/**/*.so
 pkg/**
 tmp
 *.gem
+Gemfile.lock

--- a/smoke-test/swift/Tests/SmokeXCTestSkips.swift
+++ b/smoke-test/swift/Tests/SmokeXCTestSkips.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+/// XCTest skips exercised by smoke-test xcodebuild (see perform_smoke_test action).
+/// On Xcode 27+, skip reasons appear as `Skip Message` nodes in the xcresult bundle.
+final class SmokeXCTestSkips: XCTestCase {
+    func testPass() {
+        XCTAssertTrue(true)
+    }
+
+    func testThrowSkip() throws {
+        throw XCTSkip("runtime skip reason")
+    }
+
+    func testSkipIf() throws {
+        try XCTSkipIf(true, "skip if true")
+    }
+
+    func testSkipUnless() throws {
+        try XCTSkipUnless(false, "skip unless false")
+    }
+}

--- a/xcresult/create-xcrun-xcresulttool-get-test-results-tests-json-schema.py
+++ b/xcresult/create-xcrun-xcresulttool-get-test-results-tests-json-schema.py
@@ -14,6 +14,11 @@ def main():
     json_schema["$defs"] = json_schema["schemas"]
     del json_schema["schemas"]
 
+    # Xcode 27 beta schema references SourceLocation but defines SourceCodeLocation.
+    defs = json_schema["$defs"]
+    if "SourceCodeLocation" in defs and "SourceLocation" not in defs:
+        defs["SourceLocation"] = defs.pop("SourceCodeLocation")
+
     pathlib.Path(__file__).parent.resolve().joinpath(
         "./xcrun-xcresulttool-get-test-results-tests-json-schema.json"
     ).write_text(json.dumps(json_schema, indent=2))

--- a/xcresult/xcrun-xcresulttool-formatDescription-get---format-json---legacy-json-schema.json
+++ b/xcresult/xcrun-xcresulttool-formatDescription-get---format-json---legacy-json-schema.json
@@ -140,7 +140,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["actionResult", "runDestination", "buildResult"]
+      "required": ["actionResult", "buildResult", "runDestination"]
     },
     "ActionResult": {
       "type": "object",
@@ -177,10 +177,13 @@
         },
         "consoleLogRef": {
           "$ref": "#/$defs/Reference"
+        },
+        "consoleSessionRef": {
+          "$ref": "#/$defs/Reference"
         }
       },
       "additionalProperties": false,
-      "required": ["metrics", "issues", "coverage"]
+      "required": ["metrics", "coverage", "issues"]
     },
     "ActionRunDestinationRecord": {
       "type": "object",
@@ -206,9 +209,9 @@
       },
       "additionalProperties": false,
       "required": [
+        "targetSDKRecord",
         "localComputerRecord",
-        "targetDeviceRecord",
-        "targetSDKRecord"
+        "targetDeviceRecord"
       ]
     },
     "ActionSDKRecord": {
@@ -917,8 +920,68 @@
           },
           "required": ["_values"]
         },
+        "failureSummaries": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "type": "object"
+            },
+            "_values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ActionTestFailureSummary"
+              }
+            }
+          },
+          "required": ["_values"]
+        },
+        "warningSummaries": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "type": "object"
+            },
+            "_values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ActionTestIssueSummary"
+              }
+            }
+          },
+          "required": ["_values"]
+        },
+        "expectedFailures": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "type": "object"
+            },
+            "_values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ActionTestExpectedFailure"
+              }
+            }
+          },
+          "required": ["_values"]
+        },
         "skipNoticeSummary": {
           "$ref": "#/$defs/ActionTestNoticeSummary"
+        },
+        "activitySummaries": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "type": "object"
+            },
+            "_values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ActionTestActivitySummary"
+              }
+            }
+          },
+          "required": ["_values"]
         },
         "summary": {
           "$ref": "#/$defs/String"
@@ -1757,6 +1820,60 @@
       },
       "additionalProperties": false
     },
+    "ConsoleSessionSection": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "title": {
+          "$ref": "#/$defs/String"
+        },
+        "items": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "type": "object"
+            },
+            "_values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/SessionIO"
+              }
+            }
+          },
+          "required": ["_values"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Content": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "kind": {
+          "$ref": "#/$defs/String"
+        },
+        "data": {
+          "$ref": "#/$defs/Data"
+        },
+        "log": {
+          "$ref": "#/$defs/OSLogEntry"
+        },
+        "status": {
+          "$ref": "#/$defs/StatusMessage"
+        },
+        "flushId": {
+          "$ref": "#/$defs/UUID"
+        },
+        "debugger": {
+          "$ref": "#/$defs/DebuggerContent"
+        }
+      },
+      "additionalProperties": false
+    },
     "Data": {
       "type": "object",
       "properties": {
@@ -1780,6 +1897,162 @@
         }
       },
       "required": ["_value"]
+    },
+    "DebuggerContent": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "kind": {
+          "$ref": "#/$defs/String"
+        },
+        "commandStarted": {
+          "$ref": "#/$defs/DebuggerContentCommandStarted"
+        },
+        "commandResult": {
+          "$ref": "#/$defs/DebuggerContentCommandResult"
+        },
+        "commandOutput": {
+          "$ref": "#/$defs/DebuggerContentCommandOutput"
+        },
+        "event": {
+          "$ref": "#/$defs/DebuggerContentEvent"
+        },
+        "promptText": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DebuggerContentCommandOutput": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "commandId": {
+          "$ref": "#/$defs/Int"
+        },
+        "text": {
+          "$ref": "#/$defs/String"
+        },
+        "isError": {
+          "$ref": "#/$defs/Bool"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DebuggerContentCommandResult": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "commandId": {
+          "$ref": "#/$defs/Int"
+        },
+        "succeeded": {
+          "$ref": "#/$defs/Bool"
+        },
+        "output": {
+          "$ref": "#/$defs/String"
+        },
+        "error": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DebuggerContentCommandStarted": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "commandId": {
+          "$ref": "#/$defs/Int"
+        },
+        "command": {
+          "$ref": "#/$defs/String"
+        },
+        "prompt": {
+          "$ref": "#/$defs/String"
+        },
+        "resolvedCommand": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DebuggerContentEvent": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "kind": {
+          "$ref": "#/$defs/String"
+        },
+        "customKind": {
+          "$ref": "#/$defs/String"
+        },
+        "message": {
+          "$ref": "#/$defs/String"
+        },
+        "attributedCommandId": {
+          "$ref": "#/$defs/Int"
+        },
+        "source": {
+          "$ref": "#/$defs/DebuggerContentSource"
+        },
+        "line": {
+          "$ref": "#/$defs/Int"
+        },
+        "column": {
+          "$ref": "#/$defs/Int"
+        },
+        "progressPhase": {
+          "$ref": "#/$defs/String"
+        },
+        "progressId": {
+          "$ref": "#/$defs/String"
+        },
+        "title": {
+          "$ref": "#/$defs/String"
+        },
+        "cancellable": {
+          "$ref": "#/$defs/Bool"
+        },
+        "percentage": {
+          "$ref": "#/$defs/Double"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DebuggerContentSource": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "name": {
+          "$ref": "#/$defs/String"
+        },
+        "path": {
+          "$ref": "#/$defs/String"
+        },
+        "sourceReference": {
+          "$ref": "#/$defs/Int"
+        },
+        "presentationHint": {
+          "$ref": "#/$defs/String"
+        },
+        "origin": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false
     },
     "DocumentLocation": {
       "type": "object",
@@ -1808,6 +2081,34 @@
       },
       "required": ["_value"]
     },
+    "EndpointIO": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "sequence": {
+          "$ref": "#/$defs/UInt64"
+        },
+        "endpointType": {
+          "$ref": "#/$defs/String"
+        },
+        "direction": {
+          "$ref": "#/$defs/String"
+        },
+        "content": {
+          "$ref": "#/$defs/Content"
+        },
+        "timestamp": {
+          "$ref": "#/$defs/Date"
+        },
+        "customEndpointName": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["content"]
+    },
     "EntityIdentifier": {
       "type": "object",
       "properties": {
@@ -1828,6 +2129,28 @@
         }
       },
       "additionalProperties": false
+    },
+    "GroupIO": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "sequence": {
+          "$ref": "#/$defs/UInt64"
+        },
+        "groupType": {
+          "$ref": "#/$defs/String"
+        },
+        "endpointIO": {
+          "$ref": "#/$defs/EndpointIO"
+        },
+        "customGroupName": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["endpointIO"]
     },
     "Int": {
       "type": "object",
@@ -1910,6 +2233,9 @@
             "message": {
               "$ref": "#/$defs/String"
             },
+            "compactMessage": {
+              "$ref": "#/$defs/String"
+            },
             "producingTarget": {
               "$ref": "#/$defs/String"
             },
@@ -1941,6 +2267,79 @@
         }
       },
       "additionalProperties": false
+    },
+    "OSLogEntry": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "message": {
+          "$ref": "#/$defs/String"
+        },
+        "format": {
+          "$ref": "#/$defs/String"
+        },
+        "messageType": {
+          "$ref": "#/$defs/OSLogType"
+        },
+        "pid": {
+          "$ref": "#/$defs/Int32"
+        },
+        "processName": {
+          "$ref": "#/$defs/String"
+        },
+        "processSessionUUID": {
+          "$ref": "#/$defs/UUID"
+        },
+        "tid": {
+          "$ref": "#/$defs/UInt64"
+        },
+        "subsystem": {
+          "$ref": "#/$defs/String"
+        },
+        "category": {
+          "$ref": "#/$defs/String"
+        },
+        "senderMachTime": {
+          "$ref": "#/$defs/UInt64"
+        },
+        "senderWallTime": {
+          "$ref": "#/$defs/Date"
+        },
+        "senderTimeZone": {
+          "$ref": "#/$defs/TimeZone"
+        },
+        "senderImagePath": {
+          "$ref": "#/$defs/String"
+        },
+        "senderImageName": {
+          "$ref": "#/$defs/String"
+        },
+        "senderImageUUID": {
+          "$ref": "#/$defs/UUID"
+        },
+        "senderImageOffset": {
+          "$ref": "#/$defs/UInt64"
+        },
+        "backtrace": {
+          "$ref": "#/$defs/String"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["messageType"]
+    },
+    "OSLogType": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "_value": {
+          "type": "string"
+        }
+      },
+      "required": ["_value"]
     },
     "ObjectID": {
       "type": "object",
@@ -2083,6 +2482,22 @@
       },
       "additionalProperties": false
     },
+    "SessionIO": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "sequence": {
+          "$ref": "#/$defs/UInt64"
+        },
+        "groupIO": {
+          "$ref": "#/$defs/GroupIO"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["groupIO"]
+    },
     "SortedKeyValueArray": {
       "type": "object",
       "properties": {
@@ -2190,6 +2605,21 @@
         },
         "location": {
           "$ref": "#/$defs/SourceCodeLocation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StatusMessage": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "level": {
+          "$ref": "#/$defs/String"
+        },
+        "message": {
+          "$ref": "#/$defs/String"
         }
       },
       "additionalProperties": false
@@ -2309,6 +2739,9 @@
         "message": {
           "$ref": "#/$defs/String"
         },
+        "compactMessage": {
+          "$ref": "#/$defs/String"
+        },
         "producingTarget": {
           "$ref": "#/$defs/String"
         },
@@ -2331,6 +2764,9 @@
           "$ref": "#/$defs/String"
         },
         "message": {
+          "$ref": "#/$defs/String"
+        },
+        "compactMessage": {
           "$ref": "#/$defs/String"
         },
         "producingTarget": {
@@ -2438,6 +2874,18 @@
       },
       "additionalProperties": false
     },
+    "TimeZone": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "_value": {
+          "type": "string"
+        }
+      },
+      "required": ["_value"]
+    },
     "TypeDefinition": {
       "type": "object",
       "properties": {
@@ -2502,6 +2950,18 @@
       "required": ["_value"]
     },
     "URL": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "type": "object"
+        },
+        "_value": {
+          "type": "string"
+        }
+      },
+      "required": ["_value"]
+    },
+    "UUID": {
       "type": "object",
       "properties": {
         "_type": {

--- a/xcresult/xcrun-xcresulttool-get-test-results-tests-json-schema.json
+++ b/xcresult/xcrun-xcresulttool-get-test-results-tests-json-schema.json
@@ -75,6 +75,9 @@
         "nodeIdentifier": {
           "type": "string"
         },
+        "nodeIdentifierURL": {
+          "type": "string"
+        },
         "nodeType": {
           "$ref": "#/$defs/TestNodeType"
         },
@@ -101,6 +104,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "sourceLocation": {
+          "$ref": "#/$defs/SourceLocation"
         },
         "children": {
           "type": "array",
@@ -133,8 +139,22 @@
         "Attachment",
         "Expression",
         "Test Value",
-        "Runtime Warning"
+        "Runtime Warning",
+        "Skip Message",
+        "Expected Failure"
       ]
+    },
+    "SourceLocation": {
+      "type": "object",
+      "properties": {
+        "filePath": {
+          "type": "string"
+        },
+        "lineNumber": {
+          "type": "integer"
+        }
+      },
+      "required": ["filePath", "lineNumber"]
     }
   }
 }


### PR DESCRIPTION
XCode Beta 27 updates the xcresult schema, resulting in a message when running the analytics-cli like
```txt
Error: failed to parse json from xcresulttool output: unknown variant `Skip Message`, expected one of `Test Plan`, `Unit test bundle`, `UI test bundle`, `Test Suite`, `Test Case`, `Device`, `Test Plan Configuration`, `Arguments`, `Repetition`, `Test Case Run`, `Failure Message`, `Source Code Reference`, `Attachment`, `Expression`, `Test Value`, `Runtime Warning` at line 33 column 49
```

Repro'd and validated the fix

Opted not to add xcode version matrix tests to our CI for now...