### PR TITLE
Abort the CLI immediately on SIGTERM/SIGINT (CI cancellation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5792,6 +5792,7 @@ dependencies = [
  "libc",
  "mio 1.1.0",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,6 +32,7 @@ prost-wkt-types = { version = "0.5.1", features = ["vendored-protox"] }
 tokio = { version = "*", default-features = false, features = [
   "rt-multi-thread",
   "macros",
+  "signal",
 ] }
 tempfile = "3.2.0"
 tracing = "0.1.41"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+mod shutdown;
+
 use std::{
     env,
     sync::{Arc, mpsc::Sender},
@@ -125,8 +127,22 @@ fn main() -> anyhow::Result<()> {
             );
             let (render_handle, render_sender) = spin_up_renderer();
 
-            match run(cli, render_sender.clone()).await {
-                Ok(RunResult::Upload(run_result)) => {
+            // Race the work against termination signals so a CI cancellation aborts in-flight
+            // operations immediately rather than waiting for slow retries/uploads to finish.
+            let outcome = tokio::select! {
+                biased;
+                result = run(cli, render_sender.clone()) => MainOutcome::Finished(result),
+                exit_code = shutdown::shutdown_signal() => MainOutcome::Interrupted(exit_code),
+            };
+
+            match outcome {
+                MainOutcome::Interrupted(exit_code) => {
+                    tracing::warn!(
+                        "Received termination signal; aborting in-flight work and shutting down."
+                    );
+                    close_out_and_exit(exit_code, guard, render_sender, render_handle)
+                }
+                MainOutcome::Finished(Ok(RunResult::Upload(run_result))) => {
                     let result_ptr = Arc::new(run_result);
                     send_message(
                         DisplayMessage::Final(result_ptr.clone(), String::from("upload display")),
@@ -140,7 +156,7 @@ fn main() -> anyhow::Result<()> {
                         .unwrap_or(result_ptr.quarantine_context.exit_code);
                     close_out_and_exit(exit_code, guard, render_sender, render_handle)
                 }
-                Ok(RunResult::Test(run_result)) => {
+                MainOutcome::Finished(Ok(RunResult::Test(run_result))) => {
                     let result_ptr = Arc::new(run_result);
                     send_message(
                         DisplayMessage::Final(result_ptr.clone(), String::from("test display")),
@@ -153,7 +169,7 @@ fn main() -> anyhow::Result<()> {
                         render_handle,
                     )
                 }
-                Ok(RunResult::Validate(run_result)) => {
+                MainOutcome::Finished(Ok(RunResult::Validate(run_result))) => {
                     let result_ptr = Arc::new(run_result);
                     send_message(
                         DisplayMessage::Final(result_ptr.clone(), String::from("validate display")),
@@ -161,7 +177,7 @@ fn main() -> anyhow::Result<()> {
                     );
                     close_out_and_exit(result_ptr.exit_code(), guard, render_sender, render_handle)
                 }
-                Err(error) => {
+                MainOutcome::Finished(Err(error)) => {
                     let error_report = ErrorReport::new(error, org_url_slug, None);
                     let exit_code = error_report.context.exit_code.unwrap_or(exitcode::OK);
                     send_message(
@@ -175,6 +191,14 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         })
+}
+
+/// Outcome of racing the command against termination signals in `main`.
+enum MainOutcome {
+    /// The command ran to completion (successfully or with an error).
+    Finished(anyhow::Result<RunResult>),
+    /// A termination signal was received first; the payload is the exit code to use.
+    Interrupted(i32),
 }
 
 enum RunResult {

--- a/cli/src/shutdown.rs
+++ b/cli/src/shutdown.rs
@@ -1,0 +1,49 @@
+//! Graceful shutdown on termination signals.
+//!
+//! GitHub Actions (and most CI systems) cancel a job by signaling the process tree. We race
+//! these signals against the actual work in `main` so a cancellation aborts in-flight
+//! operations (e.g. the API retry loop) immediately instead of blocking until they finish.
+
+// Conventional process exit codes for termination by signal: `128 + signal number`. This
+// POSIX/shell convention isn't part of sysexits.h, so the `exitcode` crate used elsewhere
+// doesn't define it. SIGINT is 2 and SIGTERM is 15 on the Unix platforms we target.
+const EXIT_SIGNAL_BASE: i32 = 128;
+const EXIT_CODE_SIGINT: i32 = EXIT_SIGNAL_BASE + 2;
+const EXIT_CODE_SIGTERM: i32 = EXIT_SIGNAL_BASE + 15;
+
+/// Resolves once the process receives a termination signal — SIGINT/SIGTERM on Unix, Ctrl-C
+/// on Windows. Returns the conventional `128 + signal` exit code.
+pub async fn shutdown_signal() -> i32 {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        // If we can't install the handlers, fall back to default disposition by never
+        // resolving here, letting the OS terminate the process as it normally would.
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::warn!("Failed to install SIGTERM handler: {error}");
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::warn!("Failed to install SIGINT handler: {error}");
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => EXIT_CODE_SIGTERM,
+            _ = sigint.recv() => EXIT_CODE_SIGINT,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // Ctrl-C on Windows is the SIGINT-equivalent interruption.
+        let _ = tokio::signal::ctrl_c().await;
+        EXIT_CODE_SIGINT
+    }
+}


### PR DESCRIPTION
## Problem

GitHub Actions (and most CI) cancel a job by signaling the process tree. The CLI installed **no** signal handlers and blocked on its work, so a cancellation couldn't fully complete until slow operations (e.g. the API retry loop or telemetry upload) finished on their own — customers reported jobs that wouldn't cancel until the slow upload completed.

## Change

- `main` now races the command against termination signals via `tokio::select!`. On SIGTERM/SIGINT (Unix) or Ctrl-C (Windows), the in-flight work future is **dropped** — cancelling outstanding requests and the retry loop immediately — and the process exits with the conventional `128 + signal` code.
- If handler installation fails, falls back to the OS default disposition, so behavior is no worse than before.
- Signal handling lives in its own module (`cli/src/shutdown.rs`) to keep `main.rs` focused; exit codes are named constants (`EXIT_CODE_SIGINT` = 130, `EXIT_CODE_SIGTERM` = 143) with a comment noting these come from the POSIX `128 + signal` convention, which the `exitcode`/sysexits crate doesn't define.
- Adds the `signal` feature to the `cli` crate's tokio dependency (pulls `signal-hook-registry` into `Cargo.lock`).

## Notes

This is the complementary fix to #1131 (retry deadline): the deadline bounds *total retry time* but is checked between attempts; this PR provides true *immediate* mid-request abort when CI actually cancels. The two are independent and can merge in any order.

## Testing

- `cargo build -p trunk-analytics-cli` clean on this branch standalone (off `main`, without the #1131 changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)