### PR TITLE
Add repo-wide test collection uploads to staging CI

### DIFF
--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -91,10 +91,11 @@ runs:
         --xcresult-path smoke-test/swift/TestResults.xcresult \
         --token ${{ inputs.staging-api-token }} \
         --test-process-exit-code $EXIT_CODE \
-        --test-collection-id z2dzjLHm
+        --test-collection-id z2dzjLHm # analytics-cli-smoke-tests: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/z2dzjLHm/monitors
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
+    # Repo monitors: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/repo/a84c7f42-9400-4bc4-a469-6dab0c859ac5/monitor
     - name: Upload to staging
       id: staging-upload
       if: always() && steps.staging-test-run.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
@@ -106,7 +107,7 @@ runs:
         --org-url-slug trunk-staging-org \
         --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
         --token ${{ inputs.staging-api-token }} \
-        --test-collection-id z2dzjLHm
+        --test-collection-id z2dzjLHm # analytics-cli-smoke-tests: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/z2dzjLHm/monitors
 
     - name: Upload to staging (repo-wide collection)
       id: staging-upload-repo-wide
@@ -119,7 +120,7 @@ runs:
         --org-url-slug trunk-staging-org \
         --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
         --token ${{ inputs.staging-api-token }} \
-        --test-collection-id Gtnr7BWl
+        --test-collection-id Gtnr7BWl # analytics-cli-repo-wide: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/Gtnr7BWl/monitors
 
     - name: Upload to staging with public repo id
       id: staging-upload-public-repo-id
@@ -152,7 +153,7 @@ runs:
         --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
         --token ${{ inputs.staging-api-token }} \
         --variant smoke-test-variant \
-        --test-collection-id z2dzjLHm
+        --test-collection-id z2dzjLHm # analytics-cli-smoke-tests: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/z2dzjLHm/monitors
         EXIT_CODE=$?
         if [ $EXIT_CODE -eq 0 ]; then
           echo "ERROR: Expected upload with variant to fail, but it succeeded"
@@ -211,6 +212,7 @@ runs:
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
 
+    # Repo monitors: https://app.trunk.io/trunk/flaky-tests/repo/d442f488-c374-4913-af40-d0eae875b5cb/monitor
     - name: Upload to production
       id: production-upload
       if: always() && steps.production-test-run.outcome == 'success' && (inputs.environment-type == 'production' || inputs.environment-type == 'both')
@@ -222,7 +224,7 @@ runs:
         --org-url-slug trunk \
         --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
         --token ${{ inputs.production-api-token }} \
-        --test-collection-id 4B2wfoEU
+        --test-collection-id 4B2wfoEU # analytics-cli-smoke-tests: https://app.trunk.io/trunk/flaky-tests/collections/4B2wfoEU/monitors
 
     - name: Upload to production with public repo id
       id: production-upload-public-repo-id

--- a/.github/actions/perform_smoke_test/action.yaml
+++ b/.github/actions/perform_smoke_test/action.yaml
@@ -108,6 +108,19 @@ runs:
         --token ${{ inputs.staging-api-token }} \
         --test-collection-id z2dzjLHm
 
+    - name: Upload to staging (repo-wide collection)
+      id: staging-upload-repo-wide
+      if: always() && steps.staging-test-run.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+      shell: bash
+      run: |
+        ./${{ inputs.cli-binary-location }} upload \
+        --org-url-slug trunk-staging-org \
+        --junit-paths "${{ github.workspace }}/target/**/*junit.xml" \
+        --token ${{ inputs.staging-api-token }} \
+        --test-collection-id Gtnr7BWl
+
     - name: Upload to staging with public repo id
       id: staging-upload-public-repo-id
       if: always() && steps.staging-test-run.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')
@@ -155,9 +168,9 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.test-variants }}" == "true" ]; then
-          echo "staging-success=${{ (steps.staging-upload.outcome == 'success' && steps.staging-upload-public-repo-id.outcome == 'success' && steps.staging-upload-with-variant.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')) || inputs.environment-type == 'production' }}" >> $GITHUB_OUTPUT
+          echo "staging-success=${{ (steps.staging-upload.outcome == 'success' && steps.staging-upload-repo-wide.outcome == 'success' && steps.staging-upload-public-repo-id.outcome == 'success' && steps.staging-upload-with-variant.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')) || inputs.environment-type == 'production' }}" >> $GITHUB_OUTPUT
         else
-          echo "staging-success=${{ (steps.staging-upload.outcome == 'success' && steps.staging-upload-public-repo-id.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')) || inputs.environment-type == 'production' }}" >> $GITHUB_OUTPUT
+          echo "staging-success=${{ (steps.staging-upload.outcome == 'success' && steps.staging-upload-repo-wide.outcome == 'success' && steps.staging-upload-public-repo-id.outcome == 'success' && (inputs.environment-type == 'staging' || inputs.environment-type == 'both')) || inputs.environment-type == 'production' }}" >> $GITHUB_OUTPUT
         fi
 
     - name: Run tests on production

