### PR TITLE
Add musl Linux gem support via -linux-gnu/-linux-musl split (Alpine)

### DIFF
--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -33,6 +33,10 @@ inputs:
   knapsack-pro-test-suite-token-rspec:
     description: Optional Knapsack Pro test suite token for RSpec
     required: true
+  alpine:
+    description: Run the smoke specs inside a musl (Alpine) container via docker instead of on the host
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -40,6 +44,7 @@ runs:
     - uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
+      if: inputs.alpine != 'true'
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true
@@ -51,8 +56,41 @@ runs:
         path: ${{ github.action_path }}
         merge-multiple: true
 
+    - name: Run smoke specs in a musl (Alpine) container
+      if: inputs.alpine == 'true'
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
+        TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}
+        TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
+        TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
+        TRUNK_VARIANT: ${{ inputs.variant }}
+      run: |
+        set -euxo pipefail
+        GEM_FILE=$(ls rspec_trunk_flaky_tests-*.gem | head -n 1)
+        REL="${GITHUB_ACTION_PATH#"${GITHUB_WORKSPACE}"/}"
+
+        # Forward the (non-secret) GitHub CI context so the gem detects CI and
+        # derives repo metadata just as it does on the host.
+        env | grep -E '^GITHUB_' > "${RUNNER_TEMP}/ci.env" || true
+
+        docker run --rm \
+          --env-file "${RUNNER_TEMP}/ci.env" \
+          -e GEM_FILE="${GEM_FILE}" \
+          -e TRUNK_PUBLIC_API_ADDRESS -e TRUNK_ORG_URL_SLUG -e TRUNK_API_TOKEN \
+          -e TRUNK_TEST_COLLECTION_ID -e TRUNK_VARIANT \
+          -v "${GITHUB_WORKSPACE}:/work" -w "/work/${REL}" \
+          "ruby:${{ inputs.ruby-version }}-alpine" \
+          sh -euxc '
+            gem install rspec --no-document
+            gem install "./${GEM_FILE}" --local --no-document
+            rspec -Ispec spec/test_spec.rb spec/multiple_exception_spec.rb --format documentation
+          '
+
     - name: Setup gem
       id: setup-gem
+      if: inputs.alpine != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
@@ -81,6 +119,7 @@ runs:
 
     - name: Run regular tests
       id: run-regular-tests
+      if: inputs.alpine != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
@@ -94,6 +133,7 @@ runs:
 
     - name: Run variant quarantine test without variant (should fail - not quarantined)
       id: run-variant-test-no-variant
+      if: inputs.alpine != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
@@ -115,6 +155,7 @@ runs:
 
     - name: Run variant quarantine test with variant (should pass - quarantined)
       id: run-variant-test-with-variant
+      if: inputs.alpine != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
@@ -136,6 +177,7 @@ runs:
 
     - name: Run quarantine lookup failure abort test (should fail fast, skip slow_test)
       id: run-quarantine-abort-test
+      if: inputs.alpine != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
@@ -161,7 +203,7 @@ runs:
 
     - name: Run knapsack_pro queue and verify a single local bundle
       shell: bash
-      if: inputs.knapsack-pro-test-suite-token-rspec != ''
+      if: inputs.alpine != 'true' && inputs.knapsack-pro-test-suite-token-rspec != ''
       working-directory: ${{ github.action_path }}
       env:
         KNAPSACK_PRO_TEST_DIR: spec

--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -71,8 +71,7 @@ runs:
         GEM_FILE=$(ls rspec_trunk_flaky_tests-*.gem | head -n 1)
         REL="${GITHUB_ACTION_PATH#"${GITHUB_WORKSPACE}"/}"
 
