### PR TITLE
Add TRUNK_API_CLIENT_RETRY_DEADLINE_SECS to bound API retry time

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,7 @@ bundle = { path = "../bundle" }
 tokio = { version = "*", default-features = false, features = [
   "rt-multi-thread",
   "macros",
+  "time",
 ] }
 anyhow = "1.0.44"
 reqwest = { version = "0.12.5", default-features = false, features = [

--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -1,12 +1,12 @@
-use std::sync::Arc;
 use std::sync::mpsc::Sender;
+use std::sync::{Arc, LazyLock};
 use std::{env, time::Duration};
 
-use constants::TRUNK_API_CLIENT_RETRY_COUNT_ENV;
+use constants::{TRUNK_API_CLIENT_RETRY_COUNT_ENV, TRUNK_API_CLIENT_RETRY_DEADLINE_SECS_ENV};
 use display::message::{DisplayMessage, ProgressMessage, send_message};
 use http::StatusCode;
 use tokio::time::{self, Instant};
-use tokio_retry::{Action, RetryIf, strategy::ExponentialBackoff};
+use tokio_retry::{Action, strategy::ExponentialBackoff};
 
 use crate::client::{NOT_FOUND_CONTEXT, UNAUTHORIZED_CONTEXT};
 
@@ -31,7 +31,10 @@ const fn enforce_increment_check_progress_interval_secs(
     )
 }
 
-fn default_delay() -> std::iter::Take<ExponentialBackoff> {
+/// Exponential backoff schedule for retrying API calls, sized by
+/// `TRUNK_API_CLIENT_RETRY_COUNT` (default `RETRY_COUNT_DEFAULT`). The env var is read once;
+/// `.clone()` this to obtain a fresh, un-advanced iterator for each retry loop.
+static DEFAULT_DELAY: LazyLock<std::iter::Take<ExponentialBackoff>> = LazyLock::new(|| {
     ExponentialBackoff::from_millis(RETRY_BASE_MS)
         .factor(RETRY_FACTOR)
         .take(
@@ -40,6 +43,57 @@ fn default_delay() -> std::iter::Take<ExponentialBackoff> {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(RETRY_COUNT_DEFAULT),
         )
+});
+
+/// Optional overall wall-clock budget for the retry loop, read once from
+/// `TRUNK_API_CLIENT_RETRY_DEADLINE_SECS`. `None` means no deadline (retry until the count
+/// is exhausted).
+static RETRY_DEADLINE: LazyLock<Option<Duration>> = LazyLock::new(|| {
+    env::var(TRUNK_API_CLIENT_RETRY_DEADLINE_SECS_ENV)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_secs)
+});
+
+/// Run `action`, retrying on retryable errors with exponential backoff. Mirrors the previous
+/// `tokio-retry` behavior (initial attempt + up to `DEFAULT_DELAY` retries) but adds an
+/// optional overall deadline: once the elapsed time plus the next backoff would exceed
+/// `deadline`, the loop gives up and returns the most recent error instead of sleeping again.
+async fn retry_with_deadline<A>(
+    action: &mut A,
+    deadline: Option<Duration>,
+) -> Result<A::Item, A::Error>
+where
+    A: Action,
+    A::Error: AbortableRetry,
+{
+    let retry_start = Instant::now();
+    let mut delays = DEFAULT_DELAY.clone();
+    loop {
+        match action.run().await {
+            Ok(item) => return Ok(item),
+            Err(error) => {
+                if !error.should_retry() {
+                    return Err(error);
+                }
+                let Some(delay) = delays.next() else {
+                    return Err(error);
+                };
+                if let Some(deadline) = deadline {
+                    let elapsed = retry_start.elapsed();
+                    if elapsed.saturating_add(delay) >= deadline {
+                        tracing::debug!(
+                            "Retry deadline of {:?} reached after {:?}; giving up.",
+                            deadline,
+                            elapsed
+                        );
+                        return Err(error);
+                    }
+                }
+                time::sleep(delay).await;
+            }
+        }
+    }
 }
 
 pub trait AbortableRetry {
@@ -184,12 +238,7 @@ where
             }
         });
 
-        let result = RetryIf::spawn(
-            default_delay(),
-            || self.action.run(),
-            |error: &A::Error| error.should_retry(),
-        )
-        .await;
+        let result = retry_with_deadline(&mut self.action, *RETRY_DEADLINE).await;
         report_slow_progress_handle.abort();
         check_progress_handle.abort();
 
