### PR TITLE
(CI): Use fewer release test variants

### DIFF
--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -137,7 +137,7 @@ jobs:
           trunk-org-slug: trunk-staging-org
           test-collection-id: T5yKSn9h
           platform: ${{ matrix.platform.name }}
-          variant: ${{ matrix.platform.name }}-ruby${{ matrix.ruby-version }}
+          variant: ${{ matrix.platform.name }}
           artifact-pattern: cross-gem-${{ matrix.platform.name }}
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
@@ -150,7 +150,7 @@ jobs:
           trunk-org-slug: trunk
           test-collection-id: BiBP2neA
           platform: ${{ matrix.platform.name }}
-          variant: ${{ matrix.platform.name }}-ruby${{ matrix.ruby-version }}
+          variant: ${{ matrix.platform.name }}
           artifact-pattern: cross-gem-${{ matrix.platform.name }}
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 


### PR DESCRIPTION
Removes the matrix complexity of https://github.com/trunk-io/analytics-cli/pull/1119/changes#diff-43905e5e2d18995dcc54587d628521bda13aff15d882e30ba5285305f3a9186e

While matrices are a good use case for variants, we have to quarantine each one of these individually in order to do a release, and the matrix is set up for fail-fast, so it's a pain to change things. Switching variant to OS to keep some of the same improvements.