-        # Forward the (non-secret) GitHub CI context so the gem detects CI and
-        # derives repo metadata just as it does on the host.
+        # Forward the (non-secret) GitHub CI context into the container.
         env | grep -E '^GITHUB_' > "${RUNNER_TEMP}/ci.env" || true
 
         docker run --rm \

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -156,9 +156,7 @@ jobs:
           artifact-pattern: cross-gem-${{ matrix.platform.name }}
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
-  # test-ruby-gem covers glibc/darwin via ruby/setup-ruby, which has no Alpine
-  # support. The same action runs the musl gems inside a ruby:*-alpine
-  # container (alpine: true) so they are validated on a musl host.
+  # Validate the musl gems inside Alpine (ruby/setup-ruby has no Alpine support).
   test-musl-gem:
     name: Test ${{ matrix.platform.name }} gem on Alpine (ruby ${{ matrix.ruby-version }})
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -156,12 +156,12 @@ jobs:
           artifact-pattern: cross-gem-${{ matrix.platform.name }}
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
-  # The glibc-linked *-linux gems fail to load on Alpine/musl (e.g.
-  # "Error relocating ... __res_init: symbol not found"). The musl-targeted gems
-  # must therefore be validated inside an Alpine container rather than on the
-  # glibc-based ubuntu runners used by test-ruby-gem. ruby/setup-ruby does not
-  # support Alpine, so we download the artifact on the host and exercise the gem
-  # inside an official ruby:*-alpine image via docker.
+  # test-ruby-gem covers glibc/darwin via ruby/setup-ruby, which has no Alpine
+  # support. So we validate the musl gems in an official ruby:*-alpine image:
+  # the artifact is downloaded on the host and the smoke specs run inside the
+  # container via docker. One Ruby version per arch is enough — the __res_init
+  # failure is a libc-linkage issue shared by every per-Ruby .so in a gem, and
+  # per-Ruby coverage already lives in test-ruby-gem.
   test-musl-gem:
     name: Test ${{ matrix.platform.name }} gem on Alpine (ruby ${{ matrix.ruby-version }})
     runs-on: ${{ matrix.platform.os }}
@@ -169,11 +169,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The __res_init failure is a libc-linkage issue: every per-Ruby .so in
-        # a musl gem is linked the same way, so one Ruby version proves the
-        # linkage for all. Per-Ruby load-path/ABI coverage is already handled by
-        # test-ruby-gem. We do exercise both arches, since each is a separately
-        # built artifact.
         ruby-version: ["3.4"]
         platform:
           - name: x86_64-linux-musl
@@ -181,44 +176,48 @@ jobs:
           - name: aarch64-linux-musl
             os: ubuntu-24.04-arm
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           pattern: cross-gem-${{ matrix.platform.name }}
           path: pkg
           merge-multiple: true
 
-      - name: Load and exercise musl gem on Alpine
+      - name: Run smoke specs against the musl gem on Alpine
         shell: bash
+        env:
+          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+          TRUNK_ORG_URL_SLUG: trunk-staging-org
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          TRUNK_TEST_COLLECTION_ID: T5yKSn9h
+          TRUNK_VARIANT: ${{ matrix.platform.name }}
         run: |
           set -euxo pipefail
           GEM_FILE=$(ls pkg/rspec_trunk_flaky_tests-*.gem | head -n 1)
           echo "Testing gem: ${GEM_FILE}"
 
-          # Runtime check: require dlopens the native extension (this is where a
-          # glibc-only build dies on musl), then call into it to confirm it is
-          # functional and not merely loadable.
-          cat > musl_load_test.rb <<'RUBY'
-          require 'rspec_trunk_flaky_tests'
-          puts 'loaded native extension OK'
-          info = env_parse({
-            'GITHUB_ACTIONS' => 'true',
-            'GITHUB_REF' => 'abc',
-            'GITHUB_RUN_ID' => '12345',
-            'GITHUB_REPOSITORY' => 'analytics-cli'
-          }, [])
-          abort 'env_parse returned nil' if info.nil?
-          abort "unexpected platform: #{info.platform}" unless info.platform.to_s == 'GITHUB_ACTIONS'
-          puts "env_parse OK on musl: #{info.platform}"
-          RUBY
+          # Forward the (non-secret) GitHub CI context so the gem detects CI and
+          # derives repo metadata just as it does in test-ruby-gem on the host.
+          env | grep -E '^GITHUB_' > "${RUNNER_TEMP}/ci.env" || true
 
+          # Run the same specs test-ruby-gem uses, inside Alpine, against the
+          # precompiled musl gem. This dlopens the native extension (where a
+          # glibc-only build dies on musl with __res_init), fetches the
+          # quarantine list over TLS/DNS, serializes results in the extension,
+          # and uploads — exercising the full runtime, not just gem loading.
           docker run --rm \
+            --env-file "${RUNNER_TEMP}/ci.env" \
             -e GEM_FILE="${GEM_FILE}" \
+            -e TRUNK_PUBLIC_API_ADDRESS -e TRUNK_ORG_URL_SLUG -e TRUNK_API_TOKEN \
+            -e TRUNK_TEST_COLLECTION_ID -e TRUNK_VARIANT \
             -v "${PWD}:/work" -w /work \
             "ruby:${{ matrix.ruby-version }}-alpine" \
             sh -euxc '