--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -123,8 +123,6 @@ runs:
         bundle lock --remove-platform ruby || true
         bundle install --gemfile Gemfile --local
 
-    # test-collection-id is caller-supplied (staging vs prod use different collections) — see the
-    # monitor link on the test-collection-id input at each call site (smoke_test.yml/smoke_test_main.yml).
     - name: Run regular tests
       id: run-regular-tests
       if: inputs.alpine != 'true'
@@ -139,9 +137,7 @@ runs:
         TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
         TRUNK_VARIANT: ${{ inputs.variant }}
 
-    # This action also serves the prod caller (trunk-org-slug: trunk), which must never upload to
-    # a trunk-staging-org collection, so this step is gated on staging specifically rather than a
-    # separate opt-in input.
+    # Gated on trunk-org-slug (not a dedicated input) so the prod caller never writes here.
     # TC monitors: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/Gtnr7BWl/monitors
     - name: Run regular tests (repo-wide collection)
       id: run-regular-tests-repo-wide

--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -27,11 +27,6 @@ inputs:
   test-collection-id:
     description: Optional 8 character alphanumeric ID for a test collection
     required: false
-  repo-wide-collection-id:
-    description:
-      Optional repo-wide test collection short ID. When set, the plain regular-test upload (no
-      quarantine-dependent assertions) is repeated against this collection.
-    required: false
   variant:
     description: Optional variant label to distinguish uploads within a matrix
     required: false
@@ -128,6 +123,8 @@ runs:
         bundle lock --remove-platform ruby || true
         bundle install --gemfile Gemfile --local
 
+    # test-collection-id is caller-supplied (staging vs prod use different collections) — see the
+    # monitor link on the test-collection-id input at each call site (smoke_test.yml/smoke_test_main.yml).
     - name: Run regular tests
       id: run-regular-tests
       if: inputs.alpine != 'true'
@@ -142,9 +139,13 @@ runs:
         TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
         TRUNK_VARIANT: ${{ inputs.variant }}
 
+    # This action also serves the prod caller (trunk-org-slug: trunk), which must never upload to
+    # a trunk-staging-org collection, so this step is gated on staging specifically rather than a
+    # separate opt-in input.
+    # TC monitors: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/Gtnr7BWl/monitors
     - name: Run regular tests (repo-wide collection)
       id: run-regular-tests-repo-wide
-      if: inputs.alpine != 'true' && inputs.repo-wide-collection-id != ''
+      if: inputs.alpine != 'true' && inputs.trunk-org-slug == 'trunk-staging-org'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
@@ -153,7 +154,7 @@ runs:
         TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
         TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}
         TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
-        TRUNK_TEST_COLLECTION_ID: ${{ inputs.repo-wide-collection-id }}
+        TRUNK_TEST_COLLECTION_ID: Gtnr7BWl # analytics-cli-repo-wide (constant for this repo)
         TRUNK_VARIANT: ${{ inputs.variant }}
 
     - name: Run gem unit suite against the built gem (rspec-trunk-flaky-tests/test)

--- a/.github/actions/test_ruby_gem_uploads/action.yaml
+++ b/.github/actions/test_ruby_gem_uploads/action.yaml
@@ -27,6 +27,11 @@ inputs:
   test-collection-id:
     description: Optional 8 character alphanumeric ID for a test collection
     required: false
+  repo-wide-collection-id:
+    description:
+      Optional repo-wide test collection short ID. When set, the plain regular-test upload (no
+      quarantine-dependent assertions) is repeated against this collection.
+    required: false
   variant:
     description: Optional variant label to distinguish uploads within a matrix
     required: false
@@ -135,6 +140,20 @@ runs:
         TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}
         TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
         TRUNK_TEST_COLLECTION_ID: ${{ inputs.test-collection-id }}
+        TRUNK_VARIANT: ${{ inputs.variant }}
+
+    - name: Run regular tests (repo-wide collection)
+      id: run-regular-tests-repo-wide
+      if: inputs.alpine != 'true' && inputs.repo-wide-collection-id != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        bundle exec rspec spec/test_spec.rb spec/multiple_exception_spec.rb --format documentation
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: ${{ inputs.trunk-public-api-address }}
+        TRUNK_ORG_URL_SLUG: ${{ inputs.trunk-org-slug }}
+        TRUNK_API_TOKEN: ${{ inputs.trunk-token }}
+        TRUNK_TEST_COLLECTION_ID: ${{ inputs.repo-wide-collection-id }}
         TRUNK_VARIANT: ${{ inputs.variant }}
 
     - name: Run gem unit suite against the built gem (rspec-trunk-flaky-tests/test)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -208,6 +208,22 @@ jobs:
              --test-collection-id 2tYJWMu7 \
              --variant ${{ matrix.platform.target }}
 