@@ -214,7 +263,7 @@ mod tests {
 
     use super::{
         CHECK_PROGRESS_INTERVAL_SECS, CallApi, REPORT_SLOW_PROGRESS_TIMEOUT_SECS,
-        RETRY_COUNT_DEFAULT,
+        RETRY_COUNT_DEFAULT, retry_with_deadline,
     };
     use crate::client::{CheckNotFound, CheckUnauthorized, status_code_help};
     #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
@@ -339,6 +388,39 @@ mod tests {
         .call_api()
         .await;
 
+        assert_eq!(retry_count.into_inner(), RETRY_COUNT_DEFAULT + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stops_retrying_once_deadline_would_be_exceeded() {
+        let retry_count = AtomicUsize::new(0);
+
+        // Backoffs are 2s, 4s, 8s, ... With a 5s deadline: attempt 1 (elapsed 0s, next
+        // backoff 2s -> 2s < 5s, sleep), attempt 2 (elapsed 2s, next backoff 4s -> 6s >= 5s,
+        // give up). So we expect exactly 2 attempts despite the default retry count of 5.
+        let mut action = || async {
+            retry_count.fetch_add(1, Ordering::Relaxed);
+            Result::<(), anyhow::Error>::Err(anyhow::Error::msg("Broken"))
+        };
+
+        let result = retry_with_deadline(&mut action, Some(Duration::from_secs(5))).await;
+
+        assert!(result.is_err());
+        assert_eq!(retry_count.into_inner(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_full_count_when_no_deadline_set() {
+        let retry_count = AtomicUsize::new(0);
+
+        let mut action = || async {
+            retry_count.fetch_add(1, Ordering::Relaxed);
+            Result::<(), anyhow::Error>::Err(anyhow::Error::msg("Broken"))
+        };
+
+        let result = retry_with_deadline(&mut action, None).await;
+
+        assert!(result.is_err());
         assert_eq!(retry_count.into_inner(), RETRY_COUNT_DEFAULT + 1);
     }
 

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -24,6 +24,11 @@ pub const CACHE_DIR: &str = "trunk-flaky-tests";
 pub const TRUNK_QUARANTINE_DISK_CACHE_DIR_ENV: &str = "TRUNK_QUARANTINE_DISK_CACHE_DIR";
 pub const TRUNK_PUBLIC_API_ADDRESS_ENV: &str = "TRUNK_PUBLIC_API_ADDRESS";
 pub const TRUNK_API_CLIENT_RETRY_COUNT_ENV: &str = "TRUNK_API_CLIENT_RETRY_COUNT";
+// Overall wall-clock budget (in seconds) for an API call's retry loop. When set, the loop
+// stops retrying once the elapsed time plus the next backoff would exceed this budget,
+// returning the most recent error. Pairs with TRUNK_API_CLIENT_RETRY_COUNT to tune how
+// fast and how often the CLI gives up.
+pub const TRUNK_API_CLIENT_RETRY_DEADLINE_SECS_ENV: &str = "TRUNK_API_CLIENT_RETRY_DEADLINE_SECS";
 
 // Trunk CLI environment variable names for configuration overrides
 pub const TRUNK_API_TOKEN_ENV: &str = "TRUNK_API_TOKEN";
@@ -61,6 +66,7 @@ pub const TRUNK_ENVS_TO_CAPTURE: &[&str] = &[
     TRUNK_QUARANTINE_DISK_CACHE_DIR_ENV,
     TRUNK_PUBLIC_API_ADDRESS_ENV,
     TRUNK_API_CLIENT_RETRY_COUNT_ENV,
+    TRUNK_API_CLIENT_RETRY_DEADLINE_SECS_ENV,
     TRUNK_PUBLIC_REPO_ID_ENV,
     TRUNK_ORG_URL_SLUG_ENV,
     TRUNK_TEST_COLLECTION_ID_ENV,


### PR DESCRIPTION
## Problem

The API client's retry loop (`api/src/call_api.rs`) only honored a retry *count* (`TRUNK_API_CLIENT_RETRY_COUNT`). Total wall-clock time was otherwise uncapped — per-request timeouts plus up to ~62s of exponential backoff (2/4/8/16/32s) across retries — so a slow/failing endpoint could spin for minutes (this is what surfaced the repeated `…is taking longer than expected` messages customers reported).

## Change

- New optional env var **`TRUNK_API_CLIENT_RETRY_DEADLINE_SECS`**: an overall wall-clock budget for a call's retry loop. The loop gives up once `elapsed + next_backoff >= deadline`, returning the most recent error. Pairs with `TRUNK_API_CLIENT_RETRY_COUNT` to tune how fast/often the CLI gives up.
- Replaces `tokio-retry`'s `RetryIf` with an explicit loop (behavior-identical when the deadline is unset) so the deadline can short-circuit while still returning a real error — the generic `A::Error` includes `reqwest::Error`, which has no public constructor, so a `timeout()`/`select!` wrapper couldn't synthesize one. We still use `tokio-retry`'s `ExponentialBackoff` + `Action`.
- Read the env vars once via `LazyLock` (`DEFAULT_DELAY`, `RETRY_DEADLINE`).
- Captured `TRUNK_API_CLIENT_RETRY_DEADLINE_SECS` in `TRUNK_ENVS_TO_CAPTURE` for bundle-metadata debugging.

## Notes

- The deadline is checked **between attempts**, so a single in-flight request can overshoot by up to its own reqwest per-request timeout (30s API / 1s telemetry); each attempt is already bounded by that timeout. Immediate mid-request abort on CI cancellation is handled separately in #1132 (signal handling).
- Customer mitigations enabled by this: `TRUNK_API_CLIENT_RETRY_COUNT=0` and/or a small `TRUNK_API_CLIENT_RETRY_DEADLINE_SECS`.

## Testing

- Added two deterministic unit tests (paused clock, explicit deadlines): `stops_retrying_once_deadline_would_be_exceeded` and `retries_full_count_when_no_deadline_set`.
- All 9 `call_api` tests pass; existing retry-count/backoff/`should_retry` tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)