-              gem install rspec-core --no-document
+              gem install rspec --no-document
               gem install "${GEM_FILE}" --local --no-document
-              ruby musl_load_test.rb
+              cd .github/actions/test_ruby_gem_uploads
+              rspec -Ispec spec/test_spec.rb spec/multiple_exception_spec.rb --format documentation
             '
 
   publish_ruby_gem:

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -157,11 +157,7 @@ jobs:
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
   # test-ruby-gem covers glibc/darwin via ruby/setup-ruby, which has no Alpine
-  # support. So we validate the musl gems in an official ruby:*-alpine image:
-  # the artifact is downloaded on the host and the smoke specs run inside the
-  # container via docker. One Ruby version per arch is enough — the __res_init
-  # failure is a libc-linkage issue shared by every per-Ruby .so in a gem, and
-  # per-Ruby coverage already lives in test-ruby-gem.
+  # support. So we validate the musl gems in an official ruby:*-alpine image
   test-musl-gem:
     name: Test ${{ matrix.platform.name }} gem on Alpine (ruby ${{ matrix.ruby-version }})
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -169,10 +169,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # A representative spread of Ruby ABIs with reliable Alpine images. The
-        # __res_init failure is a libc-linkage issue, so it reproduces
-        # independently of the Ruby version — no need to cover every ABI here.
-        ruby-version: ["3.1", "3.4"]
+        # The __res_init failure is a libc-linkage issue: every per-Ruby .so in
+        # a musl gem is linked the same way, so one Ruby version proves the
+        # linkage for all. Per-Ruby load-path/ABI coverage is already handled by
+        # test-ruby-gem. We do exercise both arches, since each is a separately
+        # built artifact.
+        ruby-version: ["3.4"]
         platform:
           - name: x86_64-linux-musl
             os: ubuntu-latest

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -157,7 +157,8 @@ jobs:
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
   # test-ruby-gem covers glibc/darwin via ruby/setup-ruby, which has no Alpine
-  # support. So we validate the musl gems in an official ruby:*-alpine image
+  # support. The same action runs the musl gems inside a ruby:*-alpine
+  # container (alpine: true) so they are validated on a musl host.
   test-musl-gem:
     name: Test ${{ matrix.platform.name }} gem on Alpine (ruby ${{ matrix.ruby-version }})
     runs-on: ${{ matrix.platform.os }}
@@ -174,45 +175,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - name: Test musl gem uploads → analytics-cli-ruby-gem (staging)
+        uses: ./.github/actions/test_ruby_gem_uploads
         with:
-          pattern: cross-gem-${{ matrix.platform.name }}
-          path: pkg
-          merge-multiple: true
-
-      - name: Run smoke specs against the musl gem on Alpine
-        shell: bash
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
-          TRUNK_ORG_URL_SLUG: trunk-staging-org
-          TRUNK_API_TOKEN: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-          TRUNK_TEST_COLLECTION_ID: T5yKSn9h
-          TRUNK_VARIANT: ${{ matrix.platform.name }}
-        run: |
-          set -euxo pipefail
-          GEM_FILE=$(ls pkg/rspec_trunk_flaky_tests-*.gem | head -n 1)
-          echo "Testing gem: ${GEM_FILE}"
-
-          # Forward the (non-secret) GitHub CI context so the gem detects CI and
-          # derives repo metadata just as it does in test-ruby-gem on the host.
-          env | grep -E '^GITHUB_' > "${RUNNER_TEMP}/ci.env" || true
-
-          # Run the same specs test-ruby-gem uses, but inside Alpine against the
-          # precompiled musl gem, so the musl build is exercised end to end
-          # (quarantine lookup, result serialization, upload) on a musl host.
-          docker run --rm \
-            --env-file "${RUNNER_TEMP}/ci.env" \
-            -e GEM_FILE="${GEM_FILE}" \
-            -e TRUNK_PUBLIC_API_ADDRESS -e TRUNK_ORG_URL_SLUG -e TRUNK_API_TOKEN \
-            -e TRUNK_TEST_COLLECTION_ID -e TRUNK_VARIANT \
-            -v "${PWD}:/work" -w /work \
-            "ruby:${{ matrix.ruby-version }}-alpine" \
-            sh -euxc '
-              gem install rspec --no-document
-              gem install "${GEM_FILE}" --local --no-document
-              cd .github/actions/test_ruby_gem_uploads
-              rspec -Ispec spec/test_spec.rb spec/multiple_exception_spec.rb --format documentation
-            '
+          alpine: "true"
+          ruby-version: ${{ matrix.ruby-version }}
+          trunk-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          trunk-public-api-address: https://api.trunk-staging.io
+          trunk-org-slug: trunk-staging-org
+          test-collection-id: T5yKSn9h
+          platform: ${{ matrix.platform.name }}
+          variant: ${{ matrix.platform.name }}
+          artifact-pattern: cross-gem-${{ matrix.platform.name }}
+          knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
   publish_ruby_gem:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -48,9 +48,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - x86_64-linux
