### PR TITLE
Fix ruby gem smoke test: read version from gem metadata

### DIFF
--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -105,9 +105,8 @@ runs:
         GEM_FILE=$(ls rspec_trunk_flaky_tests-*.gem | head -n 1)
         echo "Using gem file: ${GEM_FILE}"
 
-        # Extract version from gem filename (e.g., rspec_trunk_flaky_tests-0.0.0-b75353b-x86_64-linux.gem)
-        PLATFORM="${{ inputs.platform }}"
-        GEM_VERSION=$(echo "${GEM_FILE}" | sed -n "s/rspec_trunk_flaky_tests-\(.*\)-${PLATFORM}\.gem/\1/p")
+        # Read the version from gem metadata (robust to the platform suffix).
+        GEM_VERSION=$(ruby -e "require 'rubygems/package'; puts Gem::Package.new(ARGV[0]).spec.version" "${GEM_FILE}")
         echo "Extracted version: ${GEM_VERSION}"
 
         gem install "${GEM_FILE}" --local


### PR DESCRIPTION
## Summary

Fixes the `Test Ruby gem on staging`/`production` smoke jobs, which started failing on `main` after the `-linux-gnu`/`-linux-musl` split (#1137) once a gem was actually published under the new naming ([failing run](https://github.com/trunk-io/analytics-cli/actions/runs/28958741451/job/85924662351)).

## Root cause

The `test_ruby_gem_uploads` action derived the gem version by stripping `-<platform>.gem` from the filename with `sed`, using the caller's `platform` input:

```bash
PLATFORM="x86_64-linux"
GEM_VERSION=$(echo "${GEM_FILE}" | sed -n "s/rspec_trunk_flaky_tests-\(.*\)-${PLATFORM}\.gem/\1/p")
```

The published glibc gem is now named `rspec_trunk_flaky_tests-<version>-x86_64-linux-gnu.gem`, but the smoke workflows still pass `platform: x86_64-linux`. `-x86_64-linux.gem` no longer matches `-x86_64-linux-gnu.gem`, so `GEM_VERSION` came out empty and the action wrote `gem 'rspec_trunk_flaky_tests', ''` into the harness Gemfile:

```
Gem::Requirement.parse': Illformed requirement [""] (Gem::Requirement::BadRequirementError)
```

This is entirely a testing-harness artifact (unpack gem → rewrite Gemfile with a `:path =>` dependency → pin the scraped version). Real consumers install via `gem install` / `bundle install`, which match the platform and read the version from gem metadata — no filename parsing. The same failing run confirms the real path works: `gem fetch` correctly resolved and downloaded the `-x86_64-linux-gnu` gem on the glibc runner.

## Fix

Read the version straight from the gem's own metadata, so extraction is independent of the platform suffix and of any caller's `platform` input:

```bash
GEM_VERSION=$(ruby -e "require 'rubygems/package'; puts Gem::Package.new(ARGV[0]).spec.version" "${GEM_FILE}")
```

This mirrors what RubyGems/Bundler do natively and fixes every caller (`smoke_test.yml`, `smoke_test_main.yml`, `ruby.yml`, and the release `test-ruby-gem`) regardless of the platform string they pass.

Verified locally against a gem built with the exact `…-x86_64-linux-gnu.gem` filename that failed → extracts the version correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RumF5roNQnj2XsBS6erPVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RumF5roNQnj2XsBS6erPVn)_