+      - name: Upload results to staging using built CLI (repo-wide collection)
+        env:
+          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+        shell: bash
+        # Skip Windows builds - can't run Windows binaries on Linux runners
+        # Windows binaries are tested in the release workflow on actual Windows runners
+        if: ${{ !contains(matrix.platform.target, 'illumos') && !contains(matrix.platform.os-name, 'windows') }}
+        run: |
+          target/${{ matrix.platform.target }}/release/trunk-analytics-cli upload \
+             --junit-paths ${{ github.workspace }}/target/**/*junit.xml \
+             --org-url-slug trunk-staging-org \
+             --token ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }} \
+             --test-process-exit-code ${{ steps.extract.outputs.test-step-outcome }} \
+             --test-collection-id Gtnr7BWl \
+             --variant ${{ matrix.platform.target }}
+
       - name: Upload results to prod using built CLI
         shell: bash
         # Skip Windows builds - can't run Windows binaries on Linux runners

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -192,6 +192,7 @@ jobs:
             echo "test-step-outcome=0" >> $GITHUB_OUTPUT
           fi
 
+      # Repo monitors: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/repo/a84c7f42-9400-4bc4-a469-6dab0c859ac5/monitor
       - name: Upload results to staging using built CLI
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
@@ -207,6 +208,7 @@ jobs:
              --test-process-exit-code ${{ steps.extract.outputs.test-step-outcome }} \
              --test-collection-id 2tYJWMu7 \
              --variant ${{ matrix.platform.target }}
+             # analytics-cli-pr: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/2tYJWMu7/monitors
 
       - name: Upload results to staging using built CLI (repo-wide collection)
         env:
@@ -223,7 +225,9 @@ jobs:
              --test-process-exit-code ${{ steps.extract.outputs.test-step-outcome }} \
              --test-collection-id Gtnr7BWl \
              --variant ${{ matrix.platform.target }}
+             # analytics-cli-repo-wide: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/Gtnr7BWl/monitors
 
+      # Repo monitors: https://app.trunk.io/trunk/flaky-tests/repo/d442f488-c374-4913-af40-d0eae875b5cb/monitor
       - name: Upload results to prod using built CLI
         shell: bash
         # Skip Windows builds - can't run Windows binaries on Linux runners
@@ -236,6 +240,7 @@ jobs:
             --token ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }} \
             --test-collection-id EWhNPVic \
             --variant ${{ matrix.platform.target }}
+            # analytics-cli-pr: https://app.trunk.io/trunk/flaky-tests/collections/EWhNPVic/monitors
 
   trunk_check_runner:
     name: Trunk Check runner [linux]

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -138,6 +138,7 @@ jobs:
           uv pip install context-py --find-links ../dist --force-reinstall
           pytest --cov --junitxml=junit.xml
 
+      # analytics-cli-python-bindings: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/6E6WINjl/monitors
       - name: Upload x86_64 test results to staging
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64')"
         run: |
@@ -150,6 +151,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
+      # analytics-cli-python-bindings: https://app.trunk.io/trunk/flaky-tests/collections/68IdP3pq/monitors
       - name: Upload x86_64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'x86_64') && github.event_name != 'pull_request'"
         run: |
@@ -182,6 +184,7 @@ jobs:
             uv pip install context-py --find-links ../dist --force-reinstall
             pytest --cov --junitxml=junit.xml
 
+      # analytics-cli-python-bindings: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/6E6WINjl/monitors
       - name: Upload aarch64 test results to staging
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64')"
         run: |
@@ -194,6 +197,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
+      # analytics-cli-python-bindings: https://app.trunk.io/trunk/flaky-tests/collections/68IdP3pq/monitors
       - name: Upload aarch64 test results to prod
         if: "!cancelled() && startsWith(matrix.platform.target, 'aarch64') && github.event_name != 'pull_request'"
         run: |

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -173,8 +173,8 @@ jobs:
           trunk-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           trunk-public-api-address: https://api.trunk-staging.io
           trunk-org-slug: trunk-staging-org
+          # analytics-cli-ruby-gem: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/T5yKSn9h/monitors
           test-collection-id: T5yKSn9h
-          repo-wide-collection-id: Gtnr7BWl
           platform: x86_64-linux
           artifact-pattern: ""
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
@@ -200,6 +200,7 @@ jobs:
           trunk-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           trunk-public-api-address: https://api.trunk.io
           trunk-org-slug: trunk