+          - x86_64-linux-gnu
           - x86_64-linux-musl
-          - aarch64-linux
+          - aarch64-linux-gnu
           - aarch64-linux-musl
           - arm64-darwin
           - x86_64-darwin
@@ -98,7 +98,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           working-directory: rspec-trunk-flaky-tests
-          ruby-versions: 3.0,3.1,3.2,3.3,3.4,4.0
+          ruby-versions: 3.1,3.2,3.3,3.4,4.0
 
       - name: Validate ruby platform gem
         if: matrix.platform == 'ruby'
@@ -117,11 +117,11 @@ jobs:
     needs: [ci-data, cross-gem]
     strategy:
       matrix:
-        ruby-version: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby-version: ["3.1", "3.2", "3.3", "3.4", "4.0"]
         platform:
-          - name: x86_64-linux
+          - name: x86_64-linux-gnu
             os: ubuntu-latest
-          - name: aarch64-linux
+          - name: aarch64-linux-gnu
             os: ubuntu-24.04-arm
           - name: arm64-darwin
             os: macos-latest

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -197,11 +197,9 @@ jobs:
           # derives repo metadata just as it does in test-ruby-gem on the host.
           env | grep -E '^GITHUB_' > "${RUNNER_TEMP}/ci.env" || true
 
-          # Run the same specs test-ruby-gem uses, inside Alpine, against the
-          # precompiled musl gem. This dlopens the native extension (where a
-          # glibc-only build dies on musl with __res_init), fetches the
-          # quarantine list over TLS/DNS, serializes results in the extension,
-          # and uploads — exercising the full runtime, not just gem loading.
+          # Run the same specs test-ruby-gem uses, but inside Alpine against the
+          # precompiled musl gem, so the musl build is exercised end to end
+          # (quarantine lookup, result serialization, upload) on a musl host.
           docker run --rm \
             --env-file "${RUNNER_TEMP}/ci.env" \
             -e GEM_FILE="${GEM_FILE}" \

--- a/.github/workflows/release_ruby_gem.yml
+++ b/.github/workflows/release_ruby_gem.yml
@@ -49,7 +49,9 @@ jobs:
       matrix:
         platform:
           - x86_64-linux
+          - x86_64-linux-musl
           - aarch64-linux
+          - aarch64-linux-musl
           - arm64-darwin
           - x86_64-darwin
           - ruby
@@ -154,9 +156,72 @@ jobs:
           artifact-pattern: cross-gem-${{ matrix.platform.name }}
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
 
