### PR TITLE
fix(test_report): write trunk_output.bin atomically via temp file + rename

### DIFF
--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -302,24 +302,10 @@ class TrunkAnalyticsListener
 
   def initialize
     @testreport = $test_report
-    remove_preexisting_local_report
   end
 
   def example_finished(notification)
     add_test_case(notification.example)
-  end
-
-  # A previous rspec invocation may have left a report at this path; if it was
-  # longer than the one this run writes, its trailing bytes would survive the
-  # rewrite and corrupt the report. The filename must match what
-  # TestReport#try_save writes (test_report/src/report.rs).
-  def remove_preexisting_local_report
-    return unless ENV['TRUNK_LOCAL_UPLOAD_DIR']
-
-    report_path = File.join(ENV['TRUNK_LOCAL_UPLOAD_DIR'], 'trunk_output.bin')
-    File.delete(report_path) if File.exist?(report_path)
-  rescue StandardError => e
-    puts "Failed to remove pre-existing local report: #{e}".yellow
   end
 
   # trunk-ignore(rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -302,10 +302,24 @@ class TrunkAnalyticsListener
 
   def initialize
     @testreport = $test_report
+    remove_preexisting_local_report
   end
 
   def example_finished(notification)
     add_test_case(notification.example)
+  end
+
+  # A previous rspec invocation may have left a report at this path; if it was
+  # longer than the one this run writes, its trailing bytes would survive the
+  # rewrite and corrupt the report. The filename must match what
+  # TestReport#try_save writes (test_report/src/report.rs).
+  def remove_preexisting_local_report
+    return unless ENV['TRUNK_LOCAL_UPLOAD_DIR']
+
+    report_path = File.join(ENV['TRUNK_LOCAL_UPLOAD_DIR'], 'trunk_output.bin')
+    File.delete(report_path) if File.exist?(report_path)
+  rescue StandardError => e
+    puts "Failed to remove pre-existing local report: #{e}".yellow
   end
 
   # trunk-ignore(rubocop/Metrics/MethodLength,rubocop/Metrics/AbcSize)

--- a/test_report/src/report.rs
+++ b/test_report/src/report.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     env, fs,
+    io::Write,
     path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
