### PR TITLE
Abort slow-progress reporter tasks when call_api is cancelled

### DIFF
--- a/api/src/call_api.rs
+++ b/api/src/call_api.rs
@@ -168,6 +168,21 @@ impl AbortableRetry for reqwest::Error {
     }
 }
 
+/// Aborts the wrapped task when dropped. Dropping a bare [`tokio::task::JoinHandle`] only
+/// *detaches* the task — it keeps running. When `call_api`'s future is cancelled mid-flight
+/// (e.g. the losing branch of the `tokio::select!` in the CLI's main loop on SIGINT/SIGTERM),
+/// the explicit `.abort()` calls after the `.await` never execute, so without this guard the
+/// slow-progress reporter tasks leak and keep emitting "taking longer than expected" messages
+/// after the CLI has been interrupted. Binding the handles in this guard aborts them on drop —
+/// covering both normal completion and cancellation.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 pub struct CallApi<A, L, R>
 where
     A: Action,
@@ -191,7 +206,7 @@ where
         let report_slow_progress_start = time::Instant::now();
         let report_slow_progress_message = self.report_slow_progress_message;
         let mut slow_progress_sender = self.render_sender.clone();
-        let report_slow_progress_handle = tokio::spawn(async move {
+        let _report_slow_progress_guard = AbortOnDrop(tokio::spawn(async move {
             let duration = Duration::from_secs(REPORT_SLOW_PROGRESS_TIMEOUT_SECS);
             time::sleep(duration).await;
             let time_elapsed = Instant::now().duration_since(report_slow_progress_start);
@@ -208,12 +223,12 @@ where
                 );
             });
             tracing::debug!("{:?}", message);
-        });
+        }));
 
         let check_progress_start = time::Instant::now();
         let log_progress_message = self.log_progress_message;
         let mut check_progress_sender = self.render_sender.clone();
-        let check_progress_handle = tokio::spawn(async move {
+        let _check_progress_guard = AbortOnDrop(tokio::spawn(async move {
             let mut log_count = 0;
             let duration = Duration::from_secs(CHECK_PROGRESS_INTERVAL_SECS);
             let mut interval = time::interval_at(Instant::now() + duration, duration);
@@ -236,13 +251,11 @@ where
                 tracing::debug!("{}", log_message);
                 log_count += 1;
             }
-        });
+        }));
 
-        let result = retry_with_deadline(&mut self.action, *RETRY_DEADLINE).await;
-        report_slow_progress_handle.abort();
-        check_progress_handle.abort();
-
-        result
+        // The guards abort the reporter tasks when they drop at the end of this scope — on
+        // normal return here *and* if this future is cancelled while awaiting below.
+        retry_with_deadline(&mut self.action, *RETRY_DEADLINE).await
     }
 }
 
