### PR TITLE
fix(rspec): quarantine fixed-pending examples instead of hard-failing

### DIFF
--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -174,20 +174,20 @@ runs:
         TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
         TRUNK_VARIANT: ""
 
-    - name: Run variant quarantine test with variant (should pass - quarantined)
+    - name: Run variant and pending quarantine tests with variant (should pass - quarantined)
       id: run-variant-test-with-variant
       if: inputs.alpine != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        bundle exec rspec spec/variant_quarantine_spec.rb --format documentation
+        bundle exec rspec spec/variant_quarantine_spec.rb spec/pending_spec.rb --format documentation
         EXIT_CODE=$?
         if [ $EXIT_CODE -ne 0 ]; then
-          echo "ERROR: Variant quarantine test with variant should have passed (test should be quarantined)"
-          echo "Note: The variant_quarantine_test must be quarantined with variant 'smoke-test-variant' in the system"
+          echo "ERROR: Quarantine tests with variant should have passed (tests should be quarantined)"
+          echo "Note: variant_quarantine_test and pending_quarantine_test must be quarantined with variant 'smoke-test-variant' in the system"
           exit 1
         else
-          echo "SUCCESS: Variant quarantine test with variant passed (test was quarantined)"
+          echo "SUCCESS: Quarantine tests with variant passed (tests were quarantined)"
         fi
       env:
         TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
@@ -195,6 +195,28 @@ runs:
         TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
         TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
         TRUNK_VARIANT: smoke-test-variant
+
+    - name: Run pending quarantine test without variant (should fail - not quarantined)
+      id: run-pending-test-no-variant
+      if: inputs.alpine != 'true'
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        set +e
+        bundle exec rspec spec/pending_spec.rb --format documentation
+        EXIT_CODE=$?
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "ERROR: Pending quarantine test without variant should have failed (fixed-pending is not quarantined)"
+          exit 1
+        else
+          echo "SUCCESS: Pending quarantine test without variant failed as expected (fixed-pending is not quarantined)"
+        fi
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
+        TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}
+        TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
+        TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
+        TRUNK_VARIANT: ""
 
     - name: Run quarantine lookup failure abort test (should fail fast, skip slow_test)
       id: run-quarantine-abort-test

--- a/.github/actions/test_ruby_gem_uploads/spec/pending_spec.rb
+++ b/.github/actions/test_ruby_gem_uploads/spec/pending_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# A fixed-pending example (body now passes -> PendingExampleFixedError) reds the
+# build unless quarantined: it fails without a variant and passes (quarantined)
+# when run with the smoke-test-variant variant.
+describe 'pending_quarantine_test' do
+  it 'should be quarantined when run with variant' do
+    pending('expected to still fail, but the body now passes')
+    expect(2 + 2).to eq(4)
+  end
+end

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -113,7 +113,15 @@ module RSpec
         return set_exception_core(exception) if trunk_disabled
         return set_exception_core(exception) if metadata[:retry_attempts]&.positive?
 
+        handle_quarantine_check_safely(exception)
+      end
+
+      # If the quarantine machinery itself blows up, the failure must stand.
+      def handle_quarantine_check_safely(exception)
         handle_quarantine_check(exception)
+      rescue StandardError => e
+        puts "Quarantine check errored (#{e.class}: #{e.message}), treating test as not quarantined".yellow
+        set_exception_core(exception)
       end
 
       def pending_example_fixed?(exception)

--- a/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
+++ b/rspec-trunk-flaky-tests/lib/trunk_spec_helper.rb
@@ -108,11 +108,17 @@ module RSpec
       # decide if we want to fail the test or not
       # trunk-ignore(rubocop/Naming/AccessorMethodName)
       def set_exception(exception)
-        return set_exception_core(exception) if metadata[:pending]
+        # Pending stays green, except a fixed pending example is a real failure.
+        return set_exception_core(exception) if metadata[:pending] && !pending_example_fixed?(exception)
         return set_exception_core(exception) if trunk_disabled
         return set_exception_core(exception) if metadata[:retry_attempts]&.positive?
 
         handle_quarantine_check(exception)
+      end
+
+      def pending_example_fixed?(exception)
+        defined?(RSpec::Core::Pending::PendingExampleFixedError) &&
+          exception.is_a?(RSpec::Core::Pending::PendingExampleFixedError)
       end
 
       # trunk-ignore(rubocop/Metrics/AbcSize,rubocop/Metrics/MethodLength,rubocop/Metrics/CyclomaticComplexity)