+  # The glibc-linked *-linux gems fail to load on Alpine/musl (e.g.
+  # "Error relocating ... __res_init: symbol not found"). The musl-targeted gems
+  # must therefore be validated inside an Alpine container rather than on the
+  # glibc-based ubuntu runners used by test-ruby-gem. ruby/setup-ruby does not
+  # support Alpine, so we download the artifact on the host and exercise the gem
+  # inside an official ruby:*-alpine image via docker.
+  test-musl-gem:
+    name: Test ${{ matrix.platform.name }} gem on Alpine (ruby ${{ matrix.ruby-version }})
+    runs-on: ${{ matrix.platform.os }}
+    needs: cross-gem
+    strategy:
+      fail-fast: false
+      matrix:
+        # A representative spread of Ruby ABIs with reliable Alpine images. The
+        # __res_init failure is a libc-linkage issue, so it reproduces
+        # independently of the Ruby version — no need to cover every ABI here.
+        ruby-version: ["3.1", "3.4"]
+        platform:
+          - name: x86_64-linux-musl
+            os: ubuntu-latest
+          - name: aarch64-linux-musl
+            os: ubuntu-24.04-arm
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cross-gem-${{ matrix.platform.name }}
+          path: pkg
+          merge-multiple: true
+
+      - name: Load and exercise musl gem on Alpine
+        shell: bash
+        run: |
+          set -euxo pipefail
+          GEM_FILE=$(ls pkg/rspec_trunk_flaky_tests-*.gem | head -n 1)
+          echo "Testing gem: ${GEM_FILE}"
+
+          # Runtime check: require dlopens the native extension (this is where a
+          # glibc-only build dies on musl), then call into it to confirm it is
+          # functional and not merely loadable.
+          cat > musl_load_test.rb <<'RUBY'
+          require 'rspec_trunk_flaky_tests'
+          puts 'loaded native extension OK'
+          info = env_parse({
+            'GITHUB_ACTIONS' => 'true',
+            'GITHUB_REF' => 'abc',
+            'GITHUB_RUN_ID' => '12345',
+            'GITHUB_REPOSITORY' => 'analytics-cli'
+          }, [])
+          abort 'env_parse returned nil' if info.nil?
+          abort "unexpected platform: #{info.platform}" unless info.platform.to_s == 'GITHUB_ACTIONS'
+          puts "env_parse OK on musl: #{info.platform}"
+          RUBY
+
+          docker run --rm \
+            -e GEM_FILE="${GEM_FILE}" \
+            -v "${PWD}:/work" -w /work \
+            "ruby:${{ matrix.ruby-version }}-alpine" \
+            sh -euxc '
+              gem install rspec-core --no-document
+              gem install "${GEM_FILE}" --local --no-document
+              ruby musl_load_test.rb
+            '
+
   publish_ruby_gem:
     runs-on: ubuntu-latest
-    needs: test-ruby-gem
+    needs: [test-ruby-gem, test-musl-gem]
     steps:
       - uses: actions/checkout@v4
 

--- a/rspec-trunk-flaky-tests/Gemfile.lock
+++ b/rspec-trunk-flaky-tests/Gemfile.lock
@@ -30,11 +30,13 @@ GEM
     rspec-support (3.13.2)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin
   arm64-linux
   ruby
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   rake

--- a/rspec-trunk-flaky-tests/Gemfile.lock
+++ b/rspec-trunk-flaky-tests/Gemfile.lock
@@ -30,13 +30,11 @@ GEM
     rspec-support (3.13.2)
 
 PLATFORMS
-  aarch64-linux-musl
   arm64-darwin
   arm64-linux
   ruby
   x86_64-darwin
   x86_64-linux
-  x86_64-linux-musl
 
 DEPENDENCIES
   rake

--- a/rspec-trunk-flaky-tests/README.md
+++ b/rspec-trunk-flaky-tests/README.md
@@ -15,7 +15,7 @@ The gem includes a native Rust extension (`rspec_trunk_flaky_tests`) that provid
 
 ## Prerequisites
 
-- Ruby 3.0 or later
+- Ruby 3.1 or later
 - Bundler
 - Rust and Cargo (for building the native extension)
 - `rb-sys` gem (installed automatically via dependencies)
@@ -57,14 +57,14 @@ The gem will be built and available in `pkg/`.
 Build the native extension for a specific platform:
 
 ```bash
-bundle exec rake native[x86_64-linux]
+bundle exec rake native[x86_64-linux-gnu]
 ```
 
 Supported platforms:
 
-- `x86_64-linux`
+- `x86_64-linux-gnu`
 - `x86_64-linux-musl` (Alpine and other musl-based distros)
-- `aarch64-linux`
+- `aarch64-linux-gnu`
 - `aarch64-linux-musl` (Alpine and other musl-based distros)
 - `arm64-darwin`
 - `x86_64-darwin`
@@ -251,8 +251,8 @@ To release a new version:
 1. Trigger the workflow manually via GitHub Actions UI or API
 2. Provide the release tag (version number) as input
 3. The workflow will:
-   - Build the gem for all supported platforms (`x86_64-linux`, `x86_64-linux-musl`, `aarch64-linux`, `aarch64-linux-musl`, `arm64-darwin`, `x86_64-darwin`)
-   - Test the gem on all platforms with Ruby versions 3.0, 3.1, 3.2, 3.3, and 3.4
+   - Build the gem for all supported platforms (`x86_64-linux-gnu`, `x86_64-linux-musl`, `aarch64-linux-gnu`, `aarch64-linux-musl`, `arm64-darwin`, `x86_64-darwin`)
+   - Test the gem on all platforms with Ruby versions 3.1, 3.2, 3.3, 3.4, and 4.0
    - Publish the gem to RubyGems if all tests pass
 
 The workflow automatically handles cross-compilation, testing, and publishing for all supported platforms.