+          # analytics-cli-ruby-gem: https://app.trunk.io/trunk/flaky-tests/collections/BiBP2neA/monitors
           test-collection-id: BiBP2neA
           platform: x86_64-linux
           artifact-pattern: ""

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -174,6 +174,7 @@ jobs:
           trunk-public-api-address: https://api.trunk-staging.io
           trunk-org-slug: trunk-staging-org
           test-collection-id: T5yKSn9h
+          repo-wide-collection-id: Gtnr7BWl
           platform: x86_64-linux
           artifact-pattern: ""
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -226,8 +226,8 @@ jobs:
           trunk-token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           trunk-public-api-address: https://api.trunk-staging.io
           trunk-org-slug: trunk-staging-org
+          # analytics-cli-ruby-gem: https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/T5yKSn9h/monitors
           test-collection-id: T5yKSn9h
-          repo-wide-collection-id: Gtnr7BWl
           platform: x86_64-linux
           artifact-pattern: ""
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
@@ -256,6 +256,7 @@ jobs:
           trunk-token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           trunk-public-api-address: https://api.trunk.io
           trunk-org-slug: trunk
+          # analytics-cli-ruby-gem: https://app.trunk.io/trunk/flaky-tests/collections/BiBP2neA/monitors
           test-collection-id: BiBP2neA
           platform: x86_64-linux
           artifact-pattern: ""

--- a/.github/workflows/smoke_test_main.yml
+++ b/.github/workflows/smoke_test_main.yml
@@ -227,6 +227,7 @@ jobs:
           trunk-public-api-address: https://api.trunk-staging.io
           trunk-org-slug: trunk-staging-org
           test-collection-id: T5yKSn9h
+          repo-wide-collection-id: Gtnr7BWl
           platform: x86_64-linux
           artifact-pattern: ""
           knapsack-pro-test-suite-token-rspec: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}


### PR DESCRIPTION
Setting up duplicate uploads for parity analysis and test collection monitor ratcheting, as outlined in [Slack](https://trunk-io.slack.com/archives/C08AEDGMZNH/p1785341934334799)

## Summary

| Collection | Env | Workflow(s) | Source of truth for quarantining? | Monitors |
|---|---|---|---|---|
| analytics-cli-repo-wide | staging | `pull_request.yml`, `perform_smoke_test/action.yaml`, `test_ruby_gem_uploads/action.yaml` | No — repo-based | [link](https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/Gtnr7BWl/monitors) |
| analytics-cli-pr | staging | `pull_request.yml` | No — repo-based | [link](https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/2tYJWMu7/monitors) |
| analytics-cli-pr | prod | `pull_request.yml` | No — repo-based | [link](https://app.trunk.io/trunk/flaky-tests/collections/EWhNPVic/monitors) |
| analytics-cli-smoke-tests | staging | `perform_smoke_test/action.yaml` | No — repo-based | [link](https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/z2dzjLHm/monitors) |
| analytics-cli-smoke-tests | prod | `perform_smoke_test/action.yaml` | No — repo-based | [link](https://app.trunk.io/trunk/flaky-tests/collections/4B2wfoEU/monitors) |
| analytics-cli-python-bindings | staging | `pyo3.yml` | No — repo-based | [link](https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/6E6WINjl/monitors) |
| analytics-cli-python-bindings | prod | `pyo3.yml` | No — repo-based | [link](https://app.trunk.io/trunk/flaky-tests/collections/68IdP3pq/monitors) |
| analytics-cli-ruby-gem | staging | `smoke_test.yml`, `smoke_test_main.yml` | No — repo-based | [link](https://app.trunk-staging.io/trunk-staging-org/flaky-tests/collections/T5yKSn9h/monitors) |
| analytics-cli-ruby-gem | prod | `smoke_test.yml`, `smoke_test_main.yml` | No — repo-based | [link](https://app.trunk.io/trunk/flaky-tests/collections/BiBP2neA/monitors) |

Nothing here has TC-based quarantining enabled — the repo itself is the source of truth for every row. This PR only adds the `analytics-cli-repo-wide` row (staging-only); every other collection already existed and is listed for completeness.

The ruby gem action's repo-wide step is gated on `trunk-org-slug == 'trunk-staging-org'` directly (not a separate opt-in input) since it also serves the prod caller, which must never write to a staging collection — and it repeats only the plain, non-quarantine-dependent regular-test spec rather than the whole rspec suite, which depends on the narrow collection's pre-configured quarantine overrides.

## Test plan
- [ ] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"` on every touched file — done locally)
- [ ] `trunk check`/`trunk fmt` — not runnable in this sandbox, please run before merge
- [ ] Confirm a PR run uploads to `2tYJWMu7` (narrow) and `Gtnr7BWl` (repo-wide) on staging
- [ ] Confirm the ruby gem staging job's new repo-wide step succeeds without depending on quarantine overrides