@@ -401,10 +407,13 @@ class TrunkAnalyticsListener
       # the build (the pending expectation was violated), so it is a failure here too.
       [Status.new('failure'), example.exception || quarantined_exception]
     when :pending
-      # Not a skip (handled above), so this is a pending example whose body ran and
-      # failed as expected: the pending expectation ("this should fail") was met, so
-      # RSpec keeps the build green -- report it as a success.
-      [Status.new('success'), nil]
+      # A quarantined fixed-pending is left :pending but pending_fixed? -- still a
+      # failure. Otherwise the pending "should fail" expectation was met -> success.
+      if result.pending_fixed?
+        [Status.new('failure'), quarantined_exception || example.exception]
+      else
+        [Status.new('success'), nil]
+      end
     else
       [Status.new(result.status.to_s), example.exception || quarantined_exception]
     end


### PR DESCRIPTION
## Problem

Was seeing this pending fixed not being quarantined properly: https://github.com/trunk-io/flake-farm/actions/runs/29036655722/job/86202060288#step:7:83

A `pending` example whose body now passes is turned by RSpec into a real failure (`PendingExampleFixedError`) that reds the build. But `Example#set_exception` short-circuited on `metadata[:pending]` **before** reaching `handle_quarantine_check`:

```ruby
return set_exception_core(exception) if metadata[:pending]   # bailed here
...
handle_quarantine_check(exception)
```

So a fixed-pending example never consulted the quarantine list. A test you had quarantined in Trunk still failed the build, and it uploaded as a plain, **un-quarantined** failure (`is_quarantined` derives from `metadata[:quarantined_exception]`, which only `handle_quarantine_check` sets). This is what surfaced in flake-farm: `reports a fixed pending example as failure` stayed red despite being quarantined.

Follow-up to #1136, which fixed how these examples are *classified* but left the quarantine path unreached.

## Fix

- **`set_exception`**: let a `PendingExampleFixedError` fall through to the quarantine check. Ordinary still-failing pending examples (routed by RSpec to `pending_exception`) are left untouched and stay green.
- **`status_and_exception`**: a quarantined fixed-pending has its exception swallowed, so RSpec leaves it `:pending`. Key on `execution_result.pending_fixed?` (set by RSpec's `mark_fixed!` and preserved through the swallow) to still report it as a `failure` carrying the fixed error — so it serializes as `failure` + quarantined rather than `success`.
- **`handle_quarantine_check_safely`**: guards the case where the quarantine lookup itself fails/raises. This was already handled for normal failures, but for a *pending* example any exception raised inside `set_exception` was re-fed to `set_exception` by RSpec, routed into `pending_exception` (which also resets `pending_fixed`), and the example was silently reported as a green pending. Wrapping the check so that on any error we fall back to `set_exception_core(exception)` makes the real failure stand (fail closed) and logs a warning instead of swallowing it.

## Tests

Mirrors the `variant_quarantine_spec.rb` pattern in the ruby gem upload action:

- Adds `spec/pending_spec.rb` — a fixed-pending example (`pending_quarantine_test`).
- The **with-variant** step now runs `variant_quarantine_spec.rb` + `pending_spec.rb` and asserts the run passes (both quarantined under `smoke-test-variant`) — exercising the swallow path end-to-end.
- A new **no-variant** step runs `pending_spec.rb` alone and asserts a non-zero exit, isolating the fixed-pending failure when it is not quarantined.

Dylan's `test/pending_status_spec.rb` (unit-level status mapping) is unchanged.

> [!NOTE]
> For the with-variant step to pass, `pending_quarantine_test` must be quarantined under variant `smoke-test-variant` in staging — the same prerequisite `variant_quarantine_test` already has.

## Verification

- Built the native extension; full gem suite `rake test`: **18 examples, 0 failures**.
- Drove the real `run_with_trunk` path against `spec/pending_spec.rb` with a stubbed lookup:
  - quarantined → exit 0, reported `failure` + quarantined (with-variant "should pass").
  - not quarantined → exit 1 (no-variant "should fail").
  - lookup raises → warning logged, exit 1 (fail closed via `handle_quarantine_check_safely`, no silent green).
- `action.yaml` validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)