--- a/rspec-trunk-flaky-tests/README.md
+++ b/rspec-trunk-flaky-tests/README.md
@@ -63,7 +63,9 @@ bundle exec rake native[x86_64-linux]
 Supported platforms:
 
 - `x86_64-linux`
+- `x86_64-linux-musl` (Alpine and other musl-based distros)
 - `aarch64-linux`
+- `aarch64-linux-musl` (Alpine and other musl-based distros)
 - `arm64-darwin`
 - `x86_64-darwin`
 
@@ -249,7 +251,7 @@ To release a new version:
 1. Trigger the workflow manually via GitHub Actions UI or API
 2. Provide the release tag (version number) as input
 3. The workflow will:
-   - Build the gem for all supported platforms (`x86_64-linux`, `aarch64-linux`, `arm64-darwin`, `x86_64-darwin`)
+   - Build the gem for all supported platforms (`x86_64-linux`, `x86_64-linux-musl`, `aarch64-linux`, `aarch64-linux-musl`, `arm64-darwin`, `x86_64-darwin`)
    - Test the gem on all platforms with Ruby versions 3.0, 3.1, 3.2, 3.3, and 3.4
    - Publish the gem to RubyGems if all tests pass
 

--- a/rspec-trunk-flaky-tests/Rakefile
+++ b/rspec-trunk-flaky-tests/Rakefile
@@ -16,10 +16,10 @@ end
 desc 'Build native extension for a provided platform'
 task :native, [:platform] do |_t, platform:|
   Dir.chdir '..' do
-    if platform == 'x86_64-linux'
-      sh 'bundle', 'exec', 'rb-sys-dock', '--platform', platform, '--build', '--directory', 'rspec-trunk-flaky-tests', '--ruby-versions', '3.0,3.1,3.2,3.3,3.4,4.0', '--', 'sudo yum install -y perl-IPC-Cmd'
+    if %w[x86_64-linux-gnu x86_64-linux].include?(platform)
+      sh 'bundle', 'exec', 'rb-sys-dock', '--platform', platform, '--build', '--directory', 'rspec-trunk-flaky-tests', '--ruby-versions', '3.1,3.2,3.3,3.4,4.0', '--', 'sudo yum install -y perl-IPC-Cmd'
     else
-      sh 'bundle', 'exec', 'rb-sys-dock', '--platform', platform, '--build', '--directory', 'rspec-trunk-flaky-tests', '--ruby-versions', '3.0,3.1,3.2,3.3,3.4,4.0'
+      sh 'bundle', 'exec', 'rb-sys-dock', '--platform', platform, '--build', '--directory', 'rspec-trunk-flaky-tests', '--ruby-versions', '3.1,3.2,3.3,3.4,4.0'
     end
   end
 end

--- a/rspec-trunk-flaky-tests/lib/rspec_trunk_flaky_tests.rb
+++ b/rspec-trunk-flaky-tests/lib/rspec_trunk_flaky_tests.rb
@@ -18,9 +18,6 @@ rescue LoadError
         x86_64-linux, x86_64-linux-musl, aarch64-linux, aarch64-linux-musl,
         arm64-darwin, x86_64-darwin
 
-      The *-linux-musl gems support musl-based distributions such as Alpine.
-      Upgrade to a recent bundler/rubygems so the musl variant is selected.
-
       If you are on a supported platform and seeing this error, make sure
       bundler is selecting the native variant for your platform:
 

--- a/rspec-trunk-flaky-tests/lib/rspec_trunk_flaky_tests.rb
+++ b/rspec-trunk-flaky-tests/lib/rspec_trunk_flaky_tests.rb
@@ -15,8 +15,8 @@ rescue LoadError
       this dependency. It does not include a precompiled native extension.
 
       Precompiled native gems are available for:
-        x86_64-linux, x86_64-linux-musl, aarch64-linux, aarch64-linux-musl,
-        arm64-darwin, x86_64-darwin
+        x86_64-linux-gnu, x86_64-linux-musl, aarch64-linux-gnu,
+        aarch64-linux-musl, arm64-darwin, x86_64-darwin
 
       If you are on a supported platform and seeing this error, make sure
       bundler is selecting the native variant for your platform:

--- a/rspec-trunk-flaky-tests/lib/rspec_trunk_flaky_tests.rb
+++ b/rspec-trunk-flaky-tests/lib/rspec_trunk_flaky_tests.rb
@@ -15,7 +15,11 @@ rescue LoadError
       this dependency. It does not include a precompiled native extension.
 
       Precompiled native gems are available for:
-        x86_64-linux, aarch64-linux, arm64-darwin, x86_64-darwin
+        x86_64-linux, x86_64-linux-musl, aarch64-linux, aarch64-linux-musl,
+        arm64-darwin, x86_64-darwin
+
+      The *-linux-musl gems support musl-based distributions such as Alpine.
+      Upgrade to a recent bundler/rubygems so the musl variant is selected.
 
       If you are on a supported platform and seeing this error, make sure
       bundler is selecting the native variant for your platform:

--- a/rspec-trunk-flaky-tests/rspec_trunk_flaky_tests.gemspec
+++ b/rspec-trunk-flaky-tests/rspec_trunk_flaky_tests.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   # trunk-ignore(rubocop/Gemspec/RequiredRubyVersion)
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.1'
   s.name        = 'rspec_trunk_flaky_tests'
   s.version     = '0.0.0'
   # trunk-ignore(rubocop/Layout/LineLength)


### PR DESCRIPTION
## Summary

Publish the precompiled Linux gems as explicit **`x86_64-linux-gnu` / `aarch64-linux-gnu`** and **`x86_64-linux-musl` / `aarch64-linux-musl`** variants — replacing the bare `x86_64-linux` / `aarch64-linux` builds — so musl-based distros (Alpine, etc.) get a gem that actually loads. This raises the floor to **Ruby >= 3.1**.

## Background: the bug

The bare `*-linux` gems are glibc-linked. As of 0.13.0 the native extension references `__res_init`, a glibc-exclusive resolver symbol musl lacks, so loading on Alpine fails:

```
LoadError: Error relocating .../rspec_trunk_flaky_tests.so: __res_init: symbol not found
```

0.12.0 happened to load on musl by luck; 0.13.x broke it, and the `ruby`-platform gem intentionally raises, so Alpine users were pinned to 0.12.0.

## Why two gems (`-gnu` + `-musl`) and not one cross-compatible `-linux`

A single bare `-linux` gem cannot safely serve both libcs for *this* extension:

- **glibc-linked → doesn't load on musl.** A glibc build carries glibc-versioned symbol references (`__res_init`, `…@GLIBC_x.y`) that musl doesn't provide. The 0.12→0.13 breakage is exactly this — "it works on Alpine" was incidental, not a guarantee, and any dependency bump can reintroduce a glibc-only symbol.
- **musl-static labeled `-linux` → unsafe on glibc.** Tagging a static-musl build as bare `-linux` makes glibc hosts select it too, which means dlopening a musl object into a glibc Ruby process (two libcs in one address space — UB: cross-libc `malloc`/`free`, TLS, `errno`, plus static-TLS `dlopen` failures).
- **This gem is a worst case for a universal build:** it does networking (`reqwest`), TLS (vendored OpenSSL in `context`), and DNS / git-over-HTTPS. DNS resolution (`getaddrinfo`/NSS/`__res_init`) is precisely where glibc and musl diverge, and glibc's resolver can't be statically linked — so the one subsystem that would need to be portable fundamentally isn't.

### This is the documented, sanctioned approach — and the bare `-linux` + `-musl` combo is explicitly broken