@@ -757,18 +758,29 @@ impl MutTestReport {
     // saves to local fs and returns the path
     fn save(&self, path_buf: std::path::PathBuf) -> Result<std::path::PathBuf, std::io::Error> {
         // create parent directory if it doesn't exist
-        if let Some(parent) = path_buf.parent() {
-            if !parent.exists() {
-                fs::create_dir_all(parent)?;
-            }
+        let parent = path_buf
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        if !parent.exists() {
+            fs::create_dir_all(parent)?;
         }
         let buf = self.serialize_test_report();
-        fs::write(&path_buf, buf)?;
+        // write to a unique temp file and atomically rename it into place: a
+        // truncate-then-write of the final path can interleave with another
+        // writer (e.g. a parallel test shard saving to the same path), leaving
+        // the tail of a longer report past the new EOF and corrupting the protobuf.
+        // The temp file must be in the same directory so the rename cannot cross
+        // filesystems.
+        let mut temp_file = tempfile::NamedTempFile::new_in(parent)?;
+        temp_file.write_all(&buf)?;
         // file modification uses filetime which is less precise than systemTime
         // we need to update it to the current time to avoid race conditions later down the line
         // when the start time ends up being after the file modification time
-        let file = fs::File::open(&path_buf).unwrap();
-        file.set_modified(SystemTime::now())?;
+        temp_file.as_file().set_modified(SystemTime::now())?;
+        temp_file
+            .persist(&path_buf)
+            .map_err(|persist| persist.error)?;
         Ok(path_buf)
     }
 

--- a/test_report/tests/publish.rs
+++ b/test_report/tests/publish.rs
@@ -1,6 +1,15 @@
 mod common;
 
-use std::{env, fs, io::BufReader, path::Path, thread};
+use std::{
+    env, fs,
+    io::BufReader,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+};
 
 use assert_matches::assert_matches;
 use bundle::{BundleMeta, FileSetType};
@@ -280,11 +289,44 @@ fn try_save_leaves_decodable_report_under_concurrent_writers() {
     let temp_dir = tempdir().unwrap();
     setup_quarantine_disk_cache_dir(&temp_dir);
     let dir = temp_dir.path().to_str().unwrap().to_string();
+    let file_path = temp_dir.path().join("trunk_output.bin");
 
     // Writers with very different report sizes race on the same path. A
-    // truncate-then-write save can interleave so the tail of a longer report
-    // survives past a shorter one's EOF, corrupting the protobuf; the atomic
-    // temp-file + rename must always leave a complete report.
+    // truncate-then-write save can interleave with the other writers — or be
+    // observed mid-write by a reader (in production, the uploader is a separate
+    // process reading this path) — exposing an empty, truncated, or
+    // partially-overwritten file. The atomic temp-file + rename must instead
+    // guarantee that the path, whenever it exists, holds one complete report:
+    // it decodes, and carries the test_result + uploader_metadata set at
+    // construction time.
+    let writers_done = Arc::new(AtomicBool::new(false));
+
+    let reader = {
+        let writers_done = writers_done.clone();
+        let file_path = file_path.clone();
+        thread::spawn(move || {
+            let mut observations = 0u64;
+            while !writers_done.load(Ordering::Relaxed) {
+                let Ok(data) = fs::read(&file_path) else {
+                    continue;
+                };
+                let report = TestReport::decode(&*data)
+                    .expect("observed report should decode with no trailing bytes");
+                assert_eq!(
+                    report.test_results.len(),
+                    1,
+                    "observed report should be complete, not empty or truncated"
+                );
+                assert!(
+                    report.uploader_metadata.is_some(),
+                    "observed report should carry its uploader_metadata trailer"
+                );
+                observations += 1;
+            }
+            observations
+        })
+    };
+
     let handles: Vec<_> = (0..8)
         .map(|writer_index| {
             let dir = dir.clone();
@@ -320,9 +362,13 @@ fn try_save_leaves_decodable_report_under_concurrent_writers() {
     for handle in handles {
         handle.join().unwrap();
     }
+    writers_done.store(true, Ordering::Relaxed);
+    let observations = reader
+        .join()
+        .expect("reader should observe only complete reports");
+    more_asserts::assert_gt!(observations, 0);
 
-    let data =
-        fs::read(temp_dir.path().join("trunk_output.bin")).expect("Failed to read saved file");
+    let data = fs::read(&file_path).expect("Failed to read saved file");
     TestReport::decode(&*data)
         .expect("concurrently saved report should decode with no trailing bytes");
 }

--- a/test_report/tests/publish.rs
+++ b/test_report/tests/publish.rs
@@ -274,6 +274,59 @@ fn publish_try_save() {
     assert_eq!(test_result.test_case_runs.len(), 0);
 }
 
+#[test]
+fn try_save_leaves_decodable_report_under_concurrent_writers() {
+    cleanup_env_vars();
+    let temp_dir = tempdir().unwrap();
+    setup_quarantine_disk_cache_dir(&temp_dir);
+    let dir = temp_dir.path().to_str().unwrap().to_string();
+
+    // Writers with very different report sizes race on the same path. A
+    // truncate-then-write save can interleave so the tail of a longer report
+    // survives past a shorter one's EOF, corrupting the protobuf; the atomic
+    // temp-file + rename must always leave a complete report.
+    let handles: Vec<_> = (0..8)
+        .map(|writer_index| {
+            let dir = dir.clone();
+            thread::spawn(move || {
+                let report = MutTestReport::new(
+                    "test-origin".into(),
+                    "test-command".into(),
+                    Some("test-variant".into()),
+                );
+                for test_index in 0..(writer_index * 200) {
+                    report.add_test(
+                        Some(format!("{writer_index}-{test_index}")),
+                        format!("test-name-{test_index}"),
+                        "test-classname".into(),
+                        "test-file".into(),
+                        "test-parent-name".into(),
+                        None,
+                        Status::Success,
+                        0,
+                        1000,
+                        1001,
+                        String::new(),
+                        String::new(),
+                        false,
+                    );
+                }
+                for _ in 0..20 {
+                    assert!(report.try_save(dir.clone()));
+                }
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let data =
+        fs::read(temp_dir.path().join("trunk_output.bin")).expect("Failed to read saved file");
+    TestReport::decode(&*data)
+        .expect("concurrently saved report should decode with no trailing bytes");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn publish_environment_variable_overrides() {


### PR DESCRIPTION
## Summary

When `TRUNK_LOCAL_UPLOAD_DIR` is set, the rspec plugin saves `trunk_output.bin` at suite end via `TestReport::save`, which used `fs::write` — a truncate-then-write of the final path. That is not atomic: concurrent writers (e.g. parallel rspec shards saving to the same directory) can interleave so the tail of a longer report survives past a shorter one's EOF, corrupting the protobuf.

We observed exactly this in production: a customer bundle contained a fully valid `TestReport` followed by 942 bytes of a stale, larger report (with multiple layered `uploader_metadata` trailers). Ingestion deterministically fails on the stale bytes with `decode error: failed to decode Protobuf message: groups not supported`, and the upload retries until it is dead-lettered — silently losing the run's results. See TRUNK-18745 for the full byte-level analysis and evidence.

## Change

`TestReport::save` now writes the serialized report to a unique temp file (`tempfile::NamedTempFile`) in the destination directory and atomically renames it into place. The final path only ever holds one complete report — a reader or competing writer can never observe a partially-overwritten file. The temp file lives in the same directory so the rename cannot cross filesystems, and the existing mtime freshening is preserved (applied to the temp file before the rename).

An earlier revision of this PR deleted stale `trunk_output.bin` files at rspec suite start (Ruby side); that is reverted here in favor of the atomic write, which covers both the sequential-staleness and concurrent-writer cases at the source.

## Remaining gap

With N parallel shards writing the same path, atomic writes guarantee a *valid* file but still mean last-writer-wins — N−1 shards' results are dropped. Distinct per-process output paths are the follow-up if shard-level completeness is needed (tracked in TRUNK-18745).

## Testing

- `cargo check -p test_report` clean (no new warnings), `cargo fmt`, `trunk check` no new issues.
- Existing `test_report` suite passes, including `publish_try_save`.
- New regression test `try_save_leaves_decodable_report_under_concurrent_writers`: 8 threads with very differently sized reports race 20 saves each on one path; the surviving file must decode cleanly. Deterministically green with atomic rename; the old truncate-then-write could interleave and fail it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)