### PR TITLE
Add bundle, bazel-bep, and constants to workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ members = [
   "test_report",
   "third-party",
   "display",
+  "bundle",
+  "bazel-bep",
+  "constants",
 ]
 exclude = ["rspec-trunk-flaky-tests/ext/context_ruby"]
 resolver = "2"


### PR DESCRIPTION
## What

Adds `bundle`, `bazel-bep`, and `constants` to the root `Cargo.toml`'s `[workspace] members` list.

## Why

These three crates were already **implicit** workspace members — cargo automatically includes path dependencies that live inside the workspace directory and aren't in `exclude` — so this change is a no-op for cargo itself (`Cargo.lock` is unchanged).

However, external tooling that reads the root member list literally cannot see them. Specifically, trunk2 (`rs/Cargo.toml`) consumes six packages from this repo as a git dependency (`bazel-bep`, `bundle`, `codeowners`, `constants`, `context`, `proto`), and its Nix-based resolver (`cargo-nix-plugin`) resolves packages via the root workspace's member list rather than scanning the repo. It fails on the three unlisted crates:

```
error: resolveCargoWorkspace: package bazel-bep not found in git checkout <path>
       (https://github.com/trunk-io/analytics-cli#<rev>)
```

⚠️ **Please keep these entries in `members`** — an external consumer resolves this repo's packages through the root member list, so removing them again (e.g. while tidying the list) silently breaks trunk2's Nix build even though plain cargo keeps working.

`rspec-trunk-flaky-tests/` is intentionally left as-is: it's a Ruby gem extension crate and not consumed by trunk2.

## Verification

- `cargo metadata --no-deps` succeeds from the repo root and from `bundle/`
- `cargo check --workspace --all-targets` passes
- `Cargo.lock` unchanged (no resolution/feature-unification changes)
- `taplo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)