The maintainer of **both Nokogiri and rake-compiler-dock** ([@flavorjones](https://github.com/flavorjones)) documented the rule in [rake-compiler-dock#117](https://github.com/rake-compiler/rake-compiler-dock/issues/117):

> Either ship a `-linux` platform gem that works for both gnu and musl systems, or ship both `-linux-gnu` and `-linux-musl` platform gems. **Do NOT ship `-linux` and `-linux-musl` platform gems for the same version.**

Concretely, shipping bare `-linux` alongside `-linux-musl` (what this PR's first pass did) causes:

- **`bundle install` hard-fails** with `Could not find gems matching '…' valid for all resolution platforms` — bare `-linux` is ambiguous (glibc *or* musl), so Bundler can't produce a consistent multi-platform resolution.
- On **Ruby 3.0**, musl systems install the *wrong* (glibc `-linux`) gem.

Since a universal `-linux` isn't achievable for this extension, `-linux-gnu` + `-linux-musl` is the correct — and only unambiguous — option. rake-compiler-dock supports these targets since [v1.5.0](https://github.com/rake-compiler/rake-compiler-dock/blob/main/CHANGELOG.md) (bare `*-linux` is now just an alias for `*-linux-gnu`); our `Gemfile.lock` pins 1.11.0.

## Why Ruby 3.0 is dropped

The gnu/musl platform distinction — including matching a `-gnu` gem to a host that reports itself as bare `x86_64-linux` — requires **RubyGems 3.3.22 / Bundler 2.3.21** (per rake-compiler-dock#117). That RubyGems generation first ships with **Ruby 3.1**. Stock Ruby 3.0 ships RubyGems 3.2.x, which does **not** understand `-gnu`, so a `-gnu` gem would fall through to the raising stub *even for glibc users* on Ruby 3.0. Ruby 3.0 has also been EOL since March 2024. So `required_ruby_version` is bumped to `>= 3.1` and 3.0 is removed from the build/test matrices.

## Prior art

This is the same path other native-extension gems took for musl support:

- **Nokogiri** switched from a single bare `-linux` gem to separate `x86_64-linux-gnu` + `x86_64-linux-musl` (and aarch64/arm) native gems in [v1.18.0](https://github.com/sparklemotion/nokogiri/releases/tag/v1.18.0), via rake-compiler-dock v1.5.1 (contributed by @flavorjones). Published artifacts, e.g. [`nokogiri 1.18.9-x86_64-linux-musl`](https://rubygems.org/gems/nokogiri/versions/1.18.9-x86_64-linux-musl).
- **grpc** — [grpc/grpc#39443](https://github.com/grpc/grpc/issues/39443) "Build separate binary gems for -linux-gnu and -linux-musl".

## Changes

- **Release matrix:** `x86_64-linux-gnu`, `x86_64-linux-musl`, `aarch64-linux-gnu`, `aarch64-linux-musl`, `arm64-darwin`, `x86_64-darwin`, `ruby`.
- **musl validation folded into the shared `test_ruby_gem_uploads` action** via an `alpine` input: when set, it skips the host `ruby/setup-ruby`/bundler steps and runs the *same* smoke specs inside a `ruby:*-alpine` container (docker) against the precompiled musl gem — exercising the full runtime (native load, quarantine lookup over TLS/DNS, result serialization, upload). `test-musl-gem` is a thin job that calls the action with `alpine: true`; `publish_ruby_gem` is gated on it.
- **Ruby >= 3.1:** `required_ruby_version` bumped; 3.0 dropped from cross-gem, `test-ruby-gem`, and the local `rake native` task.
- **Docs / loader:** README supported-platforms + prerequisites and the `LoadError` message updated to the gnu/musl names.

## Rollout note

Consumers on musl must be on **Bundler >= 2.5.6**; earlier Bundler omits the musl native gem from the lockfile ([ruby/rubygems#7432](https://github.com/ruby/rubygems/issues/7432)). Basic gnu/musl resolution needs RubyGems >= 3.3.22 / Bundler >= 2.3.21 (ships with Ruby >= 3.1).

## Sources

- [rake-compiler-dock#117](https://github.com/rake-compiler/rake-compiler-dock/issues/117) — canonical guidance: ship `-linux-gnu` + `-linux-musl`, never bare `-linux` + `-linux-musl`; documents the `bundle install` resolution failure and the RubyGems 3.3.22 / Bundler 2.3.21 (2.5.6 for musl) requirements.
- [rake-compiler-dock CHANGELOG](https://github.com/rake-compiler/rake-compiler-dock/blob/main/CHANGELOG.md) — `-gnu`/`-musl` targets added in 1.5.0; bare `-linux` is an alias for `-linux-gnu`.
- [Nokogiri v1.18.0 release notes](https://github.com/sparklemotion/nokogiri/releases/tag/v1.18.0) — reference implementation adopting the `-gnu`/`-musl` split.
- [grpc/grpc#39443](https://github.com/grpc/grpc/issues/39443) — same split in another large native gem.
- [ruby/rubygems#7432](https://github.com/ruby/rubygems/issues/7432) — musl native gem missing from lockfile on Bundler < 2.5.6.
- [Andrew Nesbitt — Platform Strings](https://nesbitt.io/2026/02/17/platform-strings.html) — overview of RubyGems linux platform matching.

https://claude.ai/code/session_01RumF5roNQnj2XsBS6erPVn