@@ -515,5 +528,66 @@ mod tests {
         .await;
 
         assert_eq!(retry_count.into_inner(), RETRY_COUNT_DEFAULT + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn aborts_progress_reporters_when_future_is_dropped() {
+        use std::{
+            future::{Future, poll_fn},
+            pin::pin,
+            task::Poll,
+        };
+
+        lazy_static! {
+            static ref LOG_COUNT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        }
+
+        {
+            // `call_api` borrows `&mut self`, so the `CallApi` needs its own binding to outlive
+            // the future.
+            let mut call = CallApi {
+                // Never resolves on its own, so the future only ends when we drop it below.
+                action: || async {
+                    time::sleep(Duration::from_secs(3600)).await;
+                    Result::<(), anyhow::Error>::Ok(())
+                },
+                log_progress_message: |_, _| {
+                    LOG_COUNT.fetch_add(1, Ordering::SeqCst);
+                    String::new()
+                },
+                report_slow_progress_message: |_| String::new(),
+                render_sender: None,
+            };
+            let mut fut = pin!(call.call_api());
+
+            // Poll once so the reporter tasks are spawned, then suspend at the action's await.
+            poll_fn(|cx| {
+                assert!(fut.as_mut().poll(cx).is_pending());
+                Poll::Ready(())
+            })
+            .await;
+
+            // Let the check-progress interval tick a few times; the reporter is alive here.
+            time::sleep(Duration::from_secs(CHECK_PROGRESS_INTERVAL_SECS * 3)).await;
+            assert!(
+                LOG_COUNT.load(Ordering::SeqCst) > 0,
+                "progress reporter should emit while the future is alive"
+            );
+
+            // Drop the in-flight future, exactly as the `tokio::select!` in the CLI's main loop
+            // does when a SIGINT/SIGTERM wins the race.
+        }
+
+        let count_at_drop = LOG_COUNT.load(Ordering::SeqCst);
+
+        // Advance well past several more intervals. A merely-detached (leaked) task would keep
+        // ticking and bump the count; the `AbortOnDrop` guard must have aborted it instead.
+        time::sleep(Duration::from_secs(CHECK_PROGRESS_INTERVAL_SECS * 5)).await;
+
+        assert_eq!(
+            LOG_COUNT.load(Ordering::SeqCst),
+            count_at_drop,
+            "progress reporter kept running after the call_api future was dropped"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Pressing Ctrl+C (or a CI cancellation sending SIGINT/SIGTERM) during an upload was still printing repeated `... is taking longer than expected ...` messages, and could leave the CLI hanging instead of exiting immediately.

`call_api` spawns two background tasks that emit those progress messages. They were only cleaned up by explicit `.abort()` calls placed *after* the retry `.await`:

```rust
let result = retry_with_deadline(&mut self.action, *RETRY_DEADLINE).await;
report_slow_progress_handle.abort();
check_progress_handle.abort();
```

On the happy path that's fine. But when `call_api`'s future is **cancelled mid-flight** — the losing branch of the `tokio::select!` in the CLI main loop when a signal wins the race (#1132) — execution never reaches those `.abort()` calls. Dropping a `JoinHandle` merely *detaches* the task rather than aborting it, so the reporters leaked:

- they kept ticking every 2s and emitting "taking longer than expected" after the CLI was interrupted, and
- they kept a clone of the render `Sender` alive, which could wedge `render_handle.join()` during shutdown before `std::process::exit`.

## Fix

Bind each spawned handle in a small `AbortOnDrop` guard so the tasks are aborted **on drop** — covering both normal completion and cancellation. The explicit post-`.await` `.abort()` calls are removed since the guards now handle both cases via scope exit.

## Test

Added `aborts_progress_reporters_when_future_is_dropped`: polls a `call_api` future once to spawn the reporters, confirms they emit while alive, drops the future mid-flight (mimicking the `select!` cancellation), then advances paused time several intervals and asserts the emit count is unchanged.

Verified the test genuinely catches the regression — with the guard's `Drop` neutered it fails (`left: 7, right: 2`, "progress reporter kept running after the call_api future was dropped").

## Manual testing

Temporarily added a 30s `tokio::time::sleep` at the top of each upload-path `action` (`create_bundle_upload`, `get_quarantining_config`, `put_bundle_to_s3`) so the slow-progress reporters (10s timeout, then every 2s) fire and leave a window to signal the process. Built the debug binary and ran an `upload` against a dummy token, then interrupted it three ways:

- **Ctrl+C** (SIGINT) in the foreground
- `kill -INT <pid>` (SIGINT via signal)
- `kill -TERM <pid>` (SIGTERM — what CI cancellation sends)

In all three cases, with the fix:
- the process exits within a fraction of a second of the signal,
- the `... taking longer than expected ...` output stops immediately (no further lines print), and
- the exit code is **130** (SIGINT) / **143** (SIGTERM).

For contrast, neutering `AbortOnDrop::drop` reproduced the original bug: after the signal the "taking longer than expected" line kept printing every 2s and the process hung instead of exiting.

The temp sleeps were only ever local — they are **